### PR TITLE
[14.0][FIX] stock_orderpoint_manual_procurement_zero: read action with sudo

### DIFF
--- a/stock_orderpoint_manual_procurement_zero/wizards/make_procurement_orderpoint.py
+++ b/stock_orderpoint_manual_procurement_zero/wizards/make_procurement_orderpoint.py
@@ -17,9 +17,9 @@ class MakeProcurementOrderpoint(models.TransientModel):
         return res
 
     def remove_zeros(self):
-        wizard_action = self.env.ref(
+        wizard_action = self.env["ir.actions.act_window"]._for_xml_id(
             "stock_orderpoint_manual_procurement.act_make_procurement_from_orderpoint"
-        ).read()[0]
+        )
         wizard_action_context = dict(self.env.context)
         wizard_action_context["show_recommended_procure_zero"] = False
         wizard_action["context"] = str(wizard_action_context)


### PR DESCRIPTION
Added [this fix](https://github.com/antonyht27/stock-logistics-workflow/commit/4d2013b5515e0e3e9503b9c85d27f16a52696a70).

Permission error was appearing when trying to remove zeros from manual procurements.