### PR TITLE
[14.0][FIX] stock_location_flowable: flowable location blocking

### DIFF
--- a/stock_location_flowable/README.rst
+++ b/stock_location_flowable/README.rst
@@ -46,14 +46,17 @@ Authors
 ~~~~~~~
 
 * NuoBiT Solutions
+* S.L.
 
 Contributors
 ~~~~~~~~~~~~
 
-- [NuoBiT](https://www.nuobit.com):
-  - Frank Cespedes <fcespedes@nuobit.com>
-  - Deniz Gallo <dgallo@nuobit.com>
-  - Bijaya Kumal <bkumal@nuobit.com>
+* `NuoBiT <https://www.nuobit.com>`__:
+
+  * Frank Cespedes <fcespedes@nuobit.com>
+  * Deniz Gallo <dgallo@nuobit.com>
+  * Bijaya Kumal <bkumal@nuobit.com>
+  * Eric Antones <eantones@nuobit.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_location_flowable/__manifest__.py
+++ b/stock_location_flowable/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": "Customizations that allow organizing, controlling, and"
     " mixing bulk liquid and solid products in a location",
     "version": "14.0.1.0.1",
-    "author": "NuoBiT Solutions",
+    "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",
     "category": "Stock",
     "depends": ["mrp", "uom_rounding_coherence"],

--- a/stock_location_flowable/doc/diagrams/00_tank_lifecycle.svg
+++ b/stock_location_flowable/doc/diagrams/00_tank_lifecycle.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="380" viewBox="0 0 1000 380">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <rect width="1000" height="380" fill="#1a1a2e"/>
+
+  <defs>
+    <marker id="a1" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#3a86ff"/></marker>
+    <marker id="a2" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#e94560"/></marker>
+    <marker id="a3" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#4ecca3"/></marker>
+    <marker id="a4" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#888"/></marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="500" y="30" text-anchor="middle" fill="#e94560" font-size="20" font-weight="bold">Tank Lifecycle — One Tank, Four States</text>
+  <text x="500" y="52" text-anchor="middle" fill="#888" font-size="13">This is ONE tank (flowable location) going through states over time.</text>
+  <text x="500" y="70" text-anchor="middle" fill="#888" font-size="13">A reception never reserves — it just delivers stock to the tank.</text>
+
+  <!-- Tank drawing (single, centered at top) -->
+  <rect x="410" y="85" width="180" height="50" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="500" y="107" text-anchor="middle" fill="#3a86ff" font-size="13" font-weight="bold">Tank (flowable location)</text>
+  <text x="500" y="125" text-anchor="middle" fill="#888" font-size="10">e.g. R5355BBR, 0963KWH</text>
+
+  <!-- Time arrow -->
+  <line x1="50" y1="165" x2="950" y2="165" stroke="#666" stroke-width="1" marker-end="url(#a4)"/>
+  <text x="500" y="158" text-anchor="middle" fill="#666" font-size="10">TIME →</text>
+
+  <!-- State 1: Available (no stock) -->
+  <rect x="40" y="180" width="170" height="100" rx="10" fill="none" stroke="#888" stroke-width="1.5"/>
+  <text x="125" y="205" text-anchor="middle" fill="#888" font-size="14" font-weight="bold">AVAILABLE</text>
+  <text x="125" y="225" text-anchor="middle" fill="#666" font-size="10">No active MO</text>
+  <text x="125" y="240" text-anchor="middle" fill="#666" font-size="10">No blocking</text>
+  <text x="125" y="260" text-anchor="middle" fill="#666" font-size="10">Tank may have stock</text>
+  <text x="125" y="273" text-anchor="middle" fill="#666" font-size="10">or be empty</text>
+
+  <!-- Arrow: PO reception picking validated -->
+  <line x1="215" y1="230" x2="270" y2="230" stroke="#3a86ff" stroke-width="2" marker-end="url(#a1)"/>
+  <text x="243" y="218" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">PO reception</text>
+  <text x="243" y="207" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">picking validated</text>
+
+  <!-- State 2: Blocked -->
+  <rect x="275" y="180" width="190" height="100" rx="10" fill="#e94560" fill-opacity="0.12" stroke="#e94560" stroke-width="2.5"/>
+  <rect x="282" y="230" width="176" height="45" rx="5" fill="#e94560" opacity="0.15"/>
+  <text x="370" y="205" text-anchor="middle" fill="#e94560" font-size="14" font-weight="bold">BLOCKED 🔒</text>
+  <text x="370" y="248" text-anchor="middle" fill="#e94560" font-size="10">Stock arrived + MO created</text>
+  <text x="370" y="262" text-anchor="middle" fill="#e94560" font-size="10">No one else can receive</text>
+
+  <!-- Arrow: MO processes -->
+  <line x1="470" y1="230" x2="525" y2="230" stroke="#3a86ff" stroke-width="2" marker-end="url(#a1)"/>
+  <text x="498" y="218" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">MO mixes /</text>
+  <text x="498" y="207" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">consumes</text>
+
+  <!-- State 3: Processing -->
+  <rect x="530" y="180" width="190" height="100" rx="10" fill="#3a86ff" fill-opacity="0.08" stroke="#3a86ff" stroke-width="1.5"/>
+  <rect x="537" y="230" width="176" height="45" rx="5" fill="#3a86ff" opacity="0.1"/>
+  <text x="625" y="205" text-anchor="middle" fill="#3a86ff" font-size="14" font-weight="bold">PROCESSING</text>
+  <text x="625" y="248" text-anchor="middle" fill="#3a86ff" font-size="10">MO consuming stock</text>
+  <text x="625" y="262" text-anchor="middle" fill="#888" font-size="10">Still blocked (MO active)</text>
+
+  <!-- Arrow: MO done -->
+  <line x1="725" y1="230" x2="780" y2="230" stroke="#4ecca3" stroke-width="2" marker-end="url(#a3)"/>
+  <text x="753" y="218" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">MO marked</text>
+  <text x="753" y="207" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">done</text>
+
+  <!-- State 4: Available again -->
+  <rect x="785" y="180" width="170" height="100" rx="10" fill="none" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="870" y="205" text-anchor="middle" fill="#4ecca3" font-size="14" font-weight="bold">AVAILABLE</text>
+  <text x="870" y="225" text-anchor="middle" fill="#4ecca3" font-size="10">MO completed</text>
+  <text x="870" y="240" text-anchor="middle" fill="#4ecca3" font-size="10">Blocking cleared</text>
+  <text x="870" y="260" text-anchor="middle" fill="#4ecca3" font-size="10">Ready for next</text>
+  <text x="870" y="273" text-anchor="middle" fill="#4ecca3" font-size="10">PO reception</text>
+
+  <!-- Cycle arrow: back to start -->
+  <path d="M 955 230 Q 980 230 980 310 Q 980 330 500 330 Q 30 330 30 285" fill="none" stroke="#888" stroke-width="1.5" stroke-dasharray="5,5" marker-end="url(#a4)"/>
+  <text x="500" y="348" text-anchor="middle" fill="#666" font-size="11">cycle repeats with next PO reception</text>
+
+  <!-- Bottom bar: what runs at each transition -->
+  <rect x="215" y="295" width="60" height="18" rx="4" fill="#3a86ff" fill-opacity="0.3"/>
+  <text x="245" y="308" text-anchor="middle" fill="#3a86ff" font-size="8">picking</text>
+  <rect x="470" y="295" width="60" height="18" rx="4" fill="#3a86ff" fill-opacity="0.3"/>
+  <text x="500" y="308" text-anchor="middle" fill="#3a86ff" font-size="8">MO</text>
+  <rect x="725" y="295" width="60" height="18" rx="4" fill="#4ecca3" fill-opacity="0.3"/>
+  <text x="755" y="308" text-anchor="middle" fill="#4ecca3" font-size="8">move.write</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/01_first_reception.svg
+++ b/stock_location_flowable/doc/diagrams/01_first_reception.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="310" viewBox="0 0 1000 310">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="310" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 1: First PO Reception — Happy Path</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">One PO received at an available tank. MO auto-created, location blocked, MO completes, location freed.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#888" font-size="11">Everything works correctly. No bugs involved.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="170" x2="960" y2="170" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <!-- Events -->
+  <circle cx="120" cy="170" r="5" fill="#3a86ff"/>
+  <circle cx="320" cy="170" r="5" fill="#3a86ff"/>
+  <circle cx="540" cy="170" r="5" fill="#f5a623"/>
+  <circle cx="760" cy="170" r="5" fill="#4ecca3"/>
+
+  <line x1="120" y1="143" x2="120" y2="165" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="320" y1="128" x2="320" y2="165" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="540" y1="143" x2="540" y2="165" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="760" y1="133" x2="760" y2="165" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <rect x="45" y="95" width="150" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="120" y="115" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="120" y="132" text-anchor="middle" fill="#888" font-size="9">creates reception picking</text>
+
+  <rect x="215" y="90" width="210" height="35" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
+  <text x="320" y="112" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <text x="320" y="140" text-anchor="middle" fill="#4ecca3" font-size="10">MO created, location BLOCKED</text>
+
+  <rect x="455" y="100" width="170" height="40" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="540" y="117" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">MO #1 Processing</text>
+  <text x="540" y="133" text-anchor="middle" fill="#888" font-size="9">mixing / consuming</text>
+
+  <rect x="670" y="90" width="180" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
+  <text x="760" y="110" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">MO #1 Done</text>
+  <text x="760" y="127" text-anchor="middle" fill="#888" font-size="9">location UNBLOCKED</text>
+
+  <!-- State bar -->
+  <rect x="40" y="188" width="280" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="180" y="204" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="320" y="188" width="440" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="540" y="204" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO #1)</text>
+  <rect x="760" y="188" width="200" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="860" y="204" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <text x="500" y="230" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Note -->
+  <text x="500" y="265" text-anchor="middle" fill="#888" font-size="10">Blocking is set inside stock.move.write() when production.action_assign() changes the MO's raw move state.</text>
+  <text x="500" y="282" text-anchor="middle" fill="#888" font-size="10">Unblocking is set inside stock.move.write() when the MO's raw move goes to "done".</text>
+  <text x="500" y="299" text-anchor="middle" fill="#555" font-size="10">A reception never reserves — it delivers stock from a virtual supplier location to the tank.</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/02_second_reception_blocked.svg
+++ b/stock_location_flowable/doc/diagrams/02_second_reception_blocked.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="380" viewBox="0 0 1000 380">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="380" fill="#1a1a2e"/>
+
+  <!-- Title with Bug #1 -->
+  <text x="500" y="28" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">Scenario 2 — Bug #1: Second PO Reception — Location Blocked but Constraint Bypassed</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Location IS blocked. A second PO receives into the same tank. The constraint SKIPS non-MO moves.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#e94560" font-size="12">The second reception goes through. Two active MOs on the same tank.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="185" x2="960" y2="185" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="280" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="500" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="720" cy="185" r="5" fill="#e94560"/>
+
+  <line x1="100" y1="148" x2="100" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="280" y1="138" x2="280" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="500" y1="148" x2="500" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="720" y1="120" x2="720" y2="180" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO #1 -->
+  <rect x="30" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
+
+  <!-- Event 2: Reception #1 → blocked -->
+  <rect x="180" y="95" width="200" height="40" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
+  <text x="280" y="113" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <text x="280" y="130" text-anchor="middle" fill="#e94560" font-size="10">MO created, BLOCKED</text>
+
+  <!-- Time gap -->
+  <text x="390" y="177" text-anchor="middle" fill="#666" font-size="9" font-style="italic">time passes</text>
+
+  <!-- Event 3: PO #2 -->
+  <rect x="430" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="500" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #2 Confirmed</text>
+  <text x="500" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #2</text>
+
+  <!-- Event 4: Reception #2 GOES THROUGH (bug!) -->
+  <rect x="610" y="85" width="220" height="32" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="720" y="107" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception #2 GOES THROUGH!</text>
+  <!-- Bug explanation -->
+  <rect x="620" y="120" width="200" height="38" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="720" y="136" text-anchor="middle" fill="#e94560" font-size="9">constraint skips non-MO moves</text>
+  <text x="720" y="151" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">MO #2 created — TWO MOs!</text>
+
+  <!-- Danger icon -->
+  <text x="720" y="198" text-anchor="middle" fill="#e94560" font-size="16" font-weight="bold">!!</text>
+
+  <!-- State bar -->
+  <rect x="40" y="205" width="240" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="160" y="221" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="280" y="205" width="680" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="620" y="221" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO #1) — but constraint doesn't enforce it for non-MO moves</text>
+  <text x="500" y="248" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Bug #1 explanation -->
+  <rect x="60" y="265" width="880" height="90" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#e94560" stroke-width="1"/>
+  <text x="500" y="285" text-anchor="middle" fill="#e94560" font-size="12" font-weight="bold">Bug #1: constraint checked the MOVE's production, not the LOCATION's blocking state</text>
+  <text x="500" y="305" text-anchor="middle" fill="#ccc" font-size="10">Old code: "if production and location.flowable_production_id != production" — when production is False</text>
+  <text x="500" y="320" text-anchor="middle" fill="#ccc" font-size="10">(PO reception, internal transfer), the entire check is skipped. Even though the location IS blocked.</text>
+
+  <!-- PR inside the section -->
+  <rect x="305" y="337" width="390" height="20" rx="4" fill="#3a86ff" fill-opacity="0.15" stroke="#3a86ff" stroke-width="1"/>
+  <text x="500" y="351" text-anchor="middle" fill="#3a86ff" font-size="10" font-weight="bold">Fixed by PR #847: github.com/nuobit/odoo-addons/pull/847</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/03_second_reception_not_blocked.svg
+++ b/stock_location_flowable/doc/diagrams/03_second_reception_not_blocked.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="390" viewBox="0 0 1000 390">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="390" fill="#1a1a2e"/>
+
+  <!-- Title with Bug #2 -->
+  <text x="500" y="28" text-anchor="middle" fill="#f5a623" font-size="18" font-weight="bold">Scenario 3 — Bug #2: Second PO Reception — Location Not Blocked</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">First reception's production.action_assign() failed → location was never blocked. Second PO goes through.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#f5a623" font-size="12">Two active MOs on the same tank. This is the customer's case (R5355BBR).</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="185" x2="960" y2="185" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="280" cy="185" r="5" fill="#f5a623"/>
+  <circle cx="530" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="750" cy="185" r="5" fill="#e94560"/>
+
+  <line x1="100" y1="148" x2="100" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="280" y1="128" x2="280" y2="180" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="530" y1="148" x2="530" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="750" y1="120" x2="750" y2="180" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO #1 -->
+  <rect x="30" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
+
+  <!-- Event 2: Reception #1 → NOT BLOCKED -->
+  <rect x="175" y="90" width="210" height="35" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
+  <text x="280" y="112" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <rect x="200" y="128" width="160" height="18" rx="4" fill="#f5a623" fill-opacity="0.25" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="280" y="141" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">MO created, NOT BLOCKED</text>
+
+  <!-- Time gap -->
+  <text x="405" y="177" text-anchor="middle" fill="#666" font-size="9" font-style="italic">43 days pass</text>
+  <text x="405" y="189" text-anchor="middle" fill="#666" font-size="8" font-style="italic">MO #1 never completed</text>
+
+  <!-- Event 3: PO #2 -->
+  <rect x="460" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="530" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #2 Confirmed</text>
+  <text x="530" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #2</text>
+
+  <!-- Event 4: Reception #2 GOES THROUGH -->
+  <rect x="640" y="85" width="220" height="32" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="750" y="107" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception #2 GOES THROUGH!</text>
+  <rect x="655" y="120" width="190" height="38" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="750" y="136" text-anchor="middle" fill="#e94560" font-size="9">constraint passes (nothing to check)</text>
+  <text x="750" y="151" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">MO #2 created — TWO MOs!</text>
+
+  <text x="750" y="198" text-anchor="middle" fill="#e94560" font-size="16" font-weight="bold">!!</text>
+
+  <!-- State bar -->
+  <rect x="40" y="205" width="240" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="160" y="221" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="280" y="205" width="680" height="22" rx="5" fill="#f5a623" fill-opacity="0.1" stroke="#f5a623" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="620" y="221" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">SHOULD BE BLOCKED — but isn't (flowable_production_id = NULL)</text>
+  <text x="500" y="248" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Bug #2 explanation -->
+  <rect x="60" y="265" width="880" height="75" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#f5a623" stroke-width="1"/>
+  <text x="500" y="285" text-anchor="middle" fill="#f5a623" font-size="12" font-weight="bold">Bug #2: blocking depends on production.action_assign() success inside picking._action_done()</text>
+  <text x="500" y="305" text-anchor="middle" fill="#ccc" font-size="10">Blocking is set inside stock.move.write() only when action_assign changes the raw move state.</text>
+  <text x="500" y="320" text-anchor="middle" fill="#ccc" font-size="10">If reservation fails → state doesn't change → write() not triggered → flowable_production_id stays NULL.</text>
+  <text x="500" y="335" text-anchor="middle" fill="#ccc" font-size="10">The constraint has nothing to enforce — flowable_blocked is False.</text>
+
+  <!-- Customer case -->
+  <rect x="170" y="352" width="660" height="22" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="368" text-anchor="middle" fill="#888" font-size="10">Customer: R5355BBR — PO/21540 (2026-01-12) + PO/22188 (2026-02-24) — MO 00310 + MO 00321</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/04_mo_completion.svg
+++ b/stock_location_flowable/doc/diagrams/04_mo_completion.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="340" viewBox="0 0 1000 340">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="340" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 4: MO Completion — Location Unblocked</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">A PO was received, MO was created, tank is blocked. When the MO completes, the tank is unblocked for the next reception.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="185" x2="960" y2="185" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+  <text x="975" y="189" fill="#555" font-size="10">time</text>
+
+  <!-- Event markers -->
+  <circle cx="130" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="370" cy="185" r="5" fill="#f5a623"/>
+  <circle cx="620" cy="185" r="5" fill="#4ecca3"/>
+  <circle cx="860" cy="185" r="5" fill="#4ecca3"/>
+
+  <!-- Connector lines -->
+  <line x1="130" y1="148" x2="130" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="370" y1="148" x2="370" y2="180" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="620" y1="128" x2="620" y2="180" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="860" y1="148" x2="860" y2="180" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO received + MO created -->
+  <rect x="40" y="95" width="180" height="50" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="130" y="115" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO Received</text>
+  <text x="130" y="133" text-anchor="middle" fill="#888" font-size="9">MO created, tank BLOCKED</text>
+
+  <!-- Event 2: MO processing -->
+  <rect x="280" y="100" width="180" height="45" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="370" y="120" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">MO Processing</text>
+  <text x="370" y="136" text-anchor="middle" fill="#888" font-size="9">mixing / consuming stock</text>
+
+  <!-- Event 3: MO done -->
+  <rect x="510" y="80" width="220" height="65" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
+  <text x="620" y="100" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">MO Marked as Done</text>
+  <text x="620" y="118" text-anchor="middle" fill="#ccc" font-size="10">raw move state → "done"</text>
+  <text x="620" y="134" text-anchor="middle" fill="#ccc" font-size="10">stock.move.write() clears</text>
+  <text x="620" y="147" text-anchor="middle" fill="#4ecca3" font-size="10">flowable_production_id = NULL</text>
+
+  <!-- Event 4: Ready for next -->
+  <rect x="775" y="100" width="170" height="45" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="860" y="120" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Ready for Next PO</text>
+  <text x="860" y="136" text-anchor="middle" fill="#888" font-size="9">tank available again</text>
+
+  <!-- Location state bar -->
+  <rect x="40" y="203" width="90" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="85" y="220" text-anchor="middle" fill="#4ecca3" font-size="9">AVAIL</text>
+
+  <rect x="130" y="203" width="490" height="25" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="375" y="220" text-anchor="middle" fill="#e94560" font-size="10" font-weight="bold">BLOCKED (MO active)</text>
+
+  <rect x="620" y="203" width="340" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="790" y="220" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">AVAILABLE</text>
+
+  <text x="500" y="250" text-anchor="middle" fill="#888" font-size="10">TANK LOCATION STATE</text>
+
+  <!-- Mechanism note -->
+  <rect x="150" y="270" width="700" height="40" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="290" text-anchor="middle" fill="#888" font-size="10" font-weight="bold">Mechanism: stock.move.write() override detects raw move going to "done" or "cancel"</text>
+  <text x="500" y="305" text-anchor="middle" fill="#888" font-size="10">→ clears production.location_dest_id.flowable_production_id (the flowable location)</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/05_mo_cancellation.svg
+++ b/stock_location_flowable/doc/diagrams/05_mo_cancellation.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="310" viewBox="0 0 1000 310">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="310" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 5: MO Cancellation — Location Unblocked</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Same as Scenario 4, but the MO is cancelled instead of completed. The unblocking mechanism is identical.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="175" x2="960" y2="175" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+  <text x="975" y="179" fill="#555" font-size="10">time</text>
+
+  <!-- Event markers -->
+  <circle cx="150" cy="175" r="5" fill="#3a86ff"/>
+  <circle cx="460" cy="175" r="5" fill="#e94560"/>
+  <circle cx="770" cy="175" r="5" fill="#4ecca3"/>
+
+  <!-- Connector lines -->
+  <line x1="150" y1="140" x2="150" y2="170" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="460" y1="115" x2="460" y2="170" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="770" y1="140" x2="770" y2="170" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO received + MO created + blocked -->
+  <rect x="50" y="90" width="200" height="47" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="150" y="110" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO Received</text>
+  <text x="150" y="128" text-anchor="middle" fill="#888" font-size="9">MO created, tank BLOCKED</text>
+
+  <!-- Event 2: MO cancelled -->
+  <rect x="340" y="70" width="240" height="42" rx="8" fill="#0f3460" stroke="#e94560" stroke-width="2"/>
+  <text x="460" y="90" text-anchor="middle" fill="#e94560" font-size="12" font-weight="bold">MO Cancelled</text>
+  <text x="460" y="107" text-anchor="middle" fill="#ccc" font-size="10">raw move state → "cancel" → unblocked</text>
+
+  <!-- Event 3: Available again -->
+  <rect x="670" y="90" width="200" height="47" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="770" y="110" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Ready for Next PO</text>
+  <text x="770" y="128" text-anchor="middle" fill="#888" font-size="9">tank available again</text>
+
+  <!-- Location state bar -->
+  <rect x="40" y="193" width="110" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="95" y="210" text-anchor="middle" fill="#4ecca3" font-size="9">AVAIL</text>
+
+  <rect x="150" y="193" width="310" height="25" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="305" y="210" text-anchor="middle" fill="#e94560" font-size="10" font-weight="bold">BLOCKED (MO active)</text>
+
+  <rect x="460" y="193" width="500" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="710" y="210" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">AVAILABLE</text>
+
+  <text x="500" y="240" text-anchor="middle" fill="#888" font-size="10">TANK LOCATION STATE</text>
+
+  <!-- Note -->
+  <rect x="150" y="258" width="700" height="30" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="278" text-anchor="middle" fill="#888" font-size="10">Same mechanism as Scenario 4: stock.move.write() detects raw move → "cancel" → clears flowable_production_id</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/06_internal_transfer.svg
+++ b/stock_location_flowable/doc/diagrams/06_internal_transfer.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="360" viewBox="0 0 1000 360">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a2e"/>
+
+  <!-- Title with Bug #1 -->
+  <text x="500" y="28" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">Scenario 6 — Bug #1: Internal Transfer to Blocked Location — Constraint Bypassed</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Location IS blocked by an MO. An internal transfer moves stock to the same tank.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#e94560" font-size="12">The constraint SKIPS the transfer (non-MO move). Stock arrives at the blocked tank.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="180" x2="960" y2="180" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="140" cy="180" r="5" fill="#3a86ff"/>
+  <circle cx="400" cy="180" r="5" fill="#f5a623"/>
+  <circle cx="700" cy="180" r="5" fill="#e94560"/>
+
+  <line x1="140" y1="148" x2="140" y2="175" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="400" y1="148" x2="400" y2="175" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="700" y1="130" x2="700" y2="175" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO received + blocked -->
+  <rect x="40" y="100" width="200" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="140" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO Received</text>
+  <text x="140" y="137" text-anchor="middle" fill="#e94560" font-size="9">MO created, location BLOCKED</text>
+
+  <!-- Event 2: MO processing -->
+  <rect x="300" y="105" width="200" height="40" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="400" y="122" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">MO Processing</text>
+  <text x="400" y="139" text-anchor="middle" fill="#888" font-size="9">tank still blocked</text>
+
+  <!-- Event 3: Transfer GOES THROUGH (bug!) -->
+  <rect x="580" y="90" width="240" height="37" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="700" y="114" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Internal Transfer GOES THROUGH!</text>
+  <rect x="610" y="130" width="180" height="18" rx="4" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="700" y="143" text-anchor="middle" fill="#e94560" font-size="9">constraint skips non-MO moves</text>
+
+  <text x="700" y="195" text-anchor="middle" fill="#e94560" font-size="16" font-weight="bold">!!</text>
+
+  <!-- State bar -->
+  <rect x="40" y="200" width="100" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="90" y="216" text-anchor="middle" fill="#4ecca3" font-size="9">AVAIL</text>
+  <rect x="140" y="200" width="820" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="550" y="216" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO active) — but constraint doesn't enforce it for non-MO moves</text>
+  <text x="500" y="243" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Bug #1 explanation -->
+  <rect x="60" y="260" width="880" height="55" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#e94560" stroke-width="1"/>
+  <text x="500" y="280" text-anchor="middle" fill="#e94560" font-size="12" font-weight="bold">Bug #1: same as Scenario 2 — constraint checks move's production, not location's blocking state</text>
+  <text x="500" y="300" text-anchor="middle" fill="#ccc" font-size="10">Internal transfer has no production → "if production and ..." is False → constraint entirely skipped.</text>
+
+  <!-- PR inside the section -->
+  <rect x="305" y="325" width="390" height="20" rx="4" fill="#3a86ff" fill-opacity="0.15" stroke="#3a86ff" stroke-width="1"/>
+  <text x="500" y="339" text-anchor="middle" fill="#3a86ff" font-size="10" font-weight="bold">Fixed by PR #847: github.com/nuobit/odoo-addons/pull/847</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/07_proposed_fix.svg
+++ b/stock_location_flowable/doc/diagrams/07_proposed_fix.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="400" viewBox="0 0 1000 400">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="400" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 7 — Fix for Bug #2: Check Reserved Quantities at Reception</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Before allowing reception, check if any quants at the destination are reserved by other operations.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#888" font-size="12">If reserved: abort with details (who/what/how much). If all available: proceed normally, action_assign always succeeds.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="310" cy="195" r="5" fill="#4ecca3"/>
+  <circle cx="560" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="760" cy="195" r="5" fill="#e94560"/>
+  <circle cx="920" cy="195" r="5" fill="#4ecca3"/>
+
+  <line x1="100" y1="158" x2="100" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="310" y1="123" x2="310" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="560" y1="158" x2="560" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="760" y1="138" x2="760" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="920" y1="158" x2="920" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO #1 -->
+  <rect x="30" y="110" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="128" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="100" y="147" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
+
+  <!-- Event 2: Reception #1 — check passes, proceeds, BLOCKED -->
+  <rect x="205" y="88" width="210" height="32" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
+  <text x="310" y="109" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <rect x="220" y="123" width="180" height="22" rx="5" fill="#4ecca3" fill-opacity="0.25" stroke="#4ecca3" stroke-width="2"/>
+  <rect x="223" y="126" width="30" height="16" rx="3" fill="#4ecca3"/>
+  <text x="238" y="138" text-anchor="middle" fill="#1a1a2e" font-size="8" font-weight="bold">FIX</text>
+  <text x="345" y="139" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">check passes → BLOCKED</text>
+
+  <!-- Time gap -->
+  <text x="435" y="187" text-anchor="middle" fill="#666" font-size="9" font-style="italic">time passes</text>
+
+  <!-- Event 3: PO #2 -->
+  <rect x="490" y="110" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="560" y="128" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #2 Confirmed</text>
+  <text x="560" y="147" text-anchor="middle" fill="#888" font-size="9">creates reception #2</text>
+
+  <!-- Event 4: Reception #2 REJECTED by constraint (Bug #1 fix) -->
+  <rect x="655" y="95" width="210" height="40" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="760" y="113" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception #2 REJECTED</text>
+  <text x="760" y="130" text-anchor="middle" fill="#ff8a8a" font-size="9">location blocked by MO #1</text>
+  <text x="760" y="208" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">X</text>
+
+  <!-- Event 5: MO #1 done -->
+  <rect x="860" y="115" width="120" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="920" y="132" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">MO #1 Done</text>
+  <text x="920" y="149" text-anchor="middle" fill="#888" font-size="9">unblocked</text>
+
+  <!-- State bar -->
+  <rect x="40" y="220" width="270" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="175" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="310" y="220" width="610" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="615" y="236" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED — action_assign succeeds because all quants available</text>
+  <rect x="920" y="220" width="40" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="500" y="263" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Fix explanation -->
+  <rect x="60" y="280" width="880" height="80" rx="8" fill="#4ecca3" fill-opacity="0.08" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="500" y="300" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">Fix: _check_flowable_reserved_quantities() before super()._action_done()</text>
+  <text x="500" y="318" text-anchor="middle" fill="#b0e8cc" font-size="11">If any quants at the destination are reserved: UserError with details of who/what/how much.</text>
+  <text x="500" y="336" text-anchor="middle" fill="#b0e8cc" font-size="11">With all quants available, action_assign() always succeeds, blocking mechanism works reliably.</text>
+  <text x="500" y="354" text-anchor="middle" fill="#888" font-size="10">Old lot reservations become obsolete after the merge anyway — new lot replaces them all.</text>
+
+  <!-- Comparison -->
+  <rect x="200" y="370" width="600" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="384" text-anchor="middle" fill="#888" font-size="10">Compare with Scenario 3: without this fix, action_assign fails and location is never blocked</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/07_proposed_fix.svg
+++ b/stock_location_flowable/doc/diagrams/07_proposed_fix.svg
@@ -8,9 +8,9 @@
   <rect width="1000" height="400" fill="#1a1a2e"/>
 
   <!-- Title -->
