### PR TITLE
[14.0][IMP] connector_oxigesti: Remove 999 fake lot management

### DIFF
--- a/connector_oxigesti/models/sale_order_line/adapter.py
+++ b/connector_oxigesti/models/sale_order_line/adapter.py
@@ -11,7 +11,7 @@ class SaleOrderLineAdapter(Component):
 
     _apply_on = "oxigesti.sale.order.line"
 
-    _sql = """select l.Codigo_Servicio, l.CodigoArticulo, l.Partida,
+    _sql = """select l.Codigo_Servicio, l.CodigoArticulo, nullif(l.Partida, '') as "Partida",
                      l.Cantidad
               from %(schema)s.Odoo_Servicios_Cargos l
 


### PR DESCRIPTION
Find  way to use this, maybe Oxigesti should put a 999 or find another approach.
The commit is finished and working but it cannot be installed until Oxigesti behavior is changed to send a lot number in a products with tracing == 'lot'