### PR TITLE
[14.0][FIX] l10n_es_aeat_mod303_special_prorate_regularization_capital_asse…

### DIFF
--- a/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/account_asset.py
+++ b/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/account_asset.py
@@ -18,6 +18,7 @@ class AccountAsset(models.Model):
         comodel_name="capital.asset.prorate.regularization",
         inverse_name="asset_id",
         string="Active Asset Prorate Regularization",
+        groups="l10n_es_aeat.group_account_aeat",
         domain=[
             "|",
             ("mod303_id", "=", False),

--- a/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/views/account_asset.xml
+++ b/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/views/account_asset.xml
@@ -19,6 +19,7 @@
                     string="Capital Asset Prorate Regularizations"
                     name="capital_asset_prorate_regularizations"
                     attrs="{'invisible': ['|', ('prorate_tax_id', '=', False),('capital_asset_type_id','=',False)]}"
+                    groups="l10n_es_aeat.group_account_aeat"
                 >
                     <group>
                         <field


### PR DESCRIPTION
…t: error showing capital asset regularization data when user has no permissions.

It should just not show the data but not throwing an error