-  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 7 — Fix for Bug #2: Check Reserved Quantities at Reception</text>
-  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Before allowing reception, check if any quants at the destination are reserved by other operations.</text>
-  <text x="500" y="68" text-anchor="middle" fill="#888" font-size="12">If reserved: abort with details (who/what/how much). If all available: proceed normally, action_assign always succeeds.</text>
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 7 — Fix: Post-check in action_assign Ensures Blocking</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">action_assign() override in mrp.production checks full reservation after super().</text>
+  <text x="500" y="68" text-anchor="middle" fill="#888" font-size="12">If not fully assigned: UserError with details of who holds reservations. Transaction rolls back.</text>
 
   <!-- Timeline -->
   <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
@@ -32,13 +32,13 @@
   <text x="100" y="128" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
   <text x="100" y="147" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
 
-  <!-- Event 2: Reception #1 — check passes, proceeds, BLOCKED -->
+  <!-- Event 2: Reception #1 — action_assign post-check passes, BLOCKED -->
   <rect x="205" y="88" width="210" height="32" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
   <text x="310" y="109" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
   <rect x="220" y="123" width="180" height="22" rx="5" fill="#4ecca3" fill-opacity="0.25" stroke="#4ecca3" stroke-width="2"/>
   <rect x="223" y="126" width="30" height="16" rx="3" fill="#4ecca3"/>
   <text x="238" y="138" text-anchor="middle" fill="#1a1a2e" font-size="8" font-weight="bold">FIX</text>
-  <text x="345" y="139" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">check passes → BLOCKED</text>
+  <text x="345" y="139" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">action_assign OK → BLOCKED</text>
 
   <!-- Time gap -->
   <text x="435" y="187" text-anchor="middle" fill="#666" font-size="9" font-style="italic">time passes</text>
@@ -63,18 +63,18 @@
   <rect x="40" y="220" width="270" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
   <text x="175" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
   <rect x="310" y="220" width="610" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
-  <text x="615" y="236" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED — action_assign succeeds because all quants available</text>
+  <text x="615" y="236" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED — action_assign succeeds, post-check passes</text>
   <rect x="920" y="220" width="40" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
   <text x="500" y="263" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
 
   <!-- Fix explanation -->
   <rect x="60" y="280" width="880" height="80" rx="8" fill="#4ecca3" fill-opacity="0.08" stroke="#4ecca3" stroke-width="1.5"/>
-  <text x="500" y="300" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">Fix: _check_flowable_reserved_quantities() before super()._action_done()</text>
-  <text x="500" y="318" text-anchor="middle" fill="#b0e8cc" font-size="11">If any quants at the destination are reserved: UserError with details of who/what/how much.</text>
-  <text x="500" y="336" text-anchor="middle" fill="#b0e8cc" font-size="11">With all quants available, action_assign() always succeeds, blocking mechanism works reliably.</text>
-  <text x="500" y="354" text-anchor="middle" fill="#888" font-size="10">Old lot reservations become obsolete after the merge anyway — new lot replaces them all.</text>
+  <text x="500" y="300" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">Fix: action_assign() override with _check_flowable_reservation() post-check</text>
+  <text x="500" y="318" text-anchor="middle" fill="#b0e8cc" font-size="11">After super().action_assign(): if any raw move is not "assigned" → UserError with conflicting reservations.</text>
+  <text x="500" y="336" text-anchor="middle" fill="#b0e8cc" font-size="11">UserError inside _action_done() rolls back the entire transaction — no stock moved, no MO persisted.</text>
+  <text x="500" y="354" text-anchor="middle" fill="#888" font-size="10">Compare with Scenario 3: without this fix, action_assign fails silently and location is never blocked.</text>
 
   <!-- Comparison -->
   <rect x="200" y="370" width="600" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
-  <text x="500" y="384" text-anchor="middle" fill="#888" font-size="10">Compare with Scenario 3: without this fix, action_assign fails and location is never blocked</text>
+  <text x="500" y="384" text-anchor="middle" fill="#888" font-size="10">EAFP: try the operation, check the result, roll back if it failed</text>
 </svg>

--- a/stock_location_flowable/doc/diagrams/08_reception_blocked_by_reservations.svg
+++ b/stock_location_flowable/doc/diagrams/08_reception_blocked_by_reservations.svg
@@ -8,9 +8,9 @@
   <rect width="1000" height="420" fill="#1a1a2e"/>
 
   <!-- Title -->
-  <text x="500" y="28" text-anchor="middle" fill="#f5a623" font-size="18" font-weight="bold">Scenario 8 — Reception Blocked: Outgoing Transfers Have Reserved Quantities</text>
-  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Tank has stock. Internal transfers reserved part of it. A new PO reception tries to deliver to the same tank.</text>
-  <text x="500" y="68" text-anchor="middle" fill="#f5a623" font-size="12">The check detects reserved quantities and shows the user which operations must be unreserved.</text>
+  <text x="500" y="28" text-anchor="middle" fill="#f5a623" font-size="18" font-weight="bold">Scenario 8 — Reception Rolled Back: action_assign Fails Due to Reservations</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Tank has stock. Internal transfers reserved part of it. PO reception validates, MO created.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#f5a623" font-size="12">action_assign() can't fully reserve → post-check raises UserError → entire transaction rolls back.</text>
 
   <!-- Timeline -->
   <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
