### PR TITLE
[14.0][FIX] account_asset_invoice_line_link: vals dict is used in Form

### DIFF
--- a/account_asset_invoice_line_link/__manifest__.py
+++ b/account_asset_invoice_line_link/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/nuobit/odoo-addons",
     "license": "AGPL-3",
     "depends": [
-        "account_asset_hook",
+        "account_asset_management",
     ],
     "data": [
         "views/account_asset_view.xml",

--- a/account_asset_invoice_line_link/models/account_move.py
+++ b/account_asset_invoice_line_link/models/account_move.py
@@ -10,8 +10,8 @@ class AccountMove(models.Model):
 
     def _prepare_asset_vals(self, aml):
         vals = super()._prepare_asset_vals(aml)
-        vals["move_id"] = aml.move_id.id
-        vals["move_line_id"] = aml.id
+        vals["move_id"] = aml.move_id
+        vals["move_line_id"] = aml
         return vals
 
 


### PR DESCRIPTION
Form requires many2one entries to be model records instead of their ids. Without this fix, when validating an invoice with assets, you get "`AttributeError: 'int' object has no attribute 'id'`".

Fixes https://github.com/nuobit/odoo-addons/pull/60.