### PR TITLE
[14.0][FIX] account_asset_non_deductible: dependencies

### DIFF
--- a/account_asset_non_deductible/__manifest__.py
+++ b/account_asset_non_deductible/__manifest__.py
@@ -11,7 +11,6 @@
     "website": "https://github.com/nuobit/odoo-addons",
     "license": "AGPL-3",
     "depends": [
-        "account_asset_product_item",
         "l10n_es_aeat_vat_special_prorrate",
     ],
     "installable": True,


### PR DESCRIPTION
We don't merged that module in https://github.com/nuobit/odoo-addons/pull/61#issuecomment-1108604740.