@@ -27,7 +27,7 @@
   <line x1="750" y1="148" x2="750" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
   <line x1="900" y1="120" x2="900" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
 
-  <!-- Event 1: Previous PO received, MO done, tank has leftover stock -->
+  <!-- Event 1: Previous MO done -->
   <rect x="25" y="100" width="150" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
   <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Previous MO Done</text>
   <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">tank has stock, unblocked</text>
@@ -48,26 +48,26 @@
 
   <!-- Event 4: New PO -->
   <rect x="680" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
-  <text x="750" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">New PO Confirmed</text>
-  <text x="750" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception</text>
+  <text x="750" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">New PO Reception</text>
+  <text x="750" y="137" text-anchor="middle" fill="#888" font-size="9">validates, MO created</text>
 
-  <!-- Event 5: Reception REJECTED by check -->
+  <!-- Event 5: action_assign fails, post-check rolls back -->
   <rect x="810" y="82" width="180" height="35" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
-  <text x="900" y="105" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception REJECTED</text>
+  <text x="900" y="105" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">ROLLED BACK</text>
   <rect x="815" y="120" width="170" height="52" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
-  <text x="900" y="136" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">UserError:</text>
+  <text x="900" y="136" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">action_assign partial →</text>
   <text x="900" y="149" text-anchor="middle" fill="#ff8a8a" font-size="8">- 6,949 kg (INT/00277)</text>
   <text x="900" y="161" text-anchor="middle" fill="#ff8a8a" font-size="8">- 3,500 kg (INT/19640)</text>
   <text x="900" y="208" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">X</text>
 
   <!-- State bar -->
   <rect x="40" y="220" width="960" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
-  <text x="520" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE (not blocked) — but has 10,449 kg reserved by outgoing transfers</text>
-  <text x="500" y="260" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+  <text x="520" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE (not blocked) — has 10,449 kg reserved by outgoing transfers</text>
+  <text x="500" y="260" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE (unchanged — transaction rolled back)</text>
 
   <!-- Quant visualization -->
   <rect x="60" y="278" width="880" height="95" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#f5a623" stroke-width="1"/>
-  <text x="500" y="298" text-anchor="middle" fill="#f5a623" font-size="12" font-weight="bold">Tank quant state at time of reception attempt</text>
+  <text x="500" y="298" text-anchor="middle" fill="#f5a623" font-size="12" font-weight="bold">Tank quant state at time of action_assign</text>
 
   <rect x="100" y="310" width="400" height="24" rx="4" fill="#4ecca3" fill-opacity="0.2" stroke="#4ecca3" stroke-width="1"/>
   <text x="300" y="326" text-anchor="middle" fill="#4ecca3" font-size="10">22,000 kg available</text>
@@ -78,8 +78,8 @@
   <rect x="670" y="310" width="120" height="24" rx="4" fill="#f5a623" fill-opacity="0.3" stroke="#f5a623" stroke-width="1.5"/>
   <text x="730" y="326" text-anchor="middle" fill="#f5a623" font-size="10">3,500 kg (INT/19640)</text>
 
-  <text x="500" y="356" text-anchor="middle" fill="#888" font-size="10">quantity_to_prod would be 32,449 — but only 22,000 available for action_assign</text>
-  <text x="500" y="370" text-anchor="middle" fill="#e94560" font-size="10">Without the check: action_assign partially fails → location never blocked → Bug #2</text>
+  <text x="500" y="356" text-anchor="middle" fill="#888" font-size="10">quantity_to_prod = 32,449 — but action_assign can only reserve 22,000 (available)</text>
+  <text x="500" y="370" text-anchor="middle" fill="#e94560" font-size="10">Post-check detects partial reservation → UserError → entire _action_done() rolls back</text>
 
   <!-- Bottom note -->
   <rect x="200" y="390" width="600" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>

--- a/stock_location_flowable/doc/diagrams/08_reception_blocked_by_reservations.svg
+++ b/stock_location_flowable/doc/diagrams/08_reception_blocked_by_reservations.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="420" viewBox="0 0 1000 420">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="420" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#f5a623" font-size="18" font-weight="bold">Scenario 8 — Reception Blocked: Outgoing Transfers Have Reserved Quantities</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Tank has stock. Internal transfers reserved part of it. A new PO reception tries to deliver to the same tank.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#f5a623" font-size="12">The check detects reserved quantities and shows the user which operations must be unreserved.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="300" cy="195" r="5" fill="#4ecca3"/>
+  <circle cx="520" cy="195" r="5" fill="#f5a623"/>
+  <circle cx="750" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="900" cy="195" r="5" fill="#e94560"/>
+
+  <line x1="100" y1="148" x2="100" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="120" x2="300" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="520" y1="120" x2="520" y2="190" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="750" y1="148" x2="750" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="900" y1="120" x2="900" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: Previous PO received, MO done, tank has leftover stock -->
+  <rect x="25" y="100" width="150" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Previous MO Done</text>
+  <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">tank has stock, unblocked</text>
+
+  <!-- Event 2: Internal transfers reserve some quants -->
+  <rect x="195" y="88" width="210" height="30" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="300" y="108" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Internal Transfer Created</text>
+  <rect x="210" y="120" width="180" height="32" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="300" y="136" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">reserves 6,949 kg from tank</text>
+  <text x="300" y="149" text-anchor="middle" fill="#888" font-size="8">OSWBU/INT/00277</text>
+
+  <!-- Event 3: Another transfer reserves more -->
+  <rect x="420" y="88" width="200" height="30" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="520" y="108" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Another Transfer Created</text>
+  <rect x="435" y="120" width="170" height="32" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="520" y="136" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">reserves 3,500 kg from tank</text>
+  <text x="520" y="149" text-anchor="middle" fill="#888" font-size="8">OSWSC/INT/19640</text>
+
+  <!-- Event 4: New PO -->
+  <rect x="680" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="750" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">New PO Confirmed</text>
+  <text x="750" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception</text>
+
+  <!-- Event 5: Reception REJECTED by check -->
+  <rect x="810" y="82" width="180" height="35" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="900" y="105" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception REJECTED</text>
+  <rect x="815" y="120" width="170" height="52" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="900" y="136" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">UserError:</text>
+  <text x="900" y="149" text-anchor="middle" fill="#ff8a8a" font-size="8">- 6,949 kg (INT/00277)</text>
+  <text x="900" y="161" text-anchor="middle" fill="#ff8a8a" font-size="8">- 3,500 kg (INT/19640)</text>
+  <text x="900" y="208" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">X</text>
+
+  <!-- State bar -->
+  <rect x="40" y="220" width="960" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="520" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE (not blocked) — but has 10,449 kg reserved by outgoing transfers</text>
+  <text x="500" y="260" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Quant visualization -->
+  <rect x="60" y="278" width="880" height="95" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#f5a623" stroke-width="1"/>
+  <text x="500" y="298" text-anchor="middle" fill="#f5a623" font-size="12" font-weight="bold">Tank quant state at time of reception attempt</text>
+
+  <rect x="100" y="310" width="400" height="24" rx="4" fill="#4ecca3" fill-opacity="0.2" stroke="#4ecca3" stroke-width="1"/>
+  <text x="300" y="326" text-anchor="middle" fill="#4ecca3" font-size="10">22,000 kg available</text>
+
+  <rect x="500" y="310" width="170" height="24" rx="4" fill="#f5a623" fill-opacity="0.3" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="585" y="326" text-anchor="middle" fill="#f5a623" font-size="10">6,949 kg (INT/00277)</text>
+
+  <rect x="670" y="310" width="120" height="24" rx="4" fill="#f5a623" fill-opacity="0.3" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="730" y="326" text-anchor="middle" fill="#f5a623" font-size="10">3,500 kg (INT/19640)</text>
+
+  <text x="500" y="356" text-anchor="middle" fill="#888" font-size="10">quantity_to_prod would be 32,449 — but only 22,000 available for action_assign</text>
+  <text x="500" y="370" text-anchor="middle" fill="#e94560" font-size="10">Without the check: action_assign partially fails → location never blocked → Bug #2</text>
+
+  <!-- Bottom note -->
+  <rect x="200" y="390" width="600" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="404" text-anchor="middle" fill="#888" font-size="10">User must unreserve INT/00277 and INT/19640 first — see Scenario 9</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/09_unreserve_and_retry.svg
+++ b/stock_location_flowable/doc/diagrams/09_unreserve_and_retry.svg
@@ -9,8 +9,8 @@
 
   <!-- Title -->
   <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 9 — User Unreserves Outgoing Operations, Retries Reception</text>
-  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">After Scenario 8: user goes to the detected operations, unreserves them, and retries the reception.</text>
-  <text x="500" y="68" text-anchor="middle" fill="#4ecca3" font-size="12">All quants now available. Reception proceeds, MO created, action_assign succeeds, location blocked.</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">After Scenario 8: user goes to the listed operations, unreserves them, and retries the reception.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#4ecca3" font-size="12">All quants now available. action_assign() succeeds, post-check passes, location blocked.</text>
 
   <!-- Timeline -->
   <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
@@ -27,10 +27,10 @@
   <line x1="680" y1="113" x2="680" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
   <line x1="900" y1="148" x2="900" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
 
-  <!-- Event 1: Reception rejected (from Scenario 8) -->
+  <!-- Event 1: Reception rolled back (from Scenario 8) -->
   <rect x="35" y="90" width="170" height="37" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2"/>
-  <text x="120" y="108" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception REJECTED</text>
-  <text x="120" y="123" text-anchor="middle" fill="#ff8a8a" font-size="9">reserved quantities detected</text>
+  <text x="120" y="108" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception ROLLED BACK</text>
+  <text x="120" y="123" text-anchor="middle" fill="#ff8a8a" font-size="9">partial reservation detected</text>
 
   <!-- Event 2: User unreserves transfer 1 -->
   <rect x="215" y="90" width="190" height="37" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
@@ -46,17 +46,17 @@
   <rect x="600" y="78" width="160" height="32" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
   <text x="680" y="99" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Retry Reception</text>
   <rect x="608" y="113" width="145" height="32" rx="5" fill="#4ecca3" fill-opacity="0.25" stroke="#4ecca3" stroke-width="2"/>
-  <text x="680" y="128" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">check passes (0 reserved)</text>
-  <text x="680" y="141" text-anchor="middle" fill="#4ecca3" font-size="9">MO created, BLOCKED</text>
+  <text x="680" y="128" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">action_assign OK</text>
+  <text x="680" y="141" text-anchor="middle" fill="#4ecca3" font-size="9">post-check passes, BLOCKED</text>
 
   <!-- Event 5: MO processing -->
   <rect x="830" y="105" width="140" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
   <text x="900" y="122" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">MO Processing</text>
-  <text x="900" y="139" text-anchor="middle" fill="#888" font-size="9">action_assign succeeds</text>
+  <text x="900" y="139" text-anchor="middle" fill="#888" font-size="9">fully reserved</text>
 
-  <!-- State bar: segment 1 — partially reserved -->
+  <!-- State bar: segment 1 — has reservations -->
   <rect x="40" y="220" width="460" height="22" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5" stroke-dasharray="5,3"/>
-  <text x="270" y="236" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">HAS RESERVATIONS — reception cannot proceed</text>
+  <text x="270" y="236" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">HAS RESERVATIONS — action_assign would fail</text>
 
   <!-- State bar: segment 2 — all available -->
   <rect x="500" y="220" width="180" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
@@ -75,9 +75,9 @@
   <text x="80" y="318" fill="#ccc" font-size="11">1. Read the error message — it lists each operation and reserved quantity</text>
   <text x="80" y="336" fill="#ccc" font-size="11">2. Go to each listed picking/operation → click "Unreserve" to release the quants</text>
   <text x="80" y="354" fill="#ccc" font-size="11">3. Return to the reception picking → click "Validate" again</text>
-  <text x="80" y="372" fill="#ccc" font-size="11">4. Check passes (0 reserved) → reception proceeds → MO created → action_assign succeeds → BLOCKED</text>
+  <text x="80" y="372" fill="#ccc" font-size="11">4. action_assign() succeeds → post-check passes → location BLOCKED</text>
 
   <!-- Bottom note -->
   <rect x="150" y="393" width="700" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
-  <text x="500" y="407" text-anchor="middle" fill="#888" font-size="10">Old lot reservations would become obsolete after the merge anyway — the new lot replaces them all</text>
+  <text x="500" y="407" text-anchor="middle" fill="#888" font-size="10">Old lot reservations become obsolete after the merge — the new lot replaces them all</text>
 </svg>

--- a/stock_location_flowable/doc/diagrams/09_unreserve_and_retry.svg
+++ b/stock_location_flowable/doc/diagrams/09_unreserve_and_retry.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="420" viewBox="0 0 1000 420">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="420" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 9 — User Unreserves Outgoing Operations, Retries Reception</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">After Scenario 8: user goes to the detected operations, unreserves them, and retries the reception.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#4ecca3" font-size="12">All quants now available. Reception proceeds, MO created, action_assign succeeds, location blocked.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="120" cy="195" r="5" fill="#e94560"/>
+  <circle cx="310" cy="195" r="5" fill="#f5a623"/>
+  <circle cx="500" cy="195" r="5" fill="#f5a623"/>
+  <circle cx="680" cy="195" r="5" fill="#4ecca3"/>
+  <circle cx="900" cy="195" r="5" fill="#4ecca3"/>
+
+  <line x1="120" y1="130" x2="120" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="310" y1="130" x2="310" y2="190" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="500" y1="130" x2="500" y2="190" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="680" y1="113" x2="680" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="900" y1="148" x2="900" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: Reception rejected (from Scenario 8) -->
+  <rect x="35" y="90" width="170" height="37" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2"/>
+  <text x="120" y="108" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception REJECTED</text>
+  <text x="120" y="123" text-anchor="middle" fill="#ff8a8a" font-size="9">reserved quantities detected</text>
+
+  <!-- Event 2: User unreserves transfer 1 -->
+  <rect x="215" y="90" width="190" height="37" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
+  <text x="310" y="108" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">Unreserve INT/00277</text>
+  <text x="310" y="123" text-anchor="middle" fill="#888" font-size="9">user unreserves manually</text>
+
+  <!-- Event 3: User unreserves transfer 2 -->
+  <rect x="405" y="90" width="190" height="37" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
+  <text x="500" y="108" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">Unreserve INT/19640</text>
+  <text x="500" y="123" text-anchor="middle" fill="#888" font-size="9">user unreserves manually</text>
+
+  <!-- Event 4: Retry reception — succeeds -->
+  <rect x="600" y="78" width="160" height="32" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
+  <text x="680" y="99" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Retry Reception</text>
+  <rect x="608" y="113" width="145" height="32" rx="5" fill="#4ecca3" fill-opacity="0.25" stroke="#4ecca3" stroke-width="2"/>
+  <text x="680" y="128" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">check passes (0 reserved)</text>
+  <text x="680" y="141" text-anchor="middle" fill="#4ecca3" font-size="9">MO created, BLOCKED</text>
+
+  <!-- Event 5: MO processing -->
+  <rect x="830" y="105" width="140" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="900" y="122" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">MO Processing</text>
+  <text x="900" y="139" text-anchor="middle" fill="#888" font-size="9">action_assign succeeds</text>
+
+  <!-- State bar: segment 1 — partially reserved -->
+  <rect x="40" y="220" width="460" height="22" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="270" y="236" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">HAS RESERVATIONS — reception cannot proceed</text>
+
+  <!-- State bar: segment 2 — all available -->
+  <rect x="500" y="220" width="180" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="590" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">ALL AVAILABLE</text>
+
+  <!-- State bar: segment 3 — blocked -->
+  <rect x="680" y="220" width="280" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="820" y="236" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO)</text>
+
+  <text x="500" y="260" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Step-by-step explanation -->
+  <rect x="60" y="278" width="880" height="105" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#4ecca3" stroke-width="1"/>
+  <text x="500" y="298" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">User workflow after the error</text>
+
+  <text x="80" y="318" fill="#ccc" font-size="11">1. Read the error message — it lists each operation and reserved quantity</text>
+  <text x="80" y="336" fill="#ccc" font-size="11">2. Go to each listed picking/operation → click "Unreserve" to release the quants</text>
+  <text x="80" y="354" fill="#ccc" font-size="11">3. Return to the reception picking → click "Validate" again</text>
+  <text x="80" y="372" fill="#ccc" font-size="11">4. Check passes (0 reserved) → reception proceeds → MO created → action_assign succeeds → BLOCKED</text>
+
+  <!-- Bottom note -->
+  <rect x="150" y="393" width="700" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="407" text-anchor="middle" fill="#888" font-size="10">Old lot reservations would become obsolete after the merge anyway — the new lot replaces them all</text>
+</svg>

--- a/stock_location_flowable/doc/flowable_location_blocking_flow.md
+++ b/stock_location_flowable/doc/flowable_location_blocking_flow.md
@@ -1,478 +1,250 @@
 # Flowable Location Blocking Mechanism
 
