### PR TITLE
[11.0][FIX] quality_partner: constrains parameter must be simple fields

### DIFF
--- a/quality_partner/models/res_partner.py
+++ b/quality_partner/models/res_partner.py
@@ -16,8 +16,7 @@ class ResPartner(models.Model):
                                            string='Documents',
                                            inverse_name='partner_id')
 
-    @api.constrains('quality_classification_id', 'quality_document_ids',
-                    'quality_document_ids.document_type_id')
+    @api.constrains("quality_classification_id", "quality_document_ids")
     def _check_classification_document_type(self):
         for rec in self:
             if not rec.quality_classification_id:


### PR DESCRIPTION
Dotted names are not supported in @api.constrains.

Backport of https://github.com/nuobit/odoo-addons/pull/141.