### PR TITLE
[14.0][FIX] stock_barcodes_gs1_extended: allow to uninstall module

### DIFF
--- a/stock_barcodes_gs1_extended/__manifest__.py
+++ b/stock_barcodes_gs1_extended/__manifest__.py
@@ -20,5 +20,5 @@
     "installable": True,
     "development_status": "Beta",
     "maintainers": ["eantones"],
-    "auto_install": True,
+    "auto_install": False,
 }


### PR DESCRIPTION
As the base OCA module is being refactored, we will need to uninstall this module.

@eantones 