### PR TITLE
[14.0][FIX] account_invoice_name_short: don't apply group_by in ref/payment_ref

### DIFF
--- a/account_invoice_name_short/models/account_invoice.py
+++ b/account_invoice_name_short/models/account_invoice.py
@@ -77,12 +77,10 @@ def shorten_long_vals(vals):
     vals_new = {}
     if vals:
         if "ref" in vals and vals["ref"]:
-            vals_new["ref"] = shorten_long_string(
-                shorten_long_delimited_string(vals["ref"].strip())
-            )
+            vals_new["ref"] = shorten_long_string(vals["ref"].strip())
         if "payment_reference" in vals and vals["payment_reference"]:
             vals_new["payment_reference"] = shorten_long_string(
-                shorten_long_delimited_string(vals["payment_reference"].strip())
+                vals["payment_reference"].strip()
             )
         if "invoice_origin" in vals and vals["invoice_origin"]:
             vals_new["invoice_origin"] = shorten_long_delimited_string(


### PR DESCRIPTION
For some unknown reason, in https://github.com/nuobit/odoo-addons/commit/130e9a38a677f460851eef52b0e6e8ea2ed2eab8 shorten_long_delimited_string() method was applied to 'name'. But that's wrong. And during the migration it was not detected.

ref/payment_reference can by anything.