### PR TITLE
[14.0][FIX] partner_default_company: multicompany issue (greenify tests)

### DIFF
--- a/partner_default_company/models/__init__.py
+++ b/partner_default_company/models/__init__.py
@@ -1,1 +1,2 @@
+from . import res_company
 from . import res_partner

--- a/partner_default_company/models/res_company.py
+++ b/partner_default_company/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright NuoBiT Solutions, S.L. (<https://www.nuobit.com>)
+# Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import api, models
+
+
+class Company(models.Model):
+    _inherit = "res.company"
+
+    @api.model
+    def create(self, vals):
+        return super(Company, self.with_context(company_creation=True)).create(vals)

--- a/partner_default_company/models/res_partner.py
+++ b/partner_default_company/models/res_partner.py
@@ -9,6 +9,10 @@ class Partner(models.Model):
     _inherit = "res.partner"
 
     def _default_company(self):
-        return self.env.company.id
+        return (
+            not self.env.context.get("company_creation", False)
+            and self.env.company
+            or self.env["res.company"]
+        )
 
     company_id = fields.Many2one(default=_default_company)


### PR DESCRIPTION
Don't set default company for partner of companies. After the company record is created, odoo will put the same company as the record.