### PR TITLE
[14.0][FIX] project_legal_management: tree view option wasn't showing

### DIFF
--- a/project_legal_management/__manifest__.py
+++ b/project_legal_management/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "https://github.com/nuobit/odoo-addons",
     "license": "AGPL-3",
     "depends": [
-        "project",
+        "project_timeline",
         "hr",
     ],
     "data": [

--- a/project_legal_management/models/lm_issue.py
+++ b/project_legal_management/models/lm_issue.py
@@ -8,6 +8,7 @@ class LMIssue(models.Model):
     _name = "lm.issue"
     _parent_name = "parent_id"
     _inherit = "lm.tree.mixin"
+    _description = "LMIssue"
 
     name = fields.Char(required=True)
     parent_id = fields.Many2one(comodel_name="lm.issue")

--- a/project_legal_management/models/lm_probability.py
+++ b/project_legal_management/models/lm_probability.py
@@ -8,6 +8,7 @@ class LMProbability(models.Model):
     _name = "lm.probability"
     _parent_name = "parent_id"
     _inherit = "lm.tree.mixin"
+    _description = "LMProbability"
 
     name = fields.Char(required=True)
     parent_id = fields.Many2one(comodel_name="lm.probability")

--- a/project_legal_management/models/lm_resolution.py
+++ b/project_legal_management/models/lm_resolution.py
@@ -8,6 +8,7 @@ class LMResolution(models.Model):
     _name = "lm.resolution"
     _parent_name = "parent_id"
     _inherit = "lm.tree.mixin"
+    _description = "LMResolution"
 
     name = fields.Char(required=True)
     parent_id = fields.Many2one(comodel_name="lm.resolution")

--- a/project_legal_management/models/tree.py
+++ b/project_legal_management/models/tree.py
@@ -8,6 +8,7 @@ from odoo.exceptions import UserError
 
 class LMTreeMixin(models.AbstractModel):
     _name = "lm.tree.mixin"
+    _description = "LMTreeMixin"
 
     # complete_name
     complete_name = fields.Char(

--- a/project_legal_management/views/project_tree.xml
+++ b/project_legal_management/views/project_tree.xml
@@ -19,7 +19,7 @@
         </field>
     </record>
     <record id="project.open_view_project_all" model="ir.actions.act_window">
-        <field name="view_mode">kanban,form,tree</field>
+        <field name="view_mode">kanban,timeline,form,tree</field>
     </record>
     <record id="view_project_project_filter" model="ir.ui.view">
         <field name="name">view.project.project.filter.legal.management</field>


### PR DESCRIPTION
Added project_timeline dependency because it was overwriting view modes set in this module. Therefore, tree view wasn't selectable.