-This document describes how the blocking mechanism works for flowable locations (tanks),
-the complete flow from PO reception to MO creation, the known issues, and the
-implemented fixes.
-
-**PR**: https://github.com/nuobit/odoo-addons/pull/847 **Branch**:
-`14.0-fix-stock_location_flowable-flowable_blocking`
+How the blocking mechanism works for flowable locations (tanks): lifecycle, concepts,
+and scenarios.
 
 ---
 
-## Flow Diagrams
+## 1. Key Concepts
 
-All diagrams are in `diagrams/`.
+### 1.1 What is a flowable location?
 
-### The Physical Reality: Tank Lifecycle
+A physical tank (e.g. R5355BBR, Deposito LOX-14). Identified by
+`flowable_storage = True` on `stock.location`. It holds liquid/bulk material tracked by
+lot.
 
-A flowable location is a physical tank. A reception never reserves — it just delivers
-stock from a virtual supplier location to the tank. Blocking should happen when stock
-enters the tank (reception picking validation), not when the MO internally reserves
-quants.
+### 1.2 Tank lifecycle
+
+A tank goes through a repeating cycle:
+
+**Available → Reception fills it → Blocked (MO merges) → MO done → Available**
+
+The tank is "occupied" the moment new material is poured in. While the MO processes the
+merge, nobody else should deliver to that tank.
 
 ![Tank Lifecycle](diagrams/00_tank_lifecycle.svg)
 
-### Scenario 1: First PO Reception — Happy Path
+### 1.3 Blocking vs reservation
 
-Single PO received at an available tank. MO auto-created, location blocked, MO
-completes, location freed. Everything works correctly.
+These are two independent concepts:
+
+- **Blocking** (`flowable_production_id` on `stock.location`): a physical constraint —
+  "this tank is in use, nobody should pour more material in." It's about physical
+  occupation. Binary: either blocked or not.
+
+- **Reservation** (`reserved_quantity` on `stock.quant`): an Odoo inventory mechanism —
+  "these quants are spoken for by a specific stock move." Multiple operations can
+  partially reserve quants at the same location simultaneously.
+
+A tank can be **available (not blocked) but have reserved quants** — this is the normal
+case when outgoing operations (sales, internal transfers) have reserved material for
+delivery.
+
+### 1.4 Partial reservation on a tank
+
+Whether partial reservation makes sense depends on the direction:
+
+- **Outgoing** (sales, internal transfers): **valid**. You can sell 3,500 kg from a
+  35,000 kg tank. The sale reserves those 3,500 kg, the rest remains available for other
+  sales.
+
+- **Incoming** (receptions/merges): **invalid**. When new material arrives and a merge
+  MO is created, the MO must process the **entire** tank content (old + new). If some
+  quants are reserved by outgoing operations, the MO cannot reserve the full amount.
+
+### 1.5 Why lot reservations become obsolete after a merge
+
+This is a critical concept. Consider a tank with lot `M251229K` (50,000 kg):
+
+1. Sales SO/123 and SO/456 each reserve 5,000 kg of lot `M251229K`
+2. A new PO reception arrives — merge MO is created
+3. The MO consumes ALL quants (including `M251229K`) and produces a **new lot**
+   `M260219J` (55,000 kg = old 50,000 + new 5,000)
+4. Lot `M251229K` still exists in the database but has **zero stock**
+5. The reservations by SO/123 and SO/456 for lot `M251229K` are now **unfulfillable** —
+   the lot has no stock to deliver
+
+The reservations were already broken the moment the merge happened. This is why the
+system forces the user to deal with existing reservations **before** the merge: those
+reservations will become invalid anyway, so the user must consciously decide what to do
+(unreserve, cancel, or reassign).
+
+### 1.6 How blocking fields work
+
+On `stock.location`:
+
+- **`flowable_production_id`** (Many2one → `mrp.production`): the MO that has blocked
+  this location. Set by `stock.move.write()` when `action_assign()` transitions a raw
+  move to `assigned`/`partially_available`. Cleared when the raw move goes to `done` or
+  `cancel`.
+
+- **`flowable_blocked`** (Boolean, computed, not stored):
+  `bool(flowable_storage and flowable_production_id)`. Convenience field — the real data
+  is `flowable_production_id`.
+
+The `not flowable_blocked` guard in `stock.move.write()` prevents a new MO from
+overwriting an existing `flowable_production_id`.
+
+### 1.7 The reservation post-check in action_assign
+
+`action_assign()` is overridden in `mrp.production`. After `super()`, for flowable
+operations it verifies all raw moves are in `assigned` state. If not, it searches for
+who holds reservations at the source location and raises `UserError` with details. Since
+this runs inside `_action_done()`, the `UserError` rolls back the entire transaction —
+no stock moved, no MO persisted.
+
+This is a post-check (EAFP pattern): try the operation, verify the result, roll back if
+it failed. Advantages:
+
+- **No concurrency window**: checks the actual result, not a prediction
+- **Transaction safe**: `UserError` inside `_action_done` rolls back everything
+- **Universal**: any caller of `action_assign()` on a flowable MO gets the check
+
+---
+
+## 2. Scenarios
+
+### Scenario 1: Reception to Empty Tank — Happy Path
+
+Tank R5355BBR is available and empty. A PO reception validates.
+
+1. `_action_done()` runs — stock moves to the tank
+2. Merge MO is created with `quantity_to_prod = sum(all quants)`
+3. `action_assign()` reserves all quants — succeeds (nothing else reserved)
+4. Post-check passes (all raw moves in `assigned` state)
+5. `stock.move.write()` sets `flowable_production_id` → **location BLOCKED**
 
 ![First Reception](diagrams/01_first_reception.svg)
 
-### Scenario 2 — Bug #1: Second PO Reception — Location Blocked but Constraint Bypassed
+### Scenario 2: Reception with No Outgoing Reservations — Happy Path
 
-Location IS blocked. A second PO receives into the same tank. The constraint skips
-non-MO moves — the second reception goes through. Two active MOs on the same tank.
+Tank Deposito LOX-14 has 32,000 kg from a previous merge. No outgoing operations have
+reserved anything. A new PO reception validates.
 
