### PR TITLE
[14.0][FIX] l10n_es_aeat_vat_special_prorrate: recompute lines correctly

### DIFF
--- a/l10n_es_aeat_vat_special_prorrate/models/account_move.py
+++ b/l10n_es_aeat_vat_special_prorrate/models/account_move.py
@@ -24,7 +24,7 @@ class AccountMove(models.Model):
 
     @api.onchange("invoice_date", "date")
     def _onchange_dates(self):
-        self._recompute_tax_lines()
+        self._recompute_dynamic_lines()
 
 
 class AccountMoveLine(models.Model):


### PR DESCRIPTION
_recompute_dynamic_lines() will call _recompute_tax_lines() and then update correctly the invoice_line_ids.