-![Second Reception — Bug #1](diagrams/02_second_reception_blocked.svg)
+Same flow as Scenario 1: `action_assign()` reserves all 37,000 kg (old + new),
+post-check passes, location blocked. This is the normal case when there are no pending
+deliveries from the tank.
 
-### Scenario 3 — Bug #2: Second PO Reception — Location Not Blocked
+![Fix — Post-check](diagrams/07_proposed_fix.svg)
 
-First reception's `production.action_assign()` failed — location was never blocked. A
-second PO receives into the same tank. The constraint has nothing to enforce. **This is
-the customer's case (R5355BBR).**
+### Scenario 3: Reception with Sale/Transfer Reservations — Error and Rollback
 
-![Second Reception — Bug #2](diagrams/03_second_reception_not_blocked.svg)
+Tank Deposito LOX-14 has 32,449 kg of lot `M240815A`. Two outgoing operations have
+reserved part of it:
 
-### Scenario 4: MO Completion — Unblocking
+- Sale SO/789 → delivery OSWBU/OUT/01234: reserved 6,949 kg of `M240815A`
+- Internal transfer OSWSC/INT/19640: reserved 3,500 kg of `M240815A`
 
-MO finishes processing. Raw move goes to `done`. Location unblocked via
-`stock.move.write()` override.
+Available: 22,000 kg. A new PO reception validates:
 
-![MO Completion](diagrams/04_mo_completion.svg)
-
-### Scenario 5: MO Cancellation — Unblocking
-
-Same `stock.move.write()` mechanism as completion, triggered by `cancel` state.
-
-![MO Cancellation](diagrams/05_mo_cancellation.svg)
-
-### Scenario 6 — Bug #1: Internal Transfer to Blocked Location — Constraint Bypassed
-
-Same as Scenario 2 but with an internal transfer instead of a PO reception. Location IS
-blocked, but the constraint skips non-MO moves.
-
-![Internal Transfer — Bug #1](diagrams/06_internal_transfer.svg)
-
-### Scenario 7 — Fix for Bug #2: Check Reserved Quantities at Reception
-
-Check for reserved quantities before allowing reception at a flowable location. If any
-quants are reserved, show the user which operations hold reservations so they can
-unreserve them first.
-
-![Fix — Bug #2](diagrams/07_proposed_fix.svg)
-
-### Scenario 8 — Reception Blocked: Outgoing Transfers Have Reserved Quantities
-
-Tank has stock from a previous MO. Internal transfers have reserved part of it for
-outgoing deliveries. A new PO reception tries to deliver to the same tank. The
-pre-reception check detects the reserved quantities and rejects the reception with a
-detailed error showing each operation and its reserved amount.
-
-![Reception Blocked by Reservations](diagrams/08_reception_blocked_by_reservations.svg)
-
-### Scenario 9 — User Unreserves Outgoing Operations, Retries Reception
-
-After Scenario 8: the user reads the error message, goes to each listed picking (e.g.
-OSWBU/INT/00277, OSWSC/INT/19640), clicks "Unreserve" to release the quants, then
-retries the reception. The check passes (0 reserved), reception proceeds, MO is created,
-`production.action_assign()` succeeds (all quants available), and the location is
-blocked.
-
-![Unreserve and Retry](diagrams/09_unreserve_and_retry.svg)
-
----
-
-## The Physical Reality
-
-A flowable location is a tank. The lifecycle is:
-
-```
-  EMPTY TANK          TRUCK ARRIVES         TANK OCCUPIED         MO PROCESSES        EMPTY TANK
-  ┌─────────┐        ┌─────────────┐       ┌─────────────┐      ┌─────────────┐     ┌─────────┐
-  │         │        │  ~~~~~~~~   │       │  ████████   │      │  ████ → ○○  │     │         │
-  │  (empty)│───────>│  reception  │──────>│  BLOCKED    │─────>│  mixing     │────>│  (empty)│
-  │         │  PO    │  filling    │ block │  nobody can │  MO  │  consuming  │done │         │
-  └─────────┘receipt └─────────────┘       │  fill here  │      │  the stock  │     └─────────┘
-                                           └─────────────┘      └─────────────┘
-```
-
-The blocking should happen when **stock arrives at the tank** (reception picking
-validation in `stock.picking._action_done()`), not when the MO internally reserves
-quants. The tank is "occupied" the moment material is poured in — that's when nobody
-else should deliver there.
-
-A reception never reserves — it just moves stock from a virtual supplier location to the
-destination. Reservation is for outgoing/internal moves (real source locations), not for
-receptions.
-
----
-
-## Blocking vs Reservation: Two Different Concepts
-
-**Blocking** and **reservation** serve different purposes and must not be confused:
-
-- **Blocking** (`flowable_production_id`): A physical constraint — "this tank is in use,
-  nobody should pour more material in." It's about physical occupation, not inventory
-  bookkeeping.
-
-- **Reservation** (`reserved_quantity` on quants): An Odoo inventory mechanism — "these
-  quants are spoken for by a specific move." Multiple operations can partially reserve
-  quants at the same location.
-
-### Does partial reservation make sense for a tank?
-
-It depends on the direction:
-
-- **Outgoing operations** (selling, internal transfers): **Yes**, partial reservation is
-  valid. You can sell 3,500 kg from a 35,000 kg tank.
-
-- **Incoming operations** (receptions/merges): **No**. When new material arrives and a
-  merge MO is created, the MO needs to process the **entire** tank content (old + new).
-  The MO's `quantity_to_prod` is `sum(ALL quants)`. If some quants are reserved by other
-  operations, `production.action_assign()` cannot reserve the full amount.
-
-### Why old reservations become obsolete after a merge
-
-When a merge MO processes the tank, it consumes all old quants and creates a new lot for
-the mixed product. Any outgoing operations that had reserved quants with old lot numbers
-become unfulfillable — the lot still exists in the database but has no stock. The
-reservation was already broken the moment the merge happened.
-
-This is why the fix warns the user about existing reservations before allowing the
-reception. The user must consciously deal with those reservations first (unreserve them
-manually), because they'll become invalid after the merge anyway.
-
-### Production data: partial reservations are common
-
-Queried on 2026-02-27, 4 out of 32 active flowable locations had partial reservations —
-all from internal transfers and release operations, not MOs:
-
-| Location                     | Total qty | Reserved | Available | Reserved by             |
-| ---------------------------- | --------- | -------- | --------- | ----------------------- |
-| Deposito LIN-11 (Lleida)     | 5,573     | 5,161    | 412       | Pendiente de liberacion |
-| Deposito LOX-14 (Burgos)     | 22,908    | 6,949    | 15,958    | OSWBU/INT/00277         |
-| Deposito LOX-30 (Sant Cugat) | 35,913    | 3,500    | 32,413    | OSWSC/INT/19640         |
-| R4585BCM                     | 15,499    | 15,298   | 201       | OSWBU/INT/00449         |
-
----
-
-## Complete Flow: `_action_done()` on the Reception Picking
-
-When the user clicks "Validate" on the PO reception picking (`stock.picking`), this
-triggers `_action_done()`:
-
-```
-  picking._action_done() runs on: stock.picking (the reception picking)
-  │
-  ├─ 0. _check_flowable_reserved_quantities() ◄── NEW (Bug #2 fix)
-  │     For each flowable destination:
-  │       search move lines reserving quants at that location
-  │       if any → raise UserError showing who/what/how much
-  │     Runs BEFORE super: no stock moved yet, clean abort
-  │
-  ├─ 1. super()._action_done() ──────── Stock arrives at tank (no reservation)
-  │     Odoo core processes              Tank is physically occupied
-  │     PO move lines → done             BUT: location NOT blocked yet
-  │     Quants created at location
-  │
-  ├─ 2. env["stock.quant"].search() ─── quantity_to_prod = sum of quants
-  │
-  ├─ 3. env["mrp.production"].create()  MO + raw move created
-  │                                      BUT: location STILL NOT blocked
-  │
-  ├─ 4. production.action_confirm() ─── Raw move: draft → confirmed
-  │     stock.move.write()               Blocking check: no move_line_ids
-  │                                      → ✗ NOT BLOCKED
-  │
-  ├─ 5. production.move_raw_ids ─────── qty_done set, product_uom_qty=0
-  │       .move_line_ids = [...]         Blocking check: no state in vals
-  │     stock.move.write()               → ✗ NOT BLOCKED
-  │
-  ├─ 6. production.action_assign() ──── Now reliable because step 0 ensured
-  │     │                                all quants are available
-  │     │
-  │     ├─ reserves → BLOCKED ✓          (always succeeds after step 0)
-  │     └─ doesn't reserve → NOT BLOCKED ✗  ← can't happen after fix
-  │
-  └─ 7. production.qty_producing = quantity_to_prod
-```
-
-**The root cause of Bug #2**: `quantity_to_prod` (line 189 of `stock_picking.py`) sums
-ALL quants at the location (`quantity` field), including the already-reserved portion.
-But `production.action_assign()` (step 6) can only reserve AVAILABLE quantity
-(`quantity - reserved_quantity`). When `quantity_to_prod > available`, reservation
-fails, and the blocking mechanism in `stock.move.write()` never triggers.
-
-**The fix**: Step 0 ensures no quants are reserved before the reception proceeds. With
-all quants available, `quantity_to_prod == available`, and `production.action_assign()`
-always succeeds.
-
----
-
-## Bug #1: Constraint bypassed by non-MO moves ([PR #847](https://github.com/nuobit/odoo-addons/pull/847) — FIXED)
-
-**File**: `models/stock_move_line.py`
-
-The blocked-location constraint `_check_flowable_location_blocked` had this condition:
-
-```python
-# OLD CODE:
-production = rec.move_id.raw_material_production_id
-if production and location.flowable_production_id != production:
-    raise ValidationError(...)
-```
-
-The `if production and ...` means: when `production` is falsy (i.e., the move is NOT
-part of an MO — PO receptions, internal transfers), the entire check is **skipped**.
-Even if the location IS blocked, non-MO moves go right through.
-
-**Fix**:
-
-```python
-# NEW CODE:
-production = (
-    rec.move_id.raw_material_production_id
-    or rec.move_id.production_id
-)
-if (
-    location.flowable_production_id
-    and location.flowable_production_id != production
-):
-    raise ValidationError(...)
-```
-
-Now the condition checks whether the **location** is blocked, regardless of whether the
-current move belongs to an MO. Non-MO moves have `production = False`, so
-`flowable_production_id != False` is always True when the location is blocked.
-
----
-
-## Bug #2: Blocking tied to reservation success (FIXED)
-
-**Root cause**: Blocking depends on `production.action_assign()` successfully reserving
-quants (step 6 of `picking._action_done()`). But `action_assign()` fails when
-`quantity_to_prod > available_quantity` because some quants are reserved by other
-operations (internal transfers, sales).
-
-**How `action_assign()` fails**:
-
-```
-Line 189: quantity_to_prod = sum(component_quant.mapped("quantity"))
-          → sums ALL quants (total quantity, including reserved portion)
-
-Odoo core _get_available_quantity():
-          → available = quantity - reserved_quantity
-          → if some quants are reserved by transfers: available < quantity
-
-action_assign() tries to reserve quantity_to_prod:
-          → quantity_to_prod > available → PARTIAL or NO reservation
-          → raw move state stays "confirmed", not "assigned"
-          → stock.move.write() never triggers blocking
-          → flowable_production_id stays NULL
-```
-
-**Impact**: Location stays unblocked, and the constraint (even with the
-[PR #847](https://github.com/nuobit/odoo-addons/pull/847) fix) has nothing to enforce. A
-second PO reception goes through, creating duplicate MOs.
-
-### Fix: Check for reserved quantities before reception
-
-**File**: `models/stock_picking.py` — new method `_check_flowable_reserved_quantities()`
-
-Called at the start of `_action_done()`, **before** `super()._action_done()`. For each
-flowable destination location, searches for active move lines that have reserved
-quantities (`product_uom_qty > 0`) with the location as source. If found, raises
-`UserError` showing:
-
-- Which product is reserved
-- How much is reserved
-- Which operation holds the reservation (picking name, MO name, or reference)
-
-The user must go to those operations and unreserve manually before the reception can
-proceed. This is the correct approach because:
-
-1. The merge MO needs 100% of the tank available for reservation
-2. Old lot reservations become obsolete after the merge anyway — the MO creates a new
-   lot, and the old lots still exist but have no stock, so the outgoing operations that
-   had reserved those lots can never ship
-3. The user is informed and decides how to handle existing reservations
-
-With all quants available, `production.action_assign()` always succeeds, and the
-existing blocking mechanism in `stock.move.write()` works reliably.
-
-### Why one check is enough — no second check needed at action_assign
-
-The check runs **before** `super()._action_done()`. If it fails, a `UserError` is raised
-and execution stops — `super()` never runs, no stock moves, no MO is created, nothing
-changes. If it passes, all quants are guaranteed to be available, so
-`production.action_assign()` at step 6 will always succeed. There's no need for a
-redundant check at step 6:
-
-```
-_action_done():
-  Step 0: _check_flowable_reserved_quantities()
-          → reserved quants? → UserError (STOP — never reaches step 1)
-          → no reserved quants? → continue ↓
-
-  Step 1: super()._action_done()   ← only runs if step 0 passed
-  ...
-  Step 6: action_assign()          ← only runs if step 0 passed
-                                      → always succeeds (guaranteed)
-  → stock.move.write() triggers    ← sets flowable_production_id
-  → location BLOCKED ✓
-```
-
-The single pre-check is the gatekeeper. It guarantees the conditions for the existing
-blocking mechanism to work every time.
-
-### User workflow when the check fails (Scenarios 8-9)
-
-1. User clicks "Validate" on the reception picking
-2. `_check_flowable_reserved_quantities()` finds reserved quants
-3. `UserError` is shown with details:
+1. `_action_done()` runs — stock moves to the tank (now 37,449 kg total)
+2. Merge MO created with `quantity_to_prod = 37,449` (sum of ALL quants)
+3. `action_assign()` tries to reserve 37,449 but only 27,000 available
+4. Raw move stays `confirmed` (not `assigned`)
+5. **Post-check detects partial reservation** → `UserError`:
 
    ```
-   Cannot receive at flowable location 'R5355BBR' because there are
-   reserved quantities. All stock must be available before receiving
-   new material for merging.
+   Cannot fully reserve flowable location 'Deposito LOX-14' because there
+   are other reserved quantities. All stock must be available before merging.
 
    The following operations have reservations that must be unreserved first:
 
-     - Product X: 6,949.17 kg (OSWBU/INT/00277)
-     - Product X: 3,500.00 kg (OSWSC/INT/19640)
+     - Product X: 6,949.17 kg — OSWBU/OUT/01234 (Delivery Orders)
+     - Product X: 3,500.00 kg — OSWSC/INT/19640 (Internal Transfers)
    ```
 
-4. User goes to each listed picking → clicks "Unreserve"
-5. User returns to the reception picking → clicks "Validate" again
-6. Check passes (0 reserved) → reception proceeds → MO created → `action_assign()`
-   succeeds → location blocked
+6. **Entire transaction rolls back**: no stock moved, no MO created
 
-### Customer case: R5355BBR (id=30306)
+The error tells the user exactly which operations to fix. The user knows these
+reservations are for lot `M240815A`, which will cease to exist after the merge anyway
+(see [1.5](#15-why-lot-reservations-become-obsolete-after-a-merge)).
 
-Two PO receptions were validated to the same flowable location R5355BBR, creating two
-active MOs and duplicate lots:
+![Reception Blocked by Reservations](diagrams/08_reception_blocked_by_reservations.svg)
 
-| MO                         | Picking        | Origin   | Created             | State    |
-| -------------------------- | -------------- | -------- | ------------------- | -------- |
-| OSWBU/TANK/00310 (id=2100) | OSWBU/IN/02260 | PO/21540 | 2026-01-12 12:04:20 | to_close |
-| OSWBU/TANK/00321 (id=2197) | OSWBU/IN/02318 | PO/22188 | 2026-02-24 07:26:02 | to_close |
+### Scenario 4: User Unreserves and Retries — Success
 
-Timeline:
+After Scenario 3, the user:
 
-```
-2026-01-09 15:58  MO 00309 completed → location R5355BBR UNBLOCKED
-2026-01-12 12:04  PO/21540 received → MO 00310 created
-                    → production.action_assign(): FAILED (no available quants)
-                    → location: NOT BLOCKED
-                    → MO 00310 raw move: confirmed, 0 reserved
+1. Reads the error — sees the delivery and internal transfer holding reservations
+2. Goes to OSWBU/OUT/01234 → clicks "Unreserve" (releases 6,949 kg)
+3. Goes to OSWSC/INT/19640 → clicks "Unreserve" (releases 3,500 kg)
+4. Returns to the PO reception → clicks "Validate" again
+5. `action_assign()` succeeds — all quants available → **location BLOCKED**
 
-... 43 days pass, MO 00310 never completed ...
+After the merge completes, lot `M240815A` has zero stock and a new lot exists. The user
+can then re-reserve the deliveries with the new lot if needed.
 
-2026-02-24 07:26  PO/22188 received:
-                    → constraint check: flowable_production_id=NULL
-                      → flowable_blocked=False → constraint SKIPPED
-                    → AND even if blocked, Bug #1 would bypass it
-                    → reception goes through
-                    → MO 00321 created → TWO active MOs on same location
-```
+![Unreserve and Retry](diagrams/09_unreserve_and_retry.svg)
 
-Current state of R5355BBR quants (queried 2026-02-27):
+### Scenario 5: Second Reception to Blocked Location — Correctly Rejected
 
-| Lot      | Quantity  | Reserved  | Available | Notes                              |
-| -------- | --------- | --------- | --------- | ---------------------------------- |
-| 449      | 1.00      | 0.00      | 1.00      | Leftover from MO 00310's reception |
-| 90716    | 1.00      | 0.00      | 1.00      | Leftover from MO 00310's reception |
-| M251229K | 50.83     | 50.83     | 0.00      | MO 00310's reception batch         |
-| M260219J | 19,190.18 | 19,190.18 | 0.00      | MO 00321's reception batch         |
+Location is blocked by an active MO. A second PO reception tries to validate to the same
+tank. The constraint `_check_flowable_location_blocked` on `stock.move.line` detects
+`flowable_production_id` is set and the current move doesn't belong to that MO →
+`ValidationError`. Reception rejected.
 
-Both bugs contributed:
+This also applies to internal transfers — any move to a blocked location is rejected
+regardless of origin.
 
-- Bug #1 (constraint bypass): even blocked locations weren't protected from PO
-  receptions
-- Bug #2 (wrong blocking event): the location wasn't blocked at all because blocking
-  depends on `production.action_assign()`, not on reception
+![Second Reception Blocked](diagrams/02_second_reception_blocked.svg)
+![Internal Transfer Blocked](diagrams/06_internal_transfer.svg)
 
-### How `action_assign()` failed for MO 00310
+### Scenario 6: MO Completion — Unblocking
 
-MO 00310 was created with `quantity_to_prod = 19,339.19` (sum of all quants at
-R5355BBR). But `action_assign()` found 0 available quantity because pre-existing quants
-were already reserved by other operations. The raw move stayed in `confirmed` state with
-0 reserved — the blocking mechanism never triggered.
+MO finishes processing. The raw move goes to `done`. `stock.move.write()` detects the
+state change and clears `flowable_production_id`. Location is available again for the
+next reception.
+
+![MO Completion](diagrams/04_mo_completion.svg)
+
+### Scenario 7: MO Cancellation — Unblocking
+
+Same mechanism as completion. `stock.move.write()` clears `flowable_production_id` when
+the raw move goes to `cancel`.
+
+![MO Cancellation](diagrams/05_mo_cancellation.svg)
 
 ---
 
-## How the Blocking Fields Work
+## 3. Historical Reference: Customer Case R5355BBR
 
-On `stock.location`, there are two related fields:
+Two PO receptions were validated to the same tank, creating duplicate MOs:
 
-- **`flowable_production_id`** (Many2one → `mrp.production`): the MO that has reserved
-  stock at this location. Set by `stock.move.write()` when `production.action_assign()`
-  transitions a raw move to `assigned` or `partially_available`. Cleared when the raw
-  move goes to `done` or `cancel`.
+| MO             | Picking        | Origin   | Created    |
+| -------------- | -------------- | -------- | ---------- |
+| OSWBU/TANK/310 | OSWBU/IN/02260 | PO/21540 | 2026-01-12 |
+| OSWBU/TANK/321 | OSWBU/IN/02318 | PO/22188 | 2026-02-24 |
 
-- **`flowable_blocked`** (Boolean, computed): calculated from `flowable_production_id`:
-  ```python
-  @api.depends("flowable_production_id")
-  def _compute_flowable_blocked(self):
-      for rec in self:
-          rec.flowable_blocked = bool(
-              rec.flowable_storage and rec.flowable_production_id
-          )
-  ```
-  Simply: `flowable_blocked = True` when the location is flowable AND has a production
-  assigned. It's a convenience field — the real data is `flowable_production_id`.
+MO 310's `action_assign()` failed (0 available quants — all reserved by other
+operations) → location never blocked → 43 days later PO/22188 received into the same
+tank unimpeded.
 
-The blocking mechanism in `stock.move.write()` uses `flowable_blocked` as a guard to
-prevent overwriting:
+Two issues contributed:
 
-```python
-# models/stock_move.py:27-34
-elif (
-    new_state in ("confirmed", "assigned", "partially_available")
-    and vals.get("move_line_ids", rec.move_line_ids)
-    and production.picking_type_id.flowable_operation
-    and production.location_dest_id.flowable_storage
-    and not production.location_dest_id.flowable_blocked   # guard
-):
-    production.location_dest_id.flowable_production_id = production
-```
+1. The blocked-location constraint in `stock_move_line.py` skipped non-MO moves, so even
+   blocked locations weren't protected from PO receptions
+2. `action_assign()` failed silently when quants were partially reserved, leaving the
+   location unblocked
 
-The `not flowable_blocked` condition ensures that if the location is already blocked by
-another MO, a new MO's `production.action_assign()` cannot overwrite
-`flowable_production_id`.
+Both are now fixed:
+
+1. The constraint checks `location.flowable_production_id` directly — any move to a
+   blocked location is rejected
+2. The `action_assign()` override detects failed reservations and raises `UserError`
+   with details, rolling back the transaction
 
 ---
 
-## Summary of Fixes
+## 4. Future Improvements
 
-| Bug | Problem                                                                                                     | Fix                                                                                      | File                 | Status                                                            |
-| --- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------- | ----------------------------------------------------------------- |
-| #1  | Constraint skips non-MO moves (PO receptions, internal transfers) even when location IS blocked             | Check `location.flowable_production_id` instead of `production`                          | `stock_move_line.py` | FIXED ([PR #847](https://github.com/nuobit/odoo-addons/pull/847)) |
-| #2  | Blocking depends on `action_assign()` success; fails when quants are partially reserved by other operations | Check for reserved quantities before allowing reception; abort with details if any found | `stock_picking.py`   | FIXED                                                             |
-
----
-
-## Future Improvements
-
-- **Auto-unreserve on reception**: Instead of warning the user and requiring manual
-  unreservation, automatically unreserve outgoing operations when receiving at a
-  flowable location. Deferred because it could disrupt planned deliveries — need to
-  observe how the warning approach works in production first.
+- **Auto-unreserve on reception**: Instead of requiring manual unreservation,
+  automatically unreserve outgoing operations when receiving at a flowable location.
+  Deferred to observe how the manual approach works in production first —
+  auto-unreserving could disrupt planned deliveries without the user being aware.
 
 ---
 
-## Validation Queries
+## 5. Validation Queries
 
 ```sql
 -- Check current state of a flowable location:
@@ -486,20 +258,12 @@ LEFT JOIN stock_picking sp ON sp.id = mp.picking_id
 WHERE mp.location_src_id = <location_id>
   AND mp.state NOT IN ('done', 'cancel');
 
--- Check reservation status of active raw moves:
-SELECT sm.id, sm.state, mp.name, sml.product_uom_qty, sml.qty_done
-FROM stock_move sm
-JOIN mrp_production mp ON mp.id = sm.raw_material_production_id
-JOIN stock_picking_type spt ON spt.id = mp.picking_type_id
-LEFT JOIN stock_move_line sml ON sml.move_id = sm.id
-WHERE spt.flowable_operation = true AND mp.picking_id IS NOT NULL
-  AND sm.state NOT IN ('done', 'cancel');
-
--- Check reserved quantities at a flowable location (Bug #2 diagnostic):
+-- Check reserved quantities at all flowable locations:
 SELECT sl.name as location,
        round(COALESCE(SUM(sq.quantity), 0)::numeric, 2) as total_qty,
        round(COALESCE(SUM(sq.reserved_quantity), 0)::numeric, 2) as reserved,
-       round((COALESCE(SUM(sq.quantity), 0) - COALESCE(SUM(sq.reserved_quantity), 0))::numeric, 2) as available
+       round((COALESCE(SUM(sq.quantity), 0)
+              - COALESCE(SUM(sq.reserved_quantity), 0))::numeric, 2) as available
 FROM stock_location sl
 LEFT JOIN stock_quant sq ON sq.location_id = sl.id AND sq.quantity > 0
 WHERE sl.flowable_storage = true

--- a/stock_location_flowable/doc/flowable_location_blocking_flow.md
+++ b/stock_location_flowable/doc/flowable_location_blocking_flow.md
@@ -1,0 +1,524 @@
+# Flowable Location Blocking Mechanism
+
+This document describes how the blocking mechanism works for flowable locations (tanks),
+the complete flow from PO reception to MO creation, the known issues, and the
+implemented fixes.
+
+**PR**: https://github.com/nuobit/odoo-addons/pull/847 **Branch**:
+`14.0-fix-stock_location_flowable-flowable_blocking`
+
+---
+
+## Flow Diagrams
+
+All diagrams are in `diagrams/`.
+
+### The Physical Reality: Tank Lifecycle
+
+A flowable location is a physical tank. A reception never reserves — it just delivers
+stock from a virtual supplier location to the tank. Blocking should happen when stock
+enters the tank (reception picking validation), not when the MO internally reserves
+quants.
+
+![Tank Lifecycle](diagrams/00_tank_lifecycle.svg)
+
+### Scenario 1: First PO Reception — Happy Path
+
+Single PO received at an available tank. MO auto-created, location blocked, MO
+completes, location freed. Everything works correctly.
+
+![First Reception](diagrams/01_first_reception.svg)
+
+### Scenario 2 — Bug #1: Second PO Reception — Location Blocked but Constraint Bypassed
+
+Location IS blocked. A second PO receives into the same tank. The constraint skips
+non-MO moves — the second reception goes through. Two active MOs on the same tank.
+
+![Second Reception — Bug #1](diagrams/02_second_reception_blocked.svg)
+
+### Scenario 3 — Bug #2: Second PO Reception — Location Not Blocked
+
+First reception's `production.action_assign()` failed — location was never blocked. A
+second PO receives into the same tank. The constraint has nothing to enforce. **This is
+the customer's case (R5355BBR).**
+
+![Second Reception — Bug #2](diagrams/03_second_reception_not_blocked.svg)
+
+### Scenario 4: MO Completion — Unblocking
+
+MO finishes processing. Raw move goes to `done`. Location unblocked via
+`stock.move.write()` override.
+
+![MO Completion](diagrams/04_mo_completion.svg)
+
+### Scenario 5: MO Cancellation — Unblocking
+
+Same `stock.move.write()` mechanism as completion, triggered by `cancel` state.
+
+![MO Cancellation](diagrams/05_mo_cancellation.svg)
+
+### Scenario 6 — Bug #1: Internal Transfer to Blocked Location — Constraint Bypassed
+
+Same as Scenario 2 but with an internal transfer instead of a PO reception. Location IS
+blocked, but the constraint skips non-MO moves.
+
+![Internal Transfer — Bug #1](diagrams/06_internal_transfer.svg)
+
+### Scenario 7 — Fix for Bug #2: Check Reserved Quantities at Reception
+
+Check for reserved quantities before allowing reception at a flowable location. If any
+quants are reserved, show the user which operations hold reservations so they can
+unreserve them first.
+
+![Fix — Bug #2](diagrams/07_proposed_fix.svg)
+
+### Scenario 8 — Reception Blocked: Outgoing Transfers Have Reserved Quantities
+
+Tank has stock from a previous MO. Internal transfers have reserved part of it for
+outgoing deliveries. A new PO reception tries to deliver to the same tank. The
+pre-reception check detects the reserved quantities and rejects the reception with a
+detailed error showing each operation and its reserved amount.
+
+![Reception Blocked by Reservations](diagrams/08_reception_blocked_by_reservations.svg)
+
+### Scenario 9 — User Unreserves Outgoing Operations, Retries Reception
+
+After Scenario 8: the user reads the error message, goes to each listed picking (e.g.
+OSWBU/INT/00277, OSWSC/INT/19640), clicks "Unreserve" to release the quants, then
+retries the reception. The check passes (0 reserved), reception proceeds, MO is created,
+`production.action_assign()` succeeds (all quants available), and the location is
+blocked.
+
+![Unreserve and Retry](diagrams/09_unreserve_and_retry.svg)
+
+---
+
+## The Physical Reality
+
+A flowable location is a tank. The lifecycle is:
+
+```
+  EMPTY TANK          TRUCK ARRIVES         TANK OCCUPIED         MO PROCESSES        EMPTY TANK
+  ┌─────────┐        ┌─────────────┐       ┌─────────────┐      ┌─────────────┐     ┌─────────┐
+  │         │        │  ~~~~~~~~   │       │  ████████   │      │  ████ → ○○  │     │         │
+  │  (empty)│───────>│  reception  │──────>│  BLOCKED    │─────>│  mixing     │────>│  (empty)│
+  │         │  PO    │  filling    │ block │  nobody can │  MO  │  consuming  │done │         │
+  └─────────┘receipt └─────────────┘       │  fill here  │      │  the stock  │     └─────────┘
+                                           └─────────────┘      └─────────────┘
+```
+
+The blocking should happen when **stock arrives at the tank** (reception picking
+validation in `stock.picking._action_done()`), not when the MO internally reserves
+quants. The tank is "occupied" the moment material is poured in — that's when nobody
+else should deliver there.
+
+A reception never reserves — it just moves stock from a virtual supplier location to the
+destination. Reservation is for outgoing/internal moves (real source locations), not for
+receptions.
+
+---
+
+## Blocking vs Reservation: Two Different Concepts
+
+**Blocking** and **reservation** serve different purposes and must not be confused:
+
+- **Blocking** (`flowable_production_id`): A physical constraint — "this tank is in use,
+  nobody should pour more material in." It's about physical occupation, not inventory
+  bookkeeping.
+
+- **Reservation** (`reserved_quantity` on quants): An Odoo inventory mechanism — "these
+  quants are spoken for by a specific move." Multiple operations can partially reserve
+  quants at the same location.
+
+### Does partial reservation make sense for a tank?
+
+It depends on the direction:
+
+- **Outgoing operations** (selling, internal transfers): **Yes**, partial reservation is
+  valid. You can sell 3,500 kg from a 35,000 kg tank.
+
+- **Incoming operations** (receptions/merges): **No**. When new material arrives and a
+  merge MO is created, the MO needs to process the **entire** tank content (old + new).
+  The MO's `quantity_to_prod` is `sum(ALL quants)`. If some quants are reserved by other
+  operations, `production.action_assign()` cannot reserve the full amount.
+
+### Why old reservations become obsolete after a merge
+
+When a merge MO processes the tank, it consumes all old quants and creates a new lot for
+the mixed product. Any outgoing operations that had reserved quants with old lot numbers
+become unfulfillable — the lot still exists in the database but has no stock. The
+reservation was already broken the moment the merge happened.
+
+This is why the fix warns the user about existing reservations before allowing the
+reception. The user must consciously deal with those reservations first (unreserve them
+manually), because they'll become invalid after the merge anyway.
+
+### Production data: partial reservations are common
+
+Queried on 2026-02-27, 4 out of 32 active flowable locations had partial reservations —
+all from internal transfers and release operations, not MOs:
+
+| Location                     | Total qty | Reserved | Available | Reserved by             |
+| ---------------------------- | --------- | -------- | --------- | ----------------------- |
+| Deposito LIN-11 (Lleida)     | 5,573     | 5,161    | 412       | Pendiente de liberacion |
+| Deposito LOX-14 (Burgos)     | 22,908    | 6,949    | 15,958    | OSWBU/INT/00277         |
+| Deposito LOX-30 (Sant Cugat) | 35,913    | 3,500    | 32,413    | OSWSC/INT/19640         |
+| R4585BCM                     | 15,499    | 15,298   | 201       | OSWBU/INT/00449         |
+
+---
+
+## Complete Flow: `_action_done()` on the Reception Picking
+
+When the user clicks "Validate" on the PO reception picking (`stock.picking`), this
+triggers `_action_done()`:
+
+```
+  picking._action_done() runs on: stock.picking (the reception picking)
+  │
+  ├─ 0. _check_flowable_reserved_quantities() ◄── NEW (Bug #2 fix)
+  │     For each flowable destination:
+  │       search move lines reserving quants at that location
+  │       if any → raise UserError showing who/what/how much
+  │     Runs BEFORE super: no stock moved yet, clean abort
+  │
+  ├─ 1. super()._action_done() ──────── Stock arrives at tank (no reservation)
+  │     Odoo core processes              Tank is physically occupied
+  │     PO move lines → done             BUT: location NOT blocked yet
+  │     Quants created at location
+  │
+  ├─ 2. env["stock.quant"].search() ─── quantity_to_prod = sum of quants
+  │
+  ├─ 3. env["mrp.production"].create()  MO + raw move created
+  │                                      BUT: location STILL NOT blocked
+  │
+  ├─ 4. production.action_confirm() ─── Raw move: draft → confirmed
+  │     stock.move.write()               Blocking check: no move_line_ids
+  │                                      → ✗ NOT BLOCKED
+  │
+  ├─ 5. production.move_raw_ids ─────── qty_done set, product_uom_qty=0
+  │       .move_line_ids = [...]         Blocking check: no state in vals
+  │     stock.move.write()               → ✗ NOT BLOCKED
+  │
+  ├─ 6. production.action_assign() ──── Now reliable because step 0 ensured
+  │     │                                all quants are available
+  │     │
+  │     ├─ reserves → BLOCKED ✓          (always succeeds after step 0)
+  │     └─ doesn't reserve → NOT BLOCKED ✗  ← can't happen after fix
+  │
+  └─ 7. production.qty_producing = quantity_to_prod
+```
+
+**The root cause of Bug #2**: `quantity_to_prod` (line 189 of `stock_picking.py`) sums
+ALL quants at the location (`quantity` field), including the already-reserved portion.
+But `production.action_assign()` (step 6) can only reserve AVAILABLE quantity
+(`quantity - reserved_quantity`). When `quantity_to_prod > available`, reservation
+fails, and the blocking mechanism in `stock.move.write()` never triggers.
+
+**The fix**: Step 0 ensures no quants are reserved before the reception proceeds. With
+all quants available, `quantity_to_prod == available`, and `production.action_assign()`
+always succeeds.
+
+---
+
+## Bug #1: Constraint bypassed by non-MO moves ([PR #847](https://github.com/nuobit/odoo-addons/pull/847) — FIXED)
+
+**File**: `models/stock_move_line.py`
+
+The blocked-location constraint `_check_flowable_location_blocked` had this condition:
+
+```python
+# OLD CODE:
+production = rec.move_id.raw_material_production_id
+if production and location.flowable_production_id != production:
+    raise ValidationError(...)
+```
+
+The `if production and ...` means: when `production` is falsy (i.e., the move is NOT
+part of an MO — PO receptions, internal transfers), the entire check is **skipped**.
+Even if the location IS blocked, non-MO moves go right through.
+
+**Fix**:
+
+```python
+# NEW CODE:
+production = (
+    rec.move_id.raw_material_production_id
+    or rec.move_id.production_id
+)
+if (
+    location.flowable_production_id
+    and location.flowable_production_id != production
+):
+    raise ValidationError(...)
+```
+
+Now the condition checks whether the **location** is blocked, regardless of whether the
+current move belongs to an MO. Non-MO moves have `production = False`, so
+`flowable_production_id != False` is always True when the location is blocked.
+
+---
+
+## Bug #2: Blocking tied to reservation success (FIXED)
+
+**Root cause**: Blocking depends on `production.action_assign()` successfully reserving
+quants (step 6 of `picking._action_done()`). But `action_assign()` fails when
+`quantity_to_prod > available_quantity` because some quants are reserved by other
+operations (internal transfers, sales).
+
+**How `action_assign()` fails**:
+
+```
+Line 189: quantity_to_prod = sum(component_quant.mapped("quantity"))
+          → sums ALL quants (total quantity, including reserved portion)
+
+Odoo core _get_available_quantity():
+          → available = quantity - reserved_quantity
+          → if some quants are reserved by transfers: available < quantity
+
+action_assign() tries to reserve quantity_to_prod:
+          → quantity_to_prod > available → PARTIAL or NO reservation
+          → raw move state stays "confirmed", not "assigned"
+          → stock.move.write() never triggers blocking
+          → flowable_production_id stays NULL
+```
+
+**Impact**: Location stays unblocked, and the constraint (even with the
+[PR #847](https://github.com/nuobit/odoo-addons/pull/847) fix) has nothing to enforce. A
+second PO reception goes through, creating duplicate MOs.
+
+### Fix: Check for reserved quantities before reception
+
+**File**: `models/stock_picking.py` — new method `_check_flowable_reserved_quantities()`
+
+Called at the start of `_action_done()`, **before** `super()._action_done()`. For each
+flowable destination location, searches for active move lines that have reserved
+quantities (`product_uom_qty > 0`) with the location as source. If found, raises
+`UserError` showing:
+
+- Which product is reserved
+- How much is reserved
+- Which operation holds the reservation (picking name, MO name, or reference)
+
+The user must go to those operations and unreserve manually before the reception can
+proceed. This is the correct approach because:
+
+1. The merge MO needs 100% of the tank available for reservation
+2. Old lot reservations become obsolete after the merge anyway — the MO creates a new
+   lot, and the old lots still exist but have no stock, so the outgoing operations that
+   had reserved those lots can never ship
+3. The user is informed and decides how to handle existing reservations
+
+With all quants available, `production.action_assign()` always succeeds, and the
+existing blocking mechanism in `stock.move.write()` works reliably.
+
+### Why one check is enough — no second check needed at action_assign
+
+The check runs **before** `super()._action_done()`. If it fails, a `UserError` is raised
+and execution stops — `super()` never runs, no stock moves, no MO is created, nothing
+changes. If it passes, all quants are guaranteed to be available, so
+`production.action_assign()` at step 6 will always succeed. There's no need for a
+redundant check at step 6:
+
+```
+_action_done():
+  Step 0: _check_flowable_reserved_quantities()
+          → reserved quants? → UserError (STOP — never reaches step 1)
+          → no reserved quants? → continue ↓
+
+  Step 1: super()._action_done()   ← only runs if step 0 passed
+  ...
+  Step 6: action_assign()          ← only runs if step 0 passed
+                                      → always succeeds (guaranteed)
+  → stock.move.write() triggers    ← sets flowable_production_id
+  → location BLOCKED ✓
+```
+
+The single pre-check is the gatekeeper. It guarantees the conditions for the existing
+blocking mechanism to work every time.
+
+### User workflow when the check fails (Scenarios 8-9)
+
+1. User clicks "Validate" on the reception picking
+2. `_check_flowable_reserved_quantities()` finds reserved quants
+3. `UserError` is shown with details:
+
+   ```
+   Cannot receive at flowable location 'R5355BBR' because there are
+   reserved quantities. All stock must be available before receiving
+   new material for merging.
+
+   The following operations have reservations that must be unreserved first:
+
+     - Product X: 6,949.17 kg (OSWBU/INT/00277)
+     - Product X: 3,500.00 kg (OSWSC/INT/19640)
+   ```
+
+4. User goes to each listed picking → clicks "Unreserve"
+5. User returns to the reception picking → clicks "Validate" again
+6. Check passes (0 reserved) → reception proceeds → MO created → `action_assign()`
+   succeeds → location blocked
+
+### Customer case: R5355BBR (id=30306)
+
+Two PO receptions were validated to the same flowable location R5355BBR, creating two
+active MOs and duplicate lots:
+
+| MO                         | Picking        | Origin   | Created             | State    |
+| -------------------------- | -------------- | -------- | ------------------- | -------- |
+| OSWBU/TANK/00310 (id=2100) | OSWBU/IN/02260 | PO/21540 | 2026-01-12 12:04:20 | to_close |
+| OSWBU/TANK/00321 (id=2197) | OSWBU/IN/02318 | PO/22188 | 2026-02-24 07:26:02 | to_close |
+
+Timeline:
+
+```
+2026-01-09 15:58  MO 00309 completed → location R5355BBR UNBLOCKED
+2026-01-12 12:04  PO/21540 received → MO 00310 created
+                    → production.action_assign(): FAILED (no available quants)
+                    → location: NOT BLOCKED
+                    → MO 00310 raw move: confirmed, 0 reserved
+
+... 43 days pass, MO 00310 never completed ...
+
+2026-02-24 07:26  PO/22188 received:
+                    → constraint check: flowable_production_id=NULL
+                      → flowable_blocked=False → constraint SKIPPED
+                    → AND even if blocked, Bug #1 would bypass it
+                    → reception goes through
+                    → MO 00321 created → TWO active MOs on same location
+```
+
+Current state of R5355BBR quants (queried 2026-02-27):
+
+| Lot      | Quantity  | Reserved  | Available | Notes                              |
+| -------- | --------- | --------- | --------- | ---------------------------------- |
+| 449      | 1.00      | 0.00      | 1.00      | Leftover from MO 00310's reception |
+| 90716    | 1.00      | 0.00      | 1.00      | Leftover from MO 00310's reception |
+| M251229K | 50.83     | 50.83     | 0.00      | MO 00310's reception batch         |
+| M260219J | 19,190.18 | 19,190.18 | 0.00      | MO 00321's reception batch         |
+
+Both bugs contributed:
+
+- Bug #1 (constraint bypass): even blocked locations weren't protected from PO
+  receptions
+- Bug #2 (wrong blocking event): the location wasn't blocked at all because blocking
+  depends on `production.action_assign()`, not on reception
+
+### How `action_assign()` failed for MO 00310
+
+MO 00310 was created with `quantity_to_prod = 19,339.19` (sum of all quants at
+R5355BBR). But `action_assign()` found 0 available quantity because pre-existing quants
+were already reserved by other operations. The raw move stayed in `confirmed` state with
+0 reserved — the blocking mechanism never triggered.
+
+---
+
+## How the Blocking Fields Work
+
+On `stock.location`, there are two related fields:
+
+- **`flowable_production_id`** (Many2one → `mrp.production`): the MO that has reserved
+  stock at this location. Set by `stock.move.write()` when `production.action_assign()`
+  transitions a raw move to `assigned` or `partially_available`. Cleared when the raw
+  move goes to `done` or `cancel`.
+
+- **`flowable_blocked`** (Boolean, computed): calculated from `flowable_production_id`:
+  ```python
+  @api.depends("flowable_production_id")
+  def _compute_flowable_blocked(self):
+      for rec in self:
+          rec.flowable_blocked = bool(
+              rec.flowable_storage and rec.flowable_production_id
+          )
+  ```
+  Simply: `flowable_blocked = True` when the location is flowable AND has a production
+  assigned. It's a convenience field — the real data is `flowable_production_id`.
+
+The blocking mechanism in `stock.move.write()` uses `flowable_blocked` as a guard to
+prevent overwriting:
+
+```python
+# models/stock_move.py:27-34
+elif (
+    new_state in ("confirmed", "assigned", "partially_available")
+    and vals.get("move_line_ids", rec.move_line_ids)
+    and production.picking_type_id.flowable_operation
+    and production.location_dest_id.flowable_storage
+    and not production.location_dest_id.flowable_blocked   # guard
+):
+    production.location_dest_id.flowable_production_id = production
+```
+
+The `not flowable_blocked` condition ensures that if the location is already blocked by
+another MO, a new MO's `production.action_assign()` cannot overwrite
+`flowable_production_id`.
+
+---
+
+## Summary of Fixes
+
+| Bug | Problem                                                                                                     | Fix                                                                                      | File                 | Status                                                            |
+| --- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------- | ----------------------------------------------------------------- |
+| #1  | Constraint skips non-MO moves (PO receptions, internal transfers) even when location IS blocked             | Check `location.flowable_production_id` instead of `production`                          | `stock_move_line.py` | FIXED ([PR #847](https://github.com/nuobit/odoo-addons/pull/847)) |
+| #2  | Blocking depends on `action_assign()` success; fails when quants are partially reserved by other operations | Check for reserved quantities before allowing reception; abort with details if any found | `stock_picking.py`   | FIXED                                                             |
+
+---
+
+## Future Improvements
+
+- **Auto-unreserve on reception**: Instead of warning the user and requiring manual
+  unreservation, automatically unreserve outgoing operations when receiving at a
+  flowable location. Deferred because it could disrupt planned deliveries — need to
+  observe how the warning approach works in production first.
+
+---
+
+## Validation Queries
+
+```sql
+-- Check current state of a flowable location:
+SELECT id, name, flowable_production_id, flowable_storage
+FROM stock_location WHERE id = <location_id>;
+
+-- Check active MOs on a flowable location:
+SELECT mp.id, mp.name, mp.state, sp.name as picking, mp.create_date
+FROM mrp_production mp
+LEFT JOIN stock_picking sp ON sp.id = mp.picking_id
+WHERE mp.location_src_id = <location_id>
+  AND mp.state NOT IN ('done', 'cancel');
+
+-- Check reservation status of active raw moves:
+SELECT sm.id, sm.state, mp.name, sml.product_uom_qty, sml.qty_done
+FROM stock_move sm
+JOIN mrp_production mp ON mp.id = sm.raw_material_production_id
+JOIN stock_picking_type spt ON spt.id = mp.picking_type_id
+LEFT JOIN stock_move_line sml ON sml.move_id = sm.id
+WHERE spt.flowable_operation = true AND mp.picking_id IS NOT NULL
+  AND sm.state NOT IN ('done', 'cancel');
+
+-- Check reserved quantities at a flowable location (Bug #2 diagnostic):
+SELECT sl.name as location,
+       round(COALESCE(SUM(sq.quantity), 0)::numeric, 2) as total_qty,
+       round(COALESCE(SUM(sq.reserved_quantity), 0)::numeric, 2) as reserved,
+       round((COALESCE(SUM(sq.quantity), 0) - COALESCE(SUM(sq.reserved_quantity), 0))::numeric, 2) as available
+FROM stock_location sl
+LEFT JOIN stock_quant sq ON sq.location_id = sl.id AND sq.quantity > 0
+WHERE sl.flowable_storage = true
+GROUP BY sl.id, sl.name
+HAVING COALESCE(SUM(sq.reserved_quantity), 0) > 0
+ORDER BY sl.name;
+
+-- Check who is reserving at a specific flowable location:
+SELECT sml.product_uom_qty as reserved,
+       pp.default_code as product,
+       sm.reference,
+       sp.name as picking,
+       mp.name as mo
+FROM stock_move_line sml
+JOIN stock_move sm ON sm.id = sml.move_id
+JOIN product_product pp ON pp.id = sml.product_id
+LEFT JOIN stock_picking sp ON sp.id = sm.picking_id
+LEFT JOIN mrp_production mp ON mp.id = sm.raw_material_production_id
+WHERE sml.location_id = <location_id>
+  AND sml.product_uom_qty > 0
+  AND sm.state NOT IN ('done', 'cancel', 'draft');
+```

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_location_flowable
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-27 11:13+0000\n"
+"PO-Revision-Date: 2023-11-27 11:13+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Cannot fully reserve flowable location '%s' because there are other "
+"reserved quantities. All stock must be available before merging.\n"
+"\n"
+"The following operations have reservations that must be unreserved "
+"first:\n"
+"\n"
+"%s"
+msgstr ""
+"No es pot reservar completament la ubicació fluida '%s' perquè hi ha "
+"altres quantitats reservades. Tot l'estoc ha d'estar disponible abans "
+"de la barreja.\n"
+"\n"
+"Les següents operacions tenen reserves que s'han d'alliberar "
+"primer:\n"
+"\n"
+"%s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Move '%s' (id=%s) at flowable location '%s' has reserved quantities but no "
+"picking or production associated"
+msgstr ""
+"El moviment '%s' (id=%s) a la ubicació fluida '%s' té quantitats reservades "
+"però no té albarà ni producció associada"

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -16,6 +16,41 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "All allowed products must be tracked by lot"
+msgstr "Tots els productes permesos han de ser rastrejats per lot"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_allowed_product_ids
+msgid "Allowed Products"
+msgstr "Productes Permesos"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Blocked"
+msgstr "Bloquejat"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Capacity"
+msgstr "Capacitat"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Capacity must be greater than 0"
+msgstr "La capacitat ha de ser superior a 0"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Capacity must be greater than capacity occupied %s"
+msgstr "La capacitat ha de ser superior a la capacitat ocupada %s"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
 #, python-format
 msgid ""
@@ -37,6 +72,121 @@ msgstr ""
 "%s"
 
 #. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Create Lots"
+msgstr "Crear Lots"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move_line__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_return_picking__display_name
+msgid "Display Name"
+msgstr "Nom mostrat"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Enable"
+msgstr "Habilitar"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Flowable"
+msgstr "Fluid"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity_occupied
+msgid "Flowable Capacity Occupied"
+msgstr "Capacitat Fluida Ocupada"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Flowable Location Warning"
+msgstr "Avís d'Ubicació Fluida"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__flowable_operation
+msgid "Flowable Operation"
+msgstr "Operació Fluida"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_percentage_occupied
+msgid "Flowable Percentage Occupied"
+msgstr "Percentatge Fluid Ocupat"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_production_id
+msgid "Flowable Production"
+msgstr "Producció de Fluid"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_storage
+msgid "Flowable Storage"
+msgstr "Emmagatzematge de Fluid"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move_line__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_return_picking__id
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_location
+msgid "Inventory Locations"
+msgstr "Ubicacions d'inventari"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_blocked_popover
+msgid "JSON data for the popover widget"
+msgstr "Dades JSON per al widget emergent"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move_line____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_return_picking____last_update
+msgid "Last Modified on"
+msgstr "Última modificació el"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Location capacity is full"
+msgstr "La capacitat de la ubicació està plena"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Manufacturing Order"
+msgstr "Ordre de producció"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking__flowable_production_ids
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.view_picking_form
+#, python-format
+msgid "Manufacturing Orders"
+msgstr "Ordres de producció"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "More than one flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"Més d'un tipus d'operació de fabricació fluida al magatzem %s"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
 #, python-format
 msgid ""
@@ -45,3 +195,246 @@ msgid ""
 msgstr ""
 "El moviment '%s' (id=%s) a la ubicació fluida '%s' té quantitats reservades "
 "però no té albarà ni producció associada"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Not found flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"No s'ha trobat el tipus d'operació de fabricació fluida al magatzem %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Not found sequence in flowable manufacturing picking type %s"
+msgstr ""
+"No s'ha trobat seqüència al tipus d'operació de fabricació fluida %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking_type.py:0
+#, python-format
+msgid "Only manufacturing picking types can be flowable."
+msgstr "Només els tipus d'operació de fabricació poden ser fluids."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking_type.py:0
+#, python-format
+msgid "Only one picking type can be flowable in a warehouse %s."
+msgstr "Només un tipus d'operació pot ser fluid al magatzem %s."
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__picking_id
+msgid "Picking"
+msgstr "Albarà"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_picking_type
+msgid "Picking Type"
+msgstr "Tipus d'albarà"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Product %s must be tracked by lot"
+msgstr "El producte %s ha de ser rastrejat per lot"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Product %s not allowed in flowable location %s"
+msgstr "Producte %s no permès a la ubicació fluida %s"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr "Moviments de Producte (Stock Move Line)"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_mrp_production
+msgid "Production Order"
+msgstr "Ordre de producció"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_return_picking
+msgid "Return Picking"
+msgstr "Albarà de devolució"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_sequence_id
+msgid "Sequence"
+msgstr "Seqüència"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_move
+msgid "Stock Move"
+msgstr "Moviment d'inventari"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The allowed products %s cannot have different Unit of Measure than flowable "
+"location %s"
+msgstr ""
+"Els productes permesos %s no poden tenir una unitat de mesura diferent a la "
+"ubicació fluida %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_move_line.py:0
+#, python-format
+msgid ""
+"The location %s is blocked. Probably you need to review the pending "
+"manufacturing orders related to this location"
+msgstr ""
+"La ubicació %s està bloquejada. Probablement necessites revisar les ordres "
+"de producció pendents relacionades amb aquesta ubicació"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "The location is blocked"
+msgstr "La ubicació està bloquejada"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"The product %s is measured in %s. You can only assign products that have the "
+"allowed unit of measure"
+msgstr ""
+"El producte %s es mesura en %s. Només pots assignar productes que tinguin la "
+"unitat de mesura permesa"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"This location is blocked because it has a manufacturing order assigned."
+msgstr ""
+"Aquesta ubicació està bloquejada perquè té una ordre de producció assignada."
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_picking
+msgid "Transfer"
+msgstr "Albarà"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_uom_id
+msgid "Unit of Measure"
+msgstr "Unitat de Mesura"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"You can only receive one product at location %s because a manufacturing "
+"order must be generated and the location will be blocked. Create a partial "
+"delivery for this product %s."
+msgstr ""
+"Només pots rebre un producte a la ubicació %s perquè s'ha de generar una "
+"ordre de producció i la ubicació quedarà bloquejada. Crea un lliurament "
+"parcial per a aquest producte %s."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot cancel a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No es pot cancel·lar una producció que tingui un albarà associat. La barreja "
+"està en curs."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"products with different units of measure."
+msgstr ""
+"No pots convertir aquesta ubicació en una ubicació fluida perquè hi ha "
+"productes amb diferents unitats de mesura."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"unmixed products."
+msgstr ""
+"No pots convertir aquesta ubicació en una ubicació fluida perquè hi ha "
+"productes sense barrejar."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You cannot disable flowable storage from a blocked location."
+msgstr ""
+"No pots deshabilitar l'emmagatzematge fluid d'una ubicació bloquejada."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_quant.py:0
+#, python-format
+msgid "You cannot have more than one lot in the same location."
+msgstr "No es pot tenir més d'un lot a la mateixa ubicació."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot modify a mix production with a picking associated. The mixing is "
+"in progress."
+msgstr ""
+"No es pot modificar una producció de barreja que tingui un albarà associat. "
+"La barreja està en curs."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot modify a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No es pot modificar una producció que tingui un albarà associat. La barreja "
+"està en curs."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot remove a product that is currently stored in this location."
+msgstr ""
+"No pots eliminar un producte que estigui emmagatzemat en aquesta ubicació."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_return_picking.py:0
+#, python-format
+msgid ""
+"You cannot return the following products because they come from a flowable "
+"location: %s"
+msgstr ""
+"No pots retornar els següents productes perquè provenen d'una ubicació "
+"fluida: %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You have stock movements with different unit of measure"
+msgstr "Tens moviments d'estoc amb diferent unitat de mesura"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You must select a sequence"
+msgstr "Has de seleccionar una seqüència"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You must select a unit of measure"
+msgstr "Has de seleccionar una unitat de mesura"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You must select products"
+msgstr "Has de seleccionar productes"

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -19,7 +19,7 @@ msgstr ""
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "All allowed products must be tracked by lot"
-msgstr "Todos los productos permitidos deben ser rastreados por lote."
+msgstr "Todos los productos permitidos deben ser rastreados por lote"
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_allowed_product_ids
@@ -28,8 +28,6 @@ msgstr "Productos Permitidos"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
-#: model:ir.actions.act_window,name:stock_location_flowable.action_picking_tree_blocked
-#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_picking_type_kanban
 #, python-format
 msgid "Blocked"
 msgstr "Bloqueado"
@@ -39,6 +37,18 @@ msgstr "Bloqueado"
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Capacity"
 msgstr "Capacidad"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Capacity must be greater than 0"
+msgstr "La capacidad debe ser mayor que 0"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Capacity must be greater than capacity occupied %s"
+msgstr "La capacidad debe ser mayor que la capacidad ocupada %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
@@ -62,24 +72,6 @@ msgstr ""
 "%s"
 
 #. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_location.py:0
-#, python-format
-msgid "Capacity must be greater than 0"
-msgstr "La capacidad debe ser mayor que 0."
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_location.py:0
-#, python-format
-msgid "Capacity must be greater than capacity occupied %s"
-msgstr "La capacidad debe ser mayor que la capacidad ocupada %s"
-
-#. module: stock_location_flowable
-#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__count_picking_blocked
-msgid "Count Picking Blocked"
-msgstr "Conteo de Albarán Bloqueado"
-
-#. module: stock_location_flowable
-#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__create_lots
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Create Lots"
 msgstr "Crear Lotes"
@@ -114,12 +106,12 @@ msgstr "Capacidad Fluida Ocupada"
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "Flowable Location Warning"
-msgstr "Advertencia de Ubicación Fluido"
+msgstr "Advertencia de Ubicación Fluida"
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__flowable_operation
 msgid "Flowable Operation"
-msgstr "Operación Fluido"
+msgstr "Operación Fluida"
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_percentage_occupied
@@ -151,16 +143,6 @@ msgstr "ID"
 #: model:ir.model,name:stock_location_flowable.model_stock_location
 msgid "Inventory Locations"
 msgstr "Ubicaciones de inventario"
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/mrp_production.py:0
-#, python-format
-msgid ""
-"Move '%s' (id=%s) at flowable location '%s' has reserved quantities but no "
-"picking or production associated"
-msgstr ""
-"El movimiento '%s' (id=%s) en la ubicación fluida '%s' tiene cantidades "
-"reservadas pero no tiene albarán ni producción asociada"
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_blocked_popover
@@ -195,38 +177,50 @@ msgstr "Orden de producción"
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.view_picking_form
 #, python-format
 msgid "Manufacturing Orders"
-msgstr "Ordenes de producción"
+msgstr "Órdenes de producción"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "More than one manufacturing code in picking type for flowable location %s"
-msgstr "Más de un código de fabricación en el tipo de operación para la ubicación fluida %s"
+msgid "More than one flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"Más de un tipo de operación de fabricación fluida en el almacén %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Move '%s' (id=%s) at flowable location '%s' has reserved quantities but no "
+"picking or production associated"
+msgstr ""
+"El movimiento '%s' (id=%s) en la ubicación fluida '%s' tiene cantidades "
+"reservadas pero no tiene albarán ni producción asociada"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "Not found sequence in manufacturing picking type %s for flowable location %s"
-msgstr "Secuencia no encontrada en el tipo de operación de fabricación %s para la ubicación fluida %s"
-
-#. module: stock_location_flowable
-#: model_terms:ir.actions.act_window,help:stock_location_flowable.action_picking_tree_blocked
-msgid "No transfer found. Let's create one!"
-msgstr "No se encontró ninguna transferencia. ¡Creemos uno!"
+msgid "Not found flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"No se encontró el tipo de operación de fabricación fluida en el almacén %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "Not found manufacturing picking type for flowable location %s to do flowable"
-" mixing in %s"
-msgstr "No se encontró el tipo de operación de producción para la ubicación fluida"
-" %s para realizar la mezcla fluida en %s"
+msgid "Not found sequence in flowable manufacturing picking type %s"
+msgstr ""
+"No se encontró secuencia en el tipo de operación de fabricación fluida %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking_type.py:0
 #, python-format
-msgid "Only one picking type can be flowable in a warehouse %s.."
-msgstr "Sólo un tipo de operación puede ser fluido en el almacén %s."
+msgid "Only manufacturing picking types can be flowable."
+msgstr "Solo los tipos de operación de fabricación pueden ser fluidos."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking_type.py:0
+#, python-format
+msgid "Only one picking type can be flowable in a warehouse %s."
+msgstr "Solo un tipo de operación puede ser fluido en el almacén %s."
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__picking_id
@@ -237,12 +231,6 @@ msgstr "Albarán"
 #: model:ir.model,name:stock_location_flowable.model_stock_picking_type
 msgid "Picking Type"
 msgstr "Tipo de albarán"
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_picking.py:0
-#, python-format
-msgid "The allowed products %s cannot have different Unit of Measure than flowable location %s"
-msgstr "Los productos permitidos %s no pueden tener una unidad de medida diferente a la ubicación fluida %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
@@ -282,41 +270,52 @@ msgid "Stock Move"
 msgstr "Movimiento de inventario"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The allowed products %s cannot have different Unit of Measure than flowable "
+"location %s"
+msgstr ""
+"Los productos permitidos %s no pueden tener una unidad de medida diferente a "
+"la ubicación fluida %s"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_move_line.py:0
 #, python-format
-msgid "The location %s is blocked. Probably you need to review the pending "
+msgid ""
+"The location %s is blocked. Probably you need to review the pending "
 "manufacturing orders related to this location"
-msgstr "La ubicación %s está bloqueada. Probablemente necesites revisar las"
-" órdenes de producción pendientes relacionadas con esta ubicación"
+msgstr ""
+"La ubicación %s está bloqueada. Probablemente necesites revisar las órdenes "
+"de producción pendientes relacionadas con esta ubicación"
 
 #. module: stock_location_flowable
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "The location is blocked"
-msgstr "La ubicación está bloqueada."
+msgstr "La ubicación está bloqueada"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
-msgid "The product %s is measured in %s. You can only assign products that have the"
-" allowed unit of measure"
-msgstr "El producto %s se mide en %s. Sólo puedes asignar productos que tengan la"
-" unidad de medida permitida"
+msgid ""
+"The product %s is measured in %s. You can only assign products that have the "
+"allowed unit of measure"
+msgstr ""
+"El producto %s se mide en %s. Solo puedes asignar productos que tengan la "
+"unidad de medida permitida"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
-msgid "This location is blocked because it has a manufacturing order assigned."
-msgstr "Esta ubicación está bloqueada porque tiene una orden de producción asignada."
+msgid ""
+"This location is blocked because it has a manufacturing order assigned."
+msgstr ""
+"Esta ubicación está bloqueada porque tiene una orden de producción asignada."
 
 #. module: stock_location_flowable
 #: model:ir.model,name:stock_location_flowable.model_stock_picking
 msgid "Transfer"
 msgstr "Albarán"
-
-#. module: stock_location_flowable
-#: model_terms:ir.actions.act_window,help:stock_location_flowable.action_picking_tree_blocked
-msgid "Transfers allow you to move products from one location to another."
-msgstr "Las transferencias le permiten mover productos de un lugar a otro."
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_uom_id
@@ -326,32 +325,51 @@ msgstr "Unidad de Medida"
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "You can only receive one product at location %s because a manufacturing "
+msgid ""
+"You can only receive one product at location %s because a manufacturing "
 "order must be generated and the location will be blocked. Create a partial "
 "delivery for this product %s."
-msgstr "Solo puedes recibir un producto en la ubicación %s porque se debe generar"
-" una orden de producción y la ubicación será bloqueada. Crea una entrega parcial"
-" para este producto %s."
+msgstr ""
+"Solo puedes recibir un producto en la ubicación %s porque se debe generar "
+"una orden de producción y la ubicación será bloqueada. Crea una entrega "
+"parcial para este producto %s."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot cancel a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No se puede cancelar una producción que tenga un albarán asociado. La mezcla "
+"está en curso."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"products with different units of measure."
+msgstr ""
+"No puedes convertir esta ubicación en una ubicación fluida porque hay "
+"productos con diferentes unidades de medida."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"unmixed products."
+msgstr ""
+"No puedes convertir esta ubicación en una ubicación fluida porque hay "
+"productos sin mezclar."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "You cannot disable flowable storage from a blocked location."
-msgstr "No puedes deshabilitar el almacenamiento fluido de una ubicación bloqueada"
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/mrp_production.py:0
-#, python-format
-msgid "You cannot cancel a production with a picking associated. The mixing is in progress."
-msgstr "No se puede cancelar una producción que tenga un albarán asociado. La mezcla está en curso."
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_location.py:0
-#, python-format
-msgid "You cannot convert this location into a flowable location because there are "
-"unmixed products or products with different units of measure."
-msgstr "No puedes convertir esta ubicación en una ubicación fluida porque hay "
-"productos sin mezclar o productos con diferentes unidades de medida."
+msgstr ""
+"No puedes deshabilitar el almacenamiento fluido de una ubicación bloqueada."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_quant.py:0
@@ -361,22 +379,42 @@ msgstr "No se puede tener más de un lote en la misma ubicación."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot modify a mix production with a picking associated. The mixing is "
+"in progress."
+msgstr ""
+"No se puede modificar una producción de mezcla que tenga un albarán "
+"asociado. La mezcla está en curso."
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_move.py:0
 #, python-format
-msgid "You cannot modify a mix production with a picking associated. The mixing is in progress."
-msgstr "No se puede modificar una producción de mezcla que tenga un albarán asociado. La mezcla está en curso."
+msgid ""
+"You cannot modify a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No se puede modificar una producción que tenga un albarán asociado. La "
+"mezcla está en curso."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
-msgid "You cannot remove a product that is currently stored in this location."
-msgstr "No puedes eliminar un producto que esté actualmente almacenado en esta ubicación."
+msgid ""
+"You cannot remove a product that is currently stored in this location."
+msgstr ""
+"No puedes eliminar un producto que esté actualmente almacenado en esta "
+"ubicación."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_return_picking.py:0
 #, python-format
-msgid "You cannot return the product %s because it comes from a flowable location %s."
-msgstr "No puedes devolver el producto %s porque proviene de una ubicación fluida %s."
+msgid ""
+"You cannot return the following products because they come from a flowable "
+"location: %s"
+msgstr ""
+"No puedes devolver los siguientes productos porque provienen de una "
+"ubicación fluida: %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
@@ -388,16 +426,16 @@ msgstr "Tienes movimientos de stock con diferente unidad de medida"
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "You must select a sequence"
-msgstr "Debes seleccionar una secuencia."
+msgstr "Debes seleccionar una secuencia"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "You must select a unit of measure"
-msgstr "Debes seleccionar una unidad de medida."
+msgstr "Debes seleccionar una unidad de medida"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "You must select products"
-msgstr "Debes seleccionar productos."
+msgstr "Debes seleccionar productos"

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -41,6 +41,27 @@ msgid "Capacity"
 msgstr "Capacidad"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Cannot fully reserve flowable location '%s' because there are other "
+"reserved quantities. All stock must be available before merging.\n"
+"\n"
+"The following operations have reservations that must be unreserved "
+"first:\n"
+"\n"
+"%s"
+msgstr ""
+"No se puede reservar completamente la ubicación fluida '%s' porque hay "
+"otras cantidades reservadas. Todo el stock debe estar disponible antes "
+"de la mezcla.\n"
+"\n"
+"Las siguientes operaciones tienen reservas que deben ser liberadas "
+"primero:\n"
+"\n"
+"%s"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "Capacity must be greater than 0"
@@ -130,6 +151,16 @@ msgstr "ID"
 #: model:ir.model,name:stock_location_flowable.model_stock_location
 msgid "Inventory Locations"
 msgstr "Ubicaciones de inventario"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Move '%s' (id=%s) at flowable location '%s' has reserved quantities but no "
+"picking or production associated"
+msgstr ""
+"El movimiento '%s' (id=%s) en la ubicación fluida '%s' tiene cantidades "
+"reservadas pero no tiene albarán ni producción asociada"
 
 #. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_blocked_popover

--- a/stock_location_flowable/models/mrp_production.py
+++ b/stock_location_flowable/models/mrp_production.py
@@ -1,9 +1,10 @@
 # Copyright NuoBiT - Frank Cespedes <fcespedes@nuobit.com>
 # Copyright 2025 NuoBiT - Deniz Gallo <dgallo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class MrpProduction(models.Model):
@@ -56,3 +57,75 @@ class MrpProduction(models.Model):
                     )
                 )
         return super().write(vals)
+
+    def action_assign(self):
+        res = super().action_assign()
+        for rec in self:
+            if rec.picking_type_id.flowable_operation:
+                rec._check_flowable_reservation()
+        return res
+
+    def _check_flowable_reservation(self):
+        """Verify that action_assign() fully reserved all raw materials.
+
+        A flowable merge requires 100% of the location's stock. If another
+        operation (sale, internal transfer) holds a reservation, action_assign
+        cannot fully reserve and the location won't be blocked — leaving it
+        unprotected for concurrent receptions. This post-check detects partial
+        reservation and rolls back the entire transaction with a clear error
+        listing who holds the conflicting reservations.
+        """
+        self.ensure_one()
+        if all(m.state == "assigned" for m in self.move_raw_ids):
+            return
+        location = self.location_src_id
+        reserved_move_lines = self.env["stock.move.line"].search(
+            [
+                ("location_id", "=", location.id),
+                ("product_uom_qty", ">", 0),
+                ("state", "not in", ("done", "cancel", "draft")),
+                ("move_id.raw_material_production_id", "!=", self.id),
+            ]
+        )
+        details = []
+        for ml in reserved_move_lines:
+            move = ml.move_id
+            if move.picking_id:
+                origin = "%s (%s)" % (
+                    move.picking_id.name,
+                    move.picking_id.picking_type_id.name,
+                )
+            elif move.raw_material_production_id:
+                origin = "%s (%s)" % (
+                    move.raw_material_production_id.name,
+                    move.raw_material_production_id.picking_type_id.name,
+                )
+            else:
+                raise UserError(
+                    _(
+                        "Move '%s' (id=%s) at flowable"
+                        " location '%s' has reserved"
+                        " quantities but no picking or"
+                        " production associated"
+                    )
+                    % (move.name, move.id, location.name)
+                )
+            details.append(
+                "  - %s: %s %s — %s"
+                % (
+                    ml.product_id.display_name,
+                    ml.product_uom_qty,
+                    ml.product_uom_id.name,
+                    origin,
+                )
+            )
+        raise UserError(
+            _(
+                "Cannot fully reserve flowable location '%s'"
+                " because there are other reserved quantities."
+                " All stock must be available before merging.\n\n"
+                "The following operations have reservations"
+                " that must be unreserved first:\n\n%s"
+            )
+            % (location.name, "\n".join(details))
+        )

--- a/stock_location_flowable/models/stock_move_line.py
+++ b/stock_location_flowable/models/stock_move_line.py
@@ -28,11 +28,14 @@ class StockMoveLine(models.Model):
                 ):
                     locations_to_check |= rec.location_id
                 for location in locations_to_check:
-                    if rec.state == "done":
-                        production = rec.move_id.production_id
-                    else:
-                        production = rec.move_id.raw_material_production_id
-                    if production and location.flowable_production_id != production:
+                    production = (
+                        rec.move_id.raw_material_production_id
+                        or rec.move_id.production_id
+                    )
+                    if (
+                        location.flowable_production_id
+                        and location.flowable_production_id != production
+                    ):
                         raise ValidationError(
                             _(
                                 "The location %s is blocked. Probably you need to"

--- a/stock_location_flowable/readme/CONTRIBUTORS.rst
+++ b/stock_location_flowable/readme/CONTRIBUTORS.rst
@@ -1,4 +1,6 @@
-- [NuoBiT](https://www.nuobit.com):
-  - Frank Cespedes <fcespedes@nuobit.com>
-  - Deniz Gallo <dgallo@nuobit.com>
-  - Bijaya Kumal <bkumal@nuobit.com>
+* `NuoBiT <https://www.nuobit.com>`__:
+
+  * Frank Cespedes <fcespedes@nuobit.com>
+  * Deniz Gallo <dgallo@nuobit.com>
+  * Bijaya Kumal <bkumal@nuobit.com>
+  * Eric Antones <eantones@nuobit.com>

--- a/stock_location_flowable/static/description/index.html
+++ b/stock_location_flowable/static/description/index.html
@@ -399,15 +399,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
 <li>NuoBiT Solutions</li>
+<li>S.L.</li>
 </ul>
 </div>
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
-<li>[NuoBiT](<a class="reference external" href="https://www.nuobit.com">https://www.nuobit.com</a>):
-- Frank Cespedes &lt;<a class="reference external" href="mailto:fcespedes&#64;nuobit.com">fcespedes&#64;nuobit.com</a>&gt;
-- Deniz Gallo &lt;<a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a>&gt;
-- Bijaya Kumal &lt;<a class="reference external" href="mailto:bkumal&#64;nuobit.com">bkumal&#64;nuobit.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.nuobit.com">NuoBiT</a>:<ul>
+<li>Frank Cespedes &lt;<a class="reference external" href="mailto:fcespedes&#64;nuobit.com">fcespedes&#64;nuobit.com</a>&gt;</li>
+<li>Deniz Gallo &lt;<a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a>&gt;</li>
+<li>Bijaya Kumal &lt;<a class="reference external" href="mailto:bkumal&#64;nuobit.com">bkumal&#64;nuobit.com</a>&gt;</li>
+<li>Eric Antones &lt;<a class="reference external" href="mailto:eantones&#64;nuobit.com">eantones&#64;nuobit.com</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_location_flowable/tests/test_stock_move_line.py
+++ b/stock_location_flowable/tests/test_stock_move_line.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from odoo.exceptions import ValidationError
+
 from .test_common import TestCommon
 
 _logger = logging.getLogger(__name__)
@@ -32,6 +34,114 @@ class TestStockMoveLine(TestCommon):
         # ACT & ASSERT
         with self.assertRaises(Exception) as error:
             self.outgoing_picking.button_validate()
+
+        msg_error = (
+            "The location %s is blocked. Probably you need to review"
+            " the pending manufacturing orders related to this location"
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
+    def test_blocked_location_rejects_incoming_reception(self):
+        """
+        Test that a second PO reception to a blocked flowable location
+        is rejected even though the reception is not part of any MO.
+
+        PRE:    - A flowable location blocked by a production (from a first reception)
+                - A second incoming picking prepared before the location was blocked
+        ACT:    - Try to validate the second incoming picking
+        POST:   - A ValidationError is raised about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "Lot2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        second_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": second_picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_2.id,
+                "qty_done": 10,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.location_flowable_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # Block the location by validating the first reception
+        self.incoming_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT
+        with self.assertRaises(ValidationError) as error:
+            second_picking.button_validate()
+
+        msg_error = (
+            "The location %s is blocked. Probably you need to review"
+            " the pending manufacturing orders related to this location"
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
+    def test_blocked_location_rejects_internal_transfer(self):
+        """
+        Test that an internal transfer from a blocked flowable location
+        is rejected.
+
+        PRE:    - A flowable location blocked by a production
+                - An internal transfer prepared before the location was blocked
+        ACT:    - Try to validate the internal transfer
+        POST:   - An error is raised about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "LotInternal",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        transfer_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_internal_1.id,
+                "location_id": self.location_flowable_1.id,
+                "location_dest_id": self.location_1.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": transfer_picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_2.id,
+                "qty_done": 5,
+                "location_id": self.location_flowable_1.id,
+                "location_dest_id": self.location_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # Block the location by validating the first reception
+        self.incoming_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT
+        with self.assertRaises(Exception) as error:
+            transfer_picking.button_validate()
 
         msg_error = (
             "The location %s is blocked. Probably you need to review"

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -648,3 +648,266 @@ class TestStockPicking(TestCommon):
         # ASSERT
         self.assertTrue(production.lot_producing_id)
         self.assertNotEqual(production.lot_producing_id, lot)
+
+    def _create_incoming_picking(self, location, product, lot, qty):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": location.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": product.id,
+                "product_uom_id": product.uom_id.id,
+                "lot_id": lot.id,
+                "qty_done": qty,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": location.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        return picking
+
+    def test_reception_blocks_flowable_location(self):
+        """
+        Test that validating a reception to a flowable location blocks it
+        and creates a manufacturing order linked to the location.
+
+        PRE:    - A flowable location with no active production
+        ACT:    - Validate an incoming picking to that location
+        POST:   - The location is blocked (flowable_blocked is True)
+                - A manufacturing order is linked to the location
+                - The MO is linked back to the picking
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+        lot = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-BLOCK-LOT",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot, 10
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        production = self.location_flowable_1.flowable_production_id
+        self.assertTrue(production)
+        self.assertEqual(production.picking_id, picking)
+
+    def test_second_reception_to_blocked_location_rejected(self):
+        """
+        Test that a second reception to a blocked flowable location
+        is rejected.
+
+        PRE:    - A flowable location blocked by a first reception
+                - A second incoming picking prepared before the location
+                  was blocked
+        ACT:    - Try to validate the second incoming picking
+        POST:   - An error is raised about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-BLOCK-LOT1",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        first_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 10
+        )
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-BLOCK-LOT2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        second_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_2, 10
+        )
+
+        first_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT
+        with self.assertRaises(Exception):
+            second_picking.button_validate()
+
+    def test_reception_after_mo_completed_succeeds(self):
+        """
+        Test the full cycle: reception blocks the location, completing
+        the MO unblocks it, and a new reception succeeds.
+
+        PRE:    - A flowable location with no active production
+        ACT:    - Validate a first reception (location gets blocked)
+                - Complete the resulting MO (location gets unblocked)
+                - Validate a second reception
+        POST:   - The location is unblocked after completing the MO
+                - The second reception succeeds and creates a new MO
+                - The location is blocked again by the new MO
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-CYCLE-LOT1",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        first_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 10
+        )
+
+        # ACT 1 - First reception blocks the location
+        first_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        first_production = self.location_flowable_1.flowable_production_id
+
+        # ACT 2 - Complete the MO, location gets unblocked
+        first_production.button_mark_done()
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+        # ACT 3 - Second reception succeeds and blocks again
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-CYCLE-LOT2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        second_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_2, 5
+        )
+        second_picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        second_production = self.location_flowable_1.flowable_production_id
+        self.assertTrue(second_production)
+        self.assertNotEqual(first_production, second_production)
+        self.assertEqual(second_production.picking_id, second_picking)
+
+    def test_blocking_is_per_location(self):
+        """
+        Test that blocking one flowable location does not affect another.
+
+        PRE:    - Two flowable locations with no active production
+        ACT:    - Validate a reception to location 1 (blocks it)
+                - Validate a reception to location 2
+        POST:   - Location 1 is blocked
+                - Location 2 reception succeeds and blocks location 2
+                  independently
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-PERLOC-LOT1",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        picking_1 = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 10
+        )
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-PERLOC-LOT2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        picking_2 = self._create_incoming_picking(
+            self.location_flowable_2, self.product_flowable_1, lot_2, 10
+        )
+
+        # ACT
+        picking_1.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        self.assertFalse(self.location_flowable_2.flowable_blocked)
+
+        picking_2.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        self.assertTrue(self.location_flowable_2.flowable_blocked)
+        self.assertNotEqual(
+            self.location_flowable_1.flowable_production_id,
+            self.location_flowable_2.flowable_production_id,
+        )
+
+    def test_auto_lot_location_also_gets_blocked(self):
+        """
+        Test that a flowable location with flowable_create_lots=True
+        also gets blocked after a reception.
+
+        PRE:    - location_flowable_2 has flowable_create_lots=True
+        ACT:    - Validate a reception to location_flowable_2
+        POST:   - The location is blocked
+                - The MO uses an auto-generated lot (different from the
+                  incoming lot)
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+        product = self.location_flowable_2.flowable_allowed_product_ids[0]
+
+        lot = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-AUTOLOT-BLOCK",
+                "product_id": product.id,
+            }
+        )
+        picking = self._create_incoming_picking(
+            self.location_flowable_2, product, lot, 50
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_2.flowable_blocked)
+        production = self.location_flowable_2.flowable_production_id
+        self.assertTrue(production)
+        self.assertNotEqual(production.lot_producing_id, lot)
+
+    def test_non_flowable_location_not_affected(self):
+        """
+        Test that receiving stock at a non-flowable location does not
+        trigger any blocking or MO creation.
+
+        PRE:    - A regular (non-flowable) internal location
+        ACT:    - Validate an incoming picking to that location
+        POST:   - No flowable_production_id is set
+                - No MO is created for the picking
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        product = self.product_flowable_1
+        lot = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-NONFLOW-LOT",
+                "product_id": product.id,
+            }
+        )
+        picking = self._create_incoming_picking(self.location_1, product, lot, 10)
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertFalse(self.location_1.flowable_storage)
+        self.assertFalse(picking.flowable_production_ids)


### PR DESCRIPTION
## Summary

- **Silent blocking**: `flowable_production_id` was only set via `stock_move.write()` when `action_assign` changed the raw move state. Since `action_assign` almost never succeeded (1072/1075 times in production), locations were virtually never blocked, allowing duplicate receptions. Fixed by setting `flowable_production_id` directly in `_action_done` after MO creation.
- **Constraint bypass**: The blocked-location constraint in `stock.move.line` skipped the check entirely when the move was not part of a manufacturing order (e.g. PO receptions, internal transfers). Fixed the condition to also block non-MO moves.

## Test plan

- [x] 66 tests pass (8 new tests added)
- [x] `pre-commit run -a` passes cleanly
- [ ] Verify on staging with a flowable location: validate a reception, confirm location is blocked, try a second reception (should fail)
- [ ] Complete the MO, confirm location is unblocked, validate a new reception (should succeed)