### PR TITLE
[14.0][FIX] stock_location_flowable: flowable location blocking

### DIFF
--- a/stock_location_flowable/README.rst
+++ b/stock_location_flowable/README.rst
@@ -46,14 +46,17 @@ Authors
 ~~~~~~~
 
 * NuoBiT Solutions
+* S.L.
 
 Contributors
 ~~~~~~~~~~~~
 
-- [NuoBiT](https://www.nuobit.com):
-  - Frank Cespedes <fcespedes@nuobit.com>
-  - Deniz Gallo <dgallo@nuobit.com>
-  - Bijaya Kumal <bkumal@nuobit.com>
+* `NuoBiT <https://www.nuobit.com>`__:
+
+  * Frank Cespedes <fcespedes@nuobit.com>
+  * Deniz Gallo <dgallo@nuobit.com>
+  * Bijaya Kumal <bkumal@nuobit.com>
+  * Eric Antones <eantones@nuobit.com>
 
 Maintainers
 ~~~~~~~~~~~

--- a/stock_location_flowable/__manifest__.py
+++ b/stock_location_flowable/__manifest__.py
@@ -6,7 +6,7 @@
     "summary": "Customizations that allow organizing, controlling, and"
     " mixing bulk liquid and solid products in a location",
     "version": "14.0.1.0.1",
-    "author": "NuoBiT Solutions",
+    "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",
     "category": "Stock",
     "depends": ["mrp", "uom_rounding_coherence"],

--- a/stock_location_flowable/doc/diagrams/00_tank_lifecycle.svg
+++ b/stock_location_flowable/doc/diagrams/00_tank_lifecycle.svg
@@ -1,0 +1,84 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="380" viewBox="0 0 1000 380">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <rect width="1000" height="380" fill="#1a1a2e"/>
+
+  <defs>
+    <marker id="a1" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#3a86ff"/></marker>
+    <marker id="a2" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#e94560"/></marker>
+    <marker id="a3" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#4ecca3"/></marker>
+    <marker id="a4" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto"><polygon points="0 0, 10 3.5, 0 7" fill="#888"/></marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="500" y="30" text-anchor="middle" fill="#e94560" font-size="20" font-weight="bold">Tank Lifecycle — One Tank, Four States</text>
+  <text x="500" y="52" text-anchor="middle" fill="#888" font-size="13">This is ONE tank (flowable location) going through states over time.</text>
+  <text x="500" y="70" text-anchor="middle" fill="#888" font-size="13">A reception never reserves — it just delivers stock to the tank.</text>
+
+  <!-- Tank drawing (single, centered at top) -->
+  <rect x="410" y="85" width="180" height="50" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="500" y="107" text-anchor="middle" fill="#3a86ff" font-size="13" font-weight="bold">Tank (flowable location)</text>
+  <text x="500" y="125" text-anchor="middle" fill="#888" font-size="10">e.g. Tank-A, Tank-B</text>
+
+  <!-- Time arrow -->
+  <line x1="50" y1="165" x2="950" y2="165" stroke="#666" stroke-width="1" marker-end="url(#a4)"/>
+  <text x="500" y="158" text-anchor="middle" fill="#666" font-size="10">TIME →</text>
+
+  <!-- State 1: Available (no stock) -->
+  <rect x="40" y="180" width="170" height="100" rx="10" fill="none" stroke="#888" stroke-width="1.5"/>
+  <text x="125" y="205" text-anchor="middle" fill="#888" font-size="14" font-weight="bold">AVAILABLE</text>
+  <text x="125" y="225" text-anchor="middle" fill="#666" font-size="10">No active MO</text>
+  <text x="125" y="240" text-anchor="middle" fill="#666" font-size="10">No blocking</text>
+  <text x="125" y="260" text-anchor="middle" fill="#666" font-size="10">Tank may have stock</text>
+  <text x="125" y="273" text-anchor="middle" fill="#666" font-size="10">or be empty</text>
+
+  <!-- Arrow: PO reception picking validated -->
+  <line x1="215" y1="230" x2="270" y2="230" stroke="#3a86ff" stroke-width="2" marker-end="url(#a1)"/>
+  <text x="243" y="218" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">PO reception</text>
+  <text x="243" y="207" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">picking validated</text>
+
+  <!-- State 2: Blocked -->
+  <rect x="275" y="180" width="190" height="100" rx="10" fill="#e94560" fill-opacity="0.12" stroke="#e94560" stroke-width="2.5"/>
+  <rect x="282" y="230" width="176" height="45" rx="5" fill="#e94560" opacity="0.15"/>
+  <text x="370" y="205" text-anchor="middle" fill="#e94560" font-size="14" font-weight="bold">BLOCKED 🔒</text>
+  <text x="370" y="248" text-anchor="middle" fill="#e94560" font-size="10">Stock arrived + MO created</text>
+  <text x="370" y="262" text-anchor="middle" fill="#e94560" font-size="10">No one else can receive</text>
+
+  <!-- Arrow: MO processes -->
+  <line x1="470" y1="230" x2="525" y2="230" stroke="#3a86ff" stroke-width="2" marker-end="url(#a1)"/>
+  <text x="498" y="218" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">MO mixes /</text>
+  <text x="498" y="207" text-anchor="middle" fill="#3a86ff" font-size="9" font-weight="bold">consumes</text>
+
+  <!-- State 3: Processing -->
+  <rect x="530" y="180" width="190" height="100" rx="10" fill="#3a86ff" fill-opacity="0.08" stroke="#3a86ff" stroke-width="1.5"/>
+  <rect x="537" y="230" width="176" height="45" rx="5" fill="#3a86ff" opacity="0.1"/>
+  <text x="625" y="205" text-anchor="middle" fill="#3a86ff" font-size="14" font-weight="bold">PROCESSING</text>
+  <text x="625" y="248" text-anchor="middle" fill="#3a86ff" font-size="10">MO consuming stock</text>
+  <text x="625" y="262" text-anchor="middle" fill="#888" font-size="10">Still blocked (MO active)</text>
+
+  <!-- Arrow: MO done -->
+  <line x1="725" y1="230" x2="780" y2="230" stroke="#4ecca3" stroke-width="2" marker-end="url(#a3)"/>
+  <text x="753" y="218" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">MO marked</text>
+  <text x="753" y="207" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">done</text>
+
+  <!-- State 4: Available again -->
+  <rect x="785" y="180" width="170" height="100" rx="10" fill="none" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="870" y="205" text-anchor="middle" fill="#4ecca3" font-size="14" font-weight="bold">AVAILABLE</text>
+  <text x="870" y="225" text-anchor="middle" fill="#4ecca3" font-size="10">MO completed</text>
+  <text x="870" y="240" text-anchor="middle" fill="#4ecca3" font-size="10">Blocking cleared</text>
+  <text x="870" y="260" text-anchor="middle" fill="#4ecca3" font-size="10">Ready for next</text>
+  <text x="870" y="273" text-anchor="middle" fill="#4ecca3" font-size="10">PO reception</text>
+
+  <!-- Cycle arrow: back to start -->
+  <path d="M 955 230 Q 980 230 980 310 Q 980 330 500 330 Q 30 330 30 285" fill="none" stroke="#888" stroke-width="1.5" stroke-dasharray="5,5" marker-end="url(#a4)"/>
+  <text x="500" y="348" text-anchor="middle" fill="#666" font-size="11">cycle repeats with next PO reception</text>
+
+  <!-- Bottom bar: what runs at each transition -->
+  <rect x="215" y="295" width="60" height="18" rx="4" fill="#3a86ff" fill-opacity="0.3"/>
+  <text x="245" y="308" text-anchor="middle" fill="#3a86ff" font-size="8">picking</text>
+  <rect x="470" y="295" width="60" height="18" rx="4" fill="#3a86ff" fill-opacity="0.3"/>
+  <text x="500" y="308" text-anchor="middle" fill="#3a86ff" font-size="8">MO</text>
+  <rect x="725" y="295" width="60" height="18" rx="4" fill="#4ecca3" fill-opacity="0.3"/>
+  <text x="755" y="308" text-anchor="middle" fill="#4ecca3" font-size="8">move.write</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/01_first_reception.svg
+++ b/stock_location_flowable/doc/diagrams/01_first_reception.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="310" viewBox="0 0 1000 310">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="310" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 1: First PO Reception — Happy Path</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">One PO received at an available tank. MO auto-created, location blocked, MO completes, location freed.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#888" font-size="11">Everything works correctly. No bugs involved.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="170" x2="960" y2="170" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <!-- Events -->
+  <circle cx="120" cy="170" r="5" fill="#3a86ff"/>
+  <circle cx="320" cy="170" r="5" fill="#3a86ff"/>
+  <circle cx="540" cy="170" r="5" fill="#f5a623"/>
+  <circle cx="760" cy="170" r="5" fill="#4ecca3"/>
+
+  <line x1="120" y1="143" x2="120" y2="165" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="320" y1="128" x2="320" y2="165" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="540" y1="143" x2="540" y2="165" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="760" y1="133" x2="760" y2="165" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <rect x="45" y="95" width="150" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="120" y="115" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="120" y="132" text-anchor="middle" fill="#888" font-size="9">creates reception picking</text>
+
+  <rect x="215" y="90" width="210" height="35" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
+  <text x="320" y="112" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <text x="320" y="140" text-anchor="middle" fill="#4ecca3" font-size="10">MO created, location BLOCKED</text>
+
+  <rect x="455" y="100" width="170" height="40" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="540" y="117" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">MO #1 Processing</text>
+  <text x="540" y="133" text-anchor="middle" fill="#888" font-size="9">mixing / consuming</text>
+
+  <rect x="670" y="90" width="180" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
+  <text x="760" y="110" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">MO #1 Done</text>
+  <text x="760" y="127" text-anchor="middle" fill="#888" font-size="9">location UNBLOCKED</text>
+
+  <!-- State bar -->
+  <rect x="40" y="188" width="280" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="180" y="204" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="320" y="188" width="440" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="540" y="204" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO #1)</text>
+  <rect x="760" y="188" width="200" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="860" y="204" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <text x="500" y="230" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Note -->
+  <text x="500" y="265" text-anchor="middle" fill="#888" font-size="10">Blocking is set inside stock.move.write() when production.action_assign() changes the MO's raw move state.</text>
+  <text x="500" y="282" text-anchor="middle" fill="#888" font-size="10">Unblocking is set inside stock.move.write() when the MO's raw move goes to "done".</text>
+  <text x="500" y="299" text-anchor="middle" fill="#555" font-size="10">A reception never reserves — it delivers stock from a virtual supplier location to the tank.</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/02_second_reception_blocked.svg
+++ b/stock_location_flowable/doc/diagrams/02_second_reception_blocked.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="380" viewBox="0 0 1000 380">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="380" fill="#1a1a2e"/>
+
+  <!-- Title with Bug #1 -->
+  <text x="500" y="28" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">Scenario 2 — Bug #1: Second PO Reception — Location Blocked but Constraint Bypassed</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Location IS blocked. A second PO receives into the same tank. The constraint SKIPS non-MO moves.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#e94560" font-size="12">The second reception goes through. Two active MOs on the same tank.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="185" x2="960" y2="185" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="280" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="500" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="720" cy="185" r="5" fill="#e94560"/>
+
+  <line x1="100" y1="148" x2="100" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="280" y1="138" x2="280" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="500" y1="148" x2="500" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="720" y1="120" x2="720" y2="180" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO #1 -->
+  <rect x="30" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
+
+  <!-- Event 2: Reception #1 → blocked -->
+  <rect x="180" y="95" width="200" height="40" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
+  <text x="280" y="113" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <text x="280" y="130" text-anchor="middle" fill="#e94560" font-size="10">MO created, BLOCKED</text>
+
+  <!-- Time gap -->
+  <text x="390" y="177" text-anchor="middle" fill="#666" font-size="9" font-style="italic">time passes</text>
+
+  <!-- Event 3: PO #2 -->
+  <rect x="430" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="500" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #2 Confirmed</text>
+  <text x="500" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #2</text>
+
+  <!-- Event 4: Reception #2 GOES THROUGH (bug!) -->
+  <rect x="610" y="85" width="220" height="32" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="720" y="107" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception #2 GOES THROUGH!</text>
+  <!-- Bug explanation -->
+  <rect x="620" y="120" width="200" height="38" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="720" y="136" text-anchor="middle" fill="#e94560" font-size="9">constraint skips non-MO moves</text>
+  <text x="720" y="151" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">MO #2 created — TWO MOs!</text>
+
+  <!-- Danger icon -->
+  <text x="720" y="198" text-anchor="middle" fill="#e94560" font-size="16" font-weight="bold">!!</text>
+
+  <!-- State bar -->
+  <rect x="40" y="205" width="240" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="160" y="221" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="280" y="205" width="680" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="620" y="221" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO #1) — but constraint doesn't enforce it for non-MO moves</text>
+  <text x="500" y="248" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Bug #1 explanation -->
+  <rect x="60" y="265" width="880" height="90" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#e94560" stroke-width="1"/>
+  <text x="500" y="285" text-anchor="middle" fill="#e94560" font-size="12" font-weight="bold">Bug #1: constraint checked the MOVE's production, not the LOCATION's blocking state</text>
+  <text x="500" y="305" text-anchor="middle" fill="#ccc" font-size="10">Old code: "if production and location.flowable_production_id != production" — when production is False</text>
+  <text x="500" y="320" text-anchor="middle" fill="#ccc" font-size="10">(PO reception, internal transfer), the entire check is skipped. Even though the location IS blocked.</text>
+
+  <!-- PR inside the section -->
+  <rect x="305" y="337" width="390" height="20" rx="4" fill="#3a86ff" fill-opacity="0.15" stroke="#3a86ff" stroke-width="1"/>
+  <text x="500" y="351" text-anchor="middle" fill="#3a86ff" font-size="10" font-weight="bold">Fixed by PR #847: github.com/nuobit/odoo-addons/pull/847</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/03_second_reception_not_blocked.svg
+++ b/stock_location_flowable/doc/diagrams/03_second_reception_not_blocked.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="390" viewBox="0 0 1000 390">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="390" fill="#1a1a2e"/>
+
+  <!-- Title with Bug #2 -->
+  <text x="500" y="28" text-anchor="middle" fill="#f5a623" font-size="18" font-weight="bold">Scenario 3 — Bug #2: Second PO Reception — Location Not Blocked</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">First reception's production.action_assign() failed → location was never blocked. Second PO goes through.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#f5a623" font-size="12">Two active MOs on the same tank. This is an example case.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="185" x2="960" y2="185" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="280" cy="185" r="5" fill="#f5a623"/>
+  <circle cx="530" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="750" cy="185" r="5" fill="#e94560"/>
+
+  <line x1="100" y1="148" x2="100" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="280" y1="128" x2="280" y2="180" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="530" y1="148" x2="530" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="750" y1="120" x2="750" y2="180" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO #1 -->
+  <rect x="30" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
+
+  <!-- Event 2: Reception #1 → NOT BLOCKED -->
+  <rect x="175" y="90" width="210" height="35" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
+  <text x="280" y="112" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <rect x="200" y="128" width="160" height="18" rx="4" fill="#f5a623" fill-opacity="0.25" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="280" y="141" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">MO created, NOT BLOCKED</text>
+
+  <!-- Time gap -->
+  <text x="405" y="177" text-anchor="middle" fill="#666" font-size="9" font-style="italic">45 days pass</text>
+  <text x="405" y="189" text-anchor="middle" fill="#666" font-size="8" font-style="italic">MO #1 never completed</text>
+
+  <!-- Event 3: PO #2 -->
+  <rect x="460" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="530" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #2 Confirmed</text>
+  <text x="530" y="137" text-anchor="middle" fill="#888" font-size="9">creates reception #2</text>
+
+  <!-- Event 4: Reception #2 GOES THROUGH -->
+  <rect x="640" y="85" width="220" height="32" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="750" y="107" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception #2 GOES THROUGH!</text>
+  <rect x="655" y="120" width="190" height="38" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="750" y="136" text-anchor="middle" fill="#e94560" font-size="9">constraint passes (nothing to check)</text>
+  <text x="750" y="151" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">MO #2 created — TWO MOs!</text>
+
+  <text x="750" y="198" text-anchor="middle" fill="#e94560" font-size="16" font-weight="bold">!!</text>
+
+  <!-- State bar -->
+  <rect x="40" y="205" width="240" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="160" y="221" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="280" y="205" width="680" height="22" rx="5" fill="#f5a623" fill-opacity="0.1" stroke="#f5a623" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="620" y="221" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">SHOULD BE BLOCKED — but isn't (flowable_production_id = NULL)</text>
+  <text x="500" y="248" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Bug #2 explanation -->
+  <rect x="60" y="265" width="880" height="75" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#f5a623" stroke-width="1"/>
+  <text x="500" y="285" text-anchor="middle" fill="#f5a623" font-size="12" font-weight="bold">Bug #2: blocking depends on production.action_assign() success inside picking._action_done()</text>
+  <text x="500" y="305" text-anchor="middle" fill="#ccc" font-size="10">Blocking is set inside stock.move.write() only when action_assign changes the raw move state.</text>
+  <text x="500" y="320" text-anchor="middle" fill="#ccc" font-size="10">If reservation fails → state doesn't change → write() not triggered → flowable_production_id stays NULL.</text>
+  <text x="500" y="335" text-anchor="middle" fill="#ccc" font-size="10">The constraint has nothing to enforce — flowable_blocked is False.</text>
+
+  <!-- Example case -->
+  <rect x="170" y="352" width="660" height="22" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="368" text-anchor="middle" fill="#888" font-size="10">Example: Tank-A — PO/001 (2025-01-15) + PO/002 (2025-03-01) — MO 001 + MO 002</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/04_mo_completion.svg
+++ b/stock_location_flowable/doc/diagrams/04_mo_completion.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="340" viewBox="0 0 1000 340">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="340" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 4: MO Completion — Location Unblocked</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">A PO was received, MO was created, tank is blocked. When the MO completes, the tank is unblocked for the next reception.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="185" x2="960" y2="185" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+  <text x="975" y="189" fill="#555" font-size="10">time</text>
+
+  <!-- Event markers -->
+  <circle cx="130" cy="185" r="5" fill="#3a86ff"/>
+  <circle cx="370" cy="185" r="5" fill="#f5a623"/>
+  <circle cx="620" cy="185" r="5" fill="#4ecca3"/>
+  <circle cx="860" cy="185" r="5" fill="#4ecca3"/>
+
+  <!-- Connector lines -->
+  <line x1="130" y1="148" x2="130" y2="180" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="370" y1="148" x2="370" y2="180" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="620" y1="128" x2="620" y2="180" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="860" y1="148" x2="860" y2="180" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO received + MO created -->
+  <rect x="40" y="95" width="180" height="50" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="130" y="115" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO Received</text>
+  <text x="130" y="133" text-anchor="middle" fill="#888" font-size="9">MO created, tank BLOCKED</text>
+
+  <!-- Event 2: MO processing -->
+  <rect x="280" y="100" width="180" height="45" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="370" y="120" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">MO Processing</text>
+  <text x="370" y="136" text-anchor="middle" fill="#888" font-size="9">mixing / consuming stock</text>
+
+  <!-- Event 3: MO done -->
+  <rect x="510" y="80" width="220" height="65" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
+  <text x="620" y="100" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">MO Marked as Done</text>
+  <text x="620" y="118" text-anchor="middle" fill="#ccc" font-size="10">raw move state → "done"</text>
+  <text x="620" y="134" text-anchor="middle" fill="#ccc" font-size="10">stock.move.write() clears</text>
+  <text x="620" y="147" text-anchor="middle" fill="#4ecca3" font-size="10">flowable_production_id = NULL</text>
+
+  <!-- Event 4: Ready for next -->
+  <rect x="775" y="100" width="170" height="45" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="860" y="120" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Ready for Next PO</text>
+  <text x="860" y="136" text-anchor="middle" fill="#888" font-size="9">tank available again</text>
+
+  <!-- Location state bar -->
+  <rect x="40" y="203" width="90" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="85" y="220" text-anchor="middle" fill="#4ecca3" font-size="9">AVAIL</text>
+
+  <rect x="130" y="203" width="490" height="25" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="375" y="220" text-anchor="middle" fill="#e94560" font-size="10" font-weight="bold">BLOCKED (MO active)</text>
+
+  <rect x="620" y="203" width="340" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="790" y="220" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">AVAILABLE</text>
+
+  <text x="500" y="250" text-anchor="middle" fill="#888" font-size="10">TANK LOCATION STATE</text>
+
+  <!-- Mechanism note -->
+  <rect x="150" y="270" width="700" height="40" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="290" text-anchor="middle" fill="#888" font-size="10" font-weight="bold">Mechanism: stock.move.write() override detects raw move going to "done" or "cancel"</text>
+  <text x="500" y="305" text-anchor="middle" fill="#888" font-size="10">→ clears production.location_dest_id.flowable_production_id (the flowable location)</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/05_mo_cancellation.svg
+++ b/stock_location_flowable/doc/diagrams/05_mo_cancellation.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="310" viewBox="0 0 1000 310">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="310" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 5: MO Cancellation — Location Unblocked</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Same as Scenario 4, but the MO is cancelled instead of completed. The unblocking mechanism is identical.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="175" x2="960" y2="175" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+  <text x="975" y="179" fill="#555" font-size="10">time</text>
+
+  <!-- Event markers -->
+  <circle cx="150" cy="175" r="5" fill="#3a86ff"/>
+  <circle cx="460" cy="175" r="5" fill="#e94560"/>
+  <circle cx="770" cy="175" r="5" fill="#4ecca3"/>
+
+  <!-- Connector lines -->
+  <line x1="150" y1="140" x2="150" y2="170" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="460" y1="115" x2="460" y2="170" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="770" y1="140" x2="770" y2="170" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO received + MO created + blocked -->
+  <rect x="50" y="90" width="200" height="47" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="150" y="110" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO Received</text>
+  <text x="150" y="128" text-anchor="middle" fill="#888" font-size="9">MO created, tank BLOCKED</text>
+
+  <!-- Event 2: MO cancelled -->
+  <rect x="340" y="70" width="240" height="42" rx="8" fill="#0f3460" stroke="#e94560" stroke-width="2"/>
+  <text x="460" y="90" text-anchor="middle" fill="#e94560" font-size="12" font-weight="bold">MO Cancelled</text>
+  <text x="460" y="107" text-anchor="middle" fill="#ccc" font-size="10">raw move state → "cancel" → unblocked</text>
+
+  <!-- Event 3: Available again -->
+  <rect x="670" y="90" width="200" height="47" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="770" y="110" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Ready for Next PO</text>
+  <text x="770" y="128" text-anchor="middle" fill="#888" font-size="9">tank available again</text>
+
+  <!-- Location state bar -->
+  <rect x="40" y="193" width="110" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="95" y="210" text-anchor="middle" fill="#4ecca3" font-size="9">AVAIL</text>
+
+  <rect x="150" y="193" width="310" height="25" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="305" y="210" text-anchor="middle" fill="#e94560" font-size="10" font-weight="bold">BLOCKED (MO active)</text>
+
+  <rect x="460" y="193" width="500" height="25" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="710" y="210" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">AVAILABLE</text>
+
+  <text x="500" y="240" text-anchor="middle" fill="#888" font-size="10">TANK LOCATION STATE</text>
+
+  <!-- Note -->
+  <rect x="150" y="258" width="700" height="30" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="278" text-anchor="middle" fill="#888" font-size="10">Same mechanism as Scenario 4: stock.move.write() detects raw move → "cancel" → clears flowable_production_id</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/06_internal_transfer.svg
+++ b/stock_location_flowable/doc/diagrams/06_internal_transfer.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="360" viewBox="0 0 1000 360">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="360" fill="#1a1a2e"/>
+
+  <!-- Title with Bug #1 -->
+  <text x="500" y="28" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">Scenario 6 — Bug #1: Internal Transfer to Blocked Location — Constraint Bypassed</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Location IS blocked by an MO. An internal transfer moves stock to the same tank.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#e94560" font-size="12">The constraint SKIPS the transfer (non-MO move). Stock arrives at the blocked tank.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="180" x2="960" y2="180" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="140" cy="180" r="5" fill="#3a86ff"/>
+  <circle cx="400" cy="180" r="5" fill="#f5a623"/>
+  <circle cx="700" cy="180" r="5" fill="#e94560"/>
+
+  <line x1="140" y1="148" x2="140" y2="175" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="400" y1="148" x2="400" y2="175" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="700" y1="130" x2="700" y2="175" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO received + blocked -->
+  <rect x="40" y="100" width="200" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="140" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO Received</text>
+  <text x="140" y="137" text-anchor="middle" fill="#e94560" font-size="9">MO created, location BLOCKED</text>
+
+  <!-- Event 2: MO processing -->
+  <rect x="300" y="105" width="200" height="40" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="400" y="122" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">MO Processing</text>
+  <text x="400" y="139" text-anchor="middle" fill="#888" font-size="9">tank still blocked</text>
+
+  <!-- Event 3: Transfer GOES THROUGH (bug!) -->
+  <rect x="580" y="90" width="240" height="37" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="700" y="114" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Internal Transfer GOES THROUGH!</text>
+  <rect x="610" y="130" width="180" height="18" rx="4" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="700" y="143" text-anchor="middle" fill="#e94560" font-size="9">constraint skips non-MO moves</text>
+
+  <text x="700" y="195" text-anchor="middle" fill="#e94560" font-size="16" font-weight="bold">!!</text>
+
+  <!-- State bar -->
+  <rect x="40" y="200" width="100" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="90" y="216" text-anchor="middle" fill="#4ecca3" font-size="9">AVAIL</text>
+  <rect x="140" y="200" width="820" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="550" y="216" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO active) — but constraint doesn't enforce it for non-MO moves</text>
+  <text x="500" y="243" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Bug #1 explanation -->
+  <rect x="60" y="260" width="880" height="55" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#e94560" stroke-width="1"/>
+  <text x="500" y="280" text-anchor="middle" fill="#e94560" font-size="12" font-weight="bold">Bug #1: same as Scenario 2 — constraint checks move's production, not location's blocking state</text>
+  <text x="500" y="300" text-anchor="middle" fill="#ccc" font-size="10">Internal transfer has no production → "if production and ..." is False → constraint entirely skipped.</text>
+
+  <!-- PR inside the section -->
+  <rect x="305" y="325" width="390" height="20" rx="4" fill="#3a86ff" fill-opacity="0.15" stroke="#3a86ff" stroke-width="1"/>
+  <text x="500" y="339" text-anchor="middle" fill="#3a86ff" font-size="10" font-weight="bold">Fixed by PR #847: github.com/nuobit/odoo-addons/pull/847</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/07_proposed_fix.svg
+++ b/stock_location_flowable/doc/diagrams/07_proposed_fix.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="400" viewBox="0 0 1000 400">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="400" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 7 — Fix: Post-check in action_assign Ensures Blocking</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">action_assign() override in mrp.production checks full reservation after super().</text>
+  <text x="500" y="68" text-anchor="middle" fill="#888" font-size="12">If not fully assigned: UserError with details of who holds reservations. Transaction rolls back.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="310" cy="195" r="5" fill="#4ecca3"/>
+  <circle cx="560" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="760" cy="195" r="5" fill="#e94560"/>
+  <circle cx="920" cy="195" r="5" fill="#4ecca3"/>
+
+  <line x1="100" y1="158" x2="100" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="310" y1="123" x2="310" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="560" y1="158" x2="560" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="760" y1="138" x2="760" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="920" y1="158" x2="920" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: PO #1 -->
+  <rect x="30" y="110" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="128" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #1 Confirmed</text>
+  <text x="100" y="147" text-anchor="middle" fill="#888" font-size="9">creates reception #1</text>
+
+  <!-- Event 2: Reception #1 — action_assign post-check passes, BLOCKED -->
+  <rect x="205" y="88" width="210" height="32" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="2"/>
+  <text x="310" y="109" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Reception #1 Validated</text>
+  <rect x="220" y="123" width="180" height="22" rx="5" fill="#4ecca3" fill-opacity="0.25" stroke="#4ecca3" stroke-width="2"/>
+  <rect x="223" y="126" width="30" height="16" rx="3" fill="#4ecca3"/>
+  <text x="238" y="138" text-anchor="middle" fill="#1a1a2e" font-size="8" font-weight="bold">FIX</text>
+  <text x="345" y="139" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">action_assign OK → BLOCKED</text>
+
+  <!-- Time gap -->
+  <text x="435" y="187" text-anchor="middle" fill="#666" font-size="9" font-style="italic">time passes</text>
+
+  <!-- Event 3: PO #2 -->
+  <rect x="490" y="110" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="560" y="128" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">PO #2 Confirmed</text>
+  <text x="560" y="147" text-anchor="middle" fill="#888" font-size="9">creates reception #2</text>
+
+  <!-- Event 4: Reception #2 REJECTED by constraint (Bug #1 fix) -->
+  <rect x="655" y="95" width="210" height="40" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="760" y="113" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception #2 REJECTED</text>
+  <text x="760" y="130" text-anchor="middle" fill="#ff8a8a" font-size="9">location blocked by MO #1</text>
+  <text x="760" y="208" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">X</text>
+
+  <!-- Event 5: MO #1 done -->
+  <rect x="860" y="115" width="120" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="920" y="132" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">MO #1 Done</text>
+  <text x="920" y="149" text-anchor="middle" fill="#888" font-size="9">unblocked</text>
+
+  <!-- State bar -->
+  <rect x="40" y="220" width="270" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="175" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE</text>
+  <rect x="310" y="220" width="610" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="615" y="236" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED — action_assign succeeds, post-check passes</text>
+  <rect x="920" y="220" width="40" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="500" y="263" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Fix explanation -->
+  <rect x="60" y="280" width="880" height="80" rx="8" fill="#4ecca3" fill-opacity="0.08" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="500" y="300" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">Fix: action_assign() override with _check_flowable_reservation() post-check</text>
+  <text x="500" y="318" text-anchor="middle" fill="#b0e8cc" font-size="11">After super().action_assign(): if any raw move is not "assigned" → UserError with conflicting reservations.</text>
+  <text x="500" y="336" text-anchor="middle" fill="#b0e8cc" font-size="11">UserError inside _action_done() rolls back the entire transaction — no stock moved, no MO persisted.</text>
+  <text x="500" y="354" text-anchor="middle" fill="#888" font-size="10">Compare with Scenario 3: without this fix, action_assign fails silently and location is never blocked.</text>
+
+  <!-- Comparison -->
+  <rect x="200" y="370" width="600" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="384" text-anchor="middle" fill="#888" font-size="10">EAFP: try the operation, check the result, roll back if it failed</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/08_reception_blocked_by_reservations.svg
+++ b/stock_location_flowable/doc/diagrams/08_reception_blocked_by_reservations.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="420" viewBox="0 0 1000 420">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="420" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#f5a623" font-size="18" font-weight="bold">Scenario 8 — Reception Rolled Back: action_assign Fails Due to Reservations</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">Tank has stock. Internal transfers reserved part of it. PO reception validates, MO created.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#f5a623" font-size="12">action_assign() can't fully reserve → post-check raises UserError → entire transaction rolls back.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="100" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="300" cy="195" r="5" fill="#4ecca3"/>
+  <circle cx="520" cy="195" r="5" fill="#f5a623"/>
+  <circle cx="750" cy="195" r="5" fill="#3a86ff"/>
+  <circle cx="900" cy="195" r="5" fill="#e94560"/>
+
+  <line x1="100" y1="148" x2="100" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="300" y1="120" x2="300" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="520" y1="120" x2="520" y2="190" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="750" y1="148" x2="750" y2="190" stroke="#3a86ff" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="900" y1="120" x2="900" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: Previous MO done -->
+  <rect x="25" y="100" width="150" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="100" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">Previous MO Done</text>
+  <text x="100" y="137" text-anchor="middle" fill="#888" font-size="9">tank has stock, unblocked</text>
+
+  <!-- Event 2: Internal transfers reserve some quants -->
+  <rect x="195" y="88" width="210" height="30" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="300" y="108" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Internal Transfer Created</text>
+  <rect x="210" y="120" width="180" height="32" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="300" y="136" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">reserves 6,949 kg from tank</text>
+  <text x="300" y="149" text-anchor="middle" fill="#888" font-size="8">WH/INT/00001</text>
+
+  <!-- Event 3: Another transfer reserves more -->
+  <rect x="420" y="88" width="200" height="30" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="520" y="108" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Another Transfer Created</text>
+  <rect x="435" y="120" width="170" height="32" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="520" y="136" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">reserves 3,500 kg from tank</text>
+  <text x="520" y="149" text-anchor="middle" fill="#888" font-size="8">WH/INT/00002</text>
+
+  <!-- Event 4: New PO -->
+  <rect x="680" y="100" width="140" height="45" rx="8" fill="#0f3460" stroke="#3a86ff" stroke-width="1.5"/>
+  <text x="750" y="118" text-anchor="middle" fill="#3a86ff" font-size="11" font-weight="bold">New PO Reception</text>
+  <text x="750" y="137" text-anchor="middle" fill="#888" font-size="9">validates, MO created</text>
+
+  <!-- Event 5: action_assign fails, post-check rolls back -->
+  <rect x="810" y="82" width="180" height="35" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2.5"/>
+  <text x="900" y="105" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">ROLLED BACK</text>
+  <rect x="815" y="120" width="170" height="52" rx="6" fill="#e94560" fill-opacity="0.1" stroke="#e94560" stroke-width="1"/>
+  <text x="900" y="136" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">action_assign partial →</text>
+  <text x="900" y="149" text-anchor="middle" fill="#ff8a8a" font-size="8">- 6,949 kg (INT/00001)</text>
+  <text x="900" y="161" text-anchor="middle" fill="#ff8a8a" font-size="8">- 3,500 kg (INT/00002)</text>
+  <text x="900" y="208" text-anchor="middle" fill="#e94560" font-size="18" font-weight="bold">X</text>
+
+  <!-- State bar -->
+  <rect x="40" y="220" width="960" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="520" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">AVAILABLE (not blocked) — has 10,449 kg reserved by outgoing transfers</text>
+  <text x="500" y="260" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE (unchanged — transaction rolled back)</text>
+
+  <!-- Quant visualization -->
+  <rect x="60" y="278" width="880" height="95" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#f5a623" stroke-width="1"/>
+  <text x="500" y="298" text-anchor="middle" fill="#f5a623" font-size="12" font-weight="bold">Tank quant state at time of action_assign</text>
+
+  <rect x="100" y="310" width="400" height="24" rx="4" fill="#4ecca3" fill-opacity="0.2" stroke="#4ecca3" stroke-width="1"/>
+  <text x="300" y="326" text-anchor="middle" fill="#4ecca3" font-size="10">22,000 kg available</text>
+
+  <rect x="500" y="310" width="170" height="24" rx="4" fill="#f5a623" fill-opacity="0.3" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="585" y="326" text-anchor="middle" fill="#f5a623" font-size="10">6,949 kg (INT/00001)</text>
+
+  <rect x="670" y="310" width="120" height="24" rx="4" fill="#f5a623" fill-opacity="0.3" stroke="#f5a623" stroke-width="1.5"/>
+  <text x="730" y="326" text-anchor="middle" fill="#f5a623" font-size="10">3,500 kg (INT/00002)</text>
+
+  <text x="500" y="356" text-anchor="middle" fill="#888" font-size="10">quantity_to_prod = 32,449 — but action_assign can only reserve 22,000 (available)</text>
+  <text x="500" y="370" text-anchor="middle" fill="#e94560" font-size="10">Post-check detects partial reservation → UserError → entire _action_done() rolls back</text>
+
+  <!-- Bottom note -->
+  <rect x="200" y="390" width="600" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="404" text-anchor="middle" fill="#888" font-size="10">User must unreserve INT/00001 and INT/00002 first — see Scenario 9</text>
+</svg>

--- a/stock_location_flowable/doc/diagrams/09_unreserve_and_retry.svg
+++ b/stock_location_flowable/doc/diagrams/09_unreserve_and_retry.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="420" viewBox="0 0 1000 420">
+  <style>
+    text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+  </style>
+  <defs>
+    <marker id="ta" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" fill="#555"/></marker>
+  </defs>
+  <rect width="1000" height="420" fill="#1a1a2e"/>
+
+  <!-- Title -->
+  <text x="500" y="28" text-anchor="middle" fill="#4ecca3" font-size="18" font-weight="bold">Scenario 9 — User Unreserves Outgoing Operations, Retries Reception</text>
+  <text x="500" y="50" text-anchor="middle" fill="#888" font-size="12">After Scenario 8: user goes to the listed operations, unreserves them, and retries the reception.</text>
+  <text x="500" y="68" text-anchor="middle" fill="#4ecca3" font-size="12">All quants now available. action_assign() succeeds, post-check passes, location blocked.</text>
+
+  <!-- Timeline -->
+  <line x1="40" y1="195" x2="960" y2="195" stroke="#555" stroke-width="2" marker-end="url(#ta)"/>
+
+  <circle cx="120" cy="195" r="5" fill="#e94560"/>
+  <circle cx="310" cy="195" r="5" fill="#f5a623"/>
+  <circle cx="500" cy="195" r="5" fill="#f5a623"/>
+  <circle cx="680" cy="195" r="5" fill="#4ecca3"/>
+  <circle cx="900" cy="195" r="5" fill="#4ecca3"/>
+
+  <line x1="120" y1="130" x2="120" y2="190" stroke="#e94560" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="310" y1="130" x2="310" y2="190" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="500" y1="130" x2="500" y2="190" stroke="#f5a623" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="680" y1="113" x2="680" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+  <line x1="900" y1="148" x2="900" y2="190" stroke="#4ecca3" stroke-width="1" stroke-dasharray="3,3"/>
+
+  <!-- Event 1: Reception rolled back (from Scenario 8) -->
+  <rect x="35" y="90" width="170" height="37" rx="8" fill="#3a1020" stroke="#e94560" stroke-width="2"/>
+  <text x="120" y="108" text-anchor="middle" fill="#e94560" font-size="11" font-weight="bold">Reception ROLLED BACK</text>
+  <text x="120" y="123" text-anchor="middle" fill="#ff8a8a" font-size="9">partial reservation detected</text>
+
+  <!-- Event 2: User unreserves transfer 1 -->
+  <rect x="215" y="90" width="190" height="37" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
+  <text x="310" y="108" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">Unreserve INT/00001</text>
+  <text x="310" y="123" text-anchor="middle" fill="#888" font-size="9">user unreserves manually</text>
+
+  <!-- Event 3: User unreserves transfer 2 -->
+  <rect x="405" y="90" width="190" height="37" rx="8" fill="#0f3460" stroke="#f5a623" stroke-width="2"/>
+  <text x="500" y="108" text-anchor="middle" fill="#f5a623" font-size="11" font-weight="bold">Unreserve INT/00002</text>
+  <text x="500" y="123" text-anchor="middle" fill="#888" font-size="9">user unreserves manually</text>
+
+  <!-- Event 4: Retry reception — succeeds -->
+  <rect x="600" y="78" width="160" height="32" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="2"/>
+  <text x="680" y="99" text-anchor="middle" fill="#4ecca3" font-size="11" font-weight="bold">Retry Reception</text>
+  <rect x="608" y="113" width="145" height="32" rx="5" fill="#4ecca3" fill-opacity="0.25" stroke="#4ecca3" stroke-width="2"/>
+  <text x="680" y="128" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">action_assign OK</text>
+  <text x="680" y="141" text-anchor="middle" fill="#4ecca3" font-size="9">post-check passes, BLOCKED</text>
+
+  <!-- Event 5: MO processing -->
+  <rect x="830" y="105" width="140" height="40" rx="8" fill="#0f3460" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="900" y="122" text-anchor="middle" fill="#4ecca3" font-size="10" font-weight="bold">MO Processing</text>
+  <text x="900" y="139" text-anchor="middle" fill="#888" font-size="9">fully reserved</text>
+
+  <!-- State bar: segment 1 — has reservations -->
+  <rect x="40" y="220" width="460" height="22" rx="5" fill="#f5a623" fill-opacity="0.15" stroke="#f5a623" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <text x="270" y="236" text-anchor="middle" fill="#f5a623" font-size="9" font-weight="bold">HAS RESERVATIONS — action_assign would fail</text>
+
+  <!-- State bar: segment 2 — all available -->
+  <rect x="500" y="220" width="180" height="22" rx="5" fill="#4ecca3" fill-opacity="0.1" stroke="#4ecca3" stroke-width="1.5"/>
+  <text x="590" y="236" text-anchor="middle" fill="#4ecca3" font-size="9" font-weight="bold">ALL AVAILABLE</text>
+
+  <!-- State bar: segment 3 — blocked -->
+  <rect x="680" y="220" width="280" height="22" rx="5" fill="#e94560" fill-opacity="0.15" stroke="#e94560" stroke-width="2"/>
+  <text x="820" y="236" text-anchor="middle" fill="#e94560" font-size="9" font-weight="bold">BLOCKED (MO)</text>
+
+  <text x="500" y="260" text-anchor="middle" fill="#666" font-size="9">TANK LOCATION STATE</text>
+
+  <!-- Step-by-step explanation -->
+  <rect x="60" y="278" width="880" height="105" rx="8" fill="#0f3460" fill-opacity="0.3" stroke="#4ecca3" stroke-width="1"/>
+  <text x="500" y="298" text-anchor="middle" fill="#4ecca3" font-size="12" font-weight="bold">User workflow after the error</text>
+
+  <text x="80" y="318" fill="#ccc" font-size="11">1. Read the error message — it lists each operation and reserved quantity</text>
+  <text x="80" y="336" fill="#ccc" font-size="11">2. Go to each listed picking/operation → click "Unreserve" to release the quants</text>
+  <text x="80" y="354" fill="#ccc" font-size="11">3. Return to the reception picking → click "Validate" again</text>
+  <text x="80" y="372" fill="#ccc" font-size="11">4. action_assign() succeeds → post-check passes → location BLOCKED</text>
+
+  <!-- Bottom note -->
+  <rect x="150" y="393" width="700" height="20" rx="4" fill="#0f3460" fill-opacity="0.4" stroke="#888" stroke-width="1" stroke-dasharray="3,3"/>
+  <text x="500" y="407" text-anchor="middle" fill="#888" font-size="10">Old lot reservations become obsolete after the merge — the new lot replaces them all</text>
+</svg>

--- a/stock_location_flowable/doc/flowable_location_blocking_flow.md
+++ b/stock_location_flowable/doc/flowable_location_blocking_flow.md
@@ -1,0 +1,287 @@
+# Flowable Location Blocking Mechanism
+
+How the blocking mechanism works for flowable locations (tanks): lifecycle, concepts,
+and scenarios.
+
+---
+
+## 1. Key Concepts
+
+### 1.1 What is a flowable location?
+
+A physical tank (e.g. Tank-A, Tank-B). Identified by `flowable_storage = True` on
+`stock.location`. It holds liquid/bulk material tracked by lot.
+
+### 1.2 Tank lifecycle
+
+A tank goes through a repeating cycle:
+
+**Available → Reception fills it → Blocked (MO merges) → MO done → Available**
+
+The tank is "occupied" the moment new material is poured in. While the MO processes the
+merge, nobody else should deliver to that tank.
+
+![Tank Lifecycle](diagrams/00_tank_lifecycle.svg)
+
+### 1.3 Blocking vs reservation
+
+These are two independent concepts:
+
+- **Blocking** (`flowable_production_id` on `stock.location`): a physical constraint —
+  "this tank is in use, nobody should pour more material in." It's about physical
+  occupation. Binary: either blocked or not.
+
+- **Reservation** (`reserved_quantity` on `stock.quant`): an Odoo inventory mechanism —
+  "these quants are spoken for by a specific stock move." Multiple operations can
+  partially reserve quants at the same location simultaneously.
+
+A tank can be **available (not blocked) but have reserved quants** — this is the normal
+case when outgoing operations (sales, internal transfers) have reserved material for
+delivery.
+
+### 1.4 Partial reservation on a tank
+
+Whether partial reservation makes sense depends on the direction:
+
+- **Outgoing** (sales, internal transfers): **valid**. You can sell 3,500 kg from a
+  35,000 kg tank. The sale reserves those 3,500 kg, the rest remains available for other
+  sales.
+
+- **Incoming** (receptions/merges): **invalid**. When new material arrives and a merge
+  MO is created, the MO must process the **entire** tank content (old + new). If some
+  quants are reserved by outgoing operations, the MO cannot reserve the full amount.
+
+### 1.5 Why lot reservations become obsolete after a merge
+
+This is a critical concept. Consider a tank with lot `LOT-001` (50,000 kg):
+
+1. Sales SO/123 and SO/456 each reserve 5,000 kg of lot `LOT-001`
+2. A new PO reception arrives — merge MO is created
+3. The MO consumes ALL quants (including `LOT-001`) and produces a **new lot** `LOT-002`
+   (55,000 kg = old 50,000 + new 5,000)
+4. Lot `LOT-001` still exists in the database but has **zero stock**
+5. The reservations by SO/123 and SO/456 for lot `LOT-001` are now **unfulfillable** —
+   the lot has no stock to deliver
+
+The reservations were already broken the moment the merge happened. This is why the
+system forces the user to deal with existing reservations **before** the merge: those
+reservations will become invalid anyway, so the user must consciously decide what to do
+(unreserve, cancel, or reassign).
+
+### 1.6 How blocking fields work
+
+On `stock.location`:
+
+- **`flowable_production_id`** (Many2one → `mrp.production`): the MO that has blocked
+  this location. Set by `stock.move.write()` when `action_assign()` transitions a raw
+  move to `assigned`/`partially_available`. Cleared when the raw move goes to `done` or
+  `cancel`.
+
+- **`flowable_blocked`** (Boolean, computed, not stored):
+  `bool(flowable_storage and flowable_production_id)`. Convenience field — the real data
+  is `flowable_production_id`.
+
+The `not flowable_blocked` guard in `stock.move.write()` prevents a new MO from
+overwriting an existing `flowable_production_id`.
+
+### 1.7 The reservation post-check in action_assign
+
+`action_assign()` is overridden in `mrp.production`. After `super()`, for flowable
+operations it verifies all raw moves are in `assigned` state. If not, it searches for
+who holds reservations at the source location and raises `UserError` with details. Since
+this runs inside `_action_done()`, the `UserError` rolls back the entire transaction —
+no stock moved, no MO persisted.
+
+This is a post-check (EAFP pattern): try the operation, verify the result, roll back if
+it failed. Advantages:
+
+- **No concurrency window**: checks the actual result, not a prediction
+- **Transaction safe**: `UserError` inside `_action_done` rolls back everything
+- **Universal**: any caller of `action_assign()` on a flowable MO gets the check
+
+---
+
+## 2. Scenarios
+
+### Scenario 1: Reception to Empty Tank — Happy Path
+
+Tank Tank-A is available and empty. A PO reception validates.
+
+1. `_action_done()` runs — stock moves to the tank
+2. Merge MO is created with `quantity_to_prod = sum(all quants)`
+3. `action_assign()` reserves all quants — succeeds (nothing else reserved)
+4. Post-check passes (all raw moves in `assigned` state)
+5. `stock.move.write()` sets `flowable_production_id` → **location BLOCKED**
+
+![First Reception](diagrams/01_first_reception.svg)
+
+### Scenario 2: Reception with No Outgoing Reservations — Happy Path
+
+Tank Tank-B has 32,000 kg from a previous merge. No outgoing operations have reserved
+anything. A new PO reception validates.
+
+Same flow as Scenario 1: `action_assign()` reserves all 37,000 kg (old + new),
+post-check passes, location blocked. This is the normal case when there are no pending
+deliveries from the tank.
+
+![Fix — Post-check](diagrams/07_proposed_fix.svg)
+
+### Scenario 3: Reception with Sale/Transfer Reservations — Error and Rollback
+
+Tank Tank-B has 32,449 kg of lot `LOT-001`. Two outgoing operations have reserved part
+of it:
+
+- Sale SO/001 → delivery WH/OUT/00001: reserved 6,949 kg of `LOT-001`
+- Internal transfer WH/INT/00002: reserved 3,500 kg of `LOT-001`
+
+Available: 22,000 kg. A new PO reception validates:
+
+1. `_action_done()` runs — stock moves to the tank (now 37,449 kg total)
+2. Merge MO created with `quantity_to_prod = 37,449` (sum of ALL quants)
+3. `action_assign()` tries to reserve 37,449 but only 27,000 available
+4. Raw move stays `confirmed` (not `assigned`)
+5. **Post-check detects partial reservation** → `UserError`:
+
+   ```
+   Cannot fully reserve flowable location 'Tank-B' because there
+   are other reserved quantities. All stock must be available before merging.
+
+   The following operations have reservations that must be unreserved first:
+
+     - Product X: 6,949.17 kg — WH/OUT/00001 (Delivery Orders)
+     - Product X: 3,500.00 kg — WH/INT/00002 (Internal Transfers)
+   ```
+
+6. **Entire transaction rolls back**: no stock moved, no MO created
+
+The error tells the user exactly which operations to fix. The user knows these
+reservations are for lot `LOT-001`, which will cease to exist after the merge anyway
+(see [1.5](#15-why-lot-reservations-become-obsolete-after-a-merge)).
+
+![Reception Blocked by Reservations](diagrams/08_reception_blocked_by_reservations.svg)
+
+### Scenario 4: User Unreserves and Retries — Success
+
+After Scenario 3, the user:
+
+1. Reads the error — sees the delivery and internal transfer holding reservations
+2. Goes to WH/OUT/00001 → clicks "Unreserve" (releases 6,949 kg)
+3. Goes to WH/INT/00002 → clicks "Unreserve" (releases 3,500 kg)
+4. Returns to the PO reception → clicks "Validate" again
+5. `action_assign()` succeeds — all quants available → **location BLOCKED**
+
+After the merge completes, lot `LOT-001` has zero stock and a new lot exists. The user
+can then re-reserve the deliveries with the new lot if needed.
+
+![Unreserve and Retry](diagrams/09_unreserve_and_retry.svg)
+
+### Scenario 5: Second Reception to Blocked Location — Correctly Rejected
+
+Location is blocked by an active MO. A second PO reception tries to validate to the same
+tank. The constraint `_check_flowable_location_blocked` on `stock.move.line` detects
+`flowable_production_id` is set and the current move doesn't belong to that MO →
+`ValidationError`. Reception rejected.
+
+This also applies to internal transfers — any move to a blocked location is rejected
+regardless of origin.
+
+![Second Reception Blocked](diagrams/02_second_reception_blocked.svg)
+![Internal Transfer Blocked](diagrams/06_internal_transfer.svg)
+
+### Scenario 6: MO Completion — Unblocking
+
+MO finishes processing. The raw move goes to `done`. `stock.move.write()` detects the
+state change and clears `flowable_production_id`. Location is available again for the
+next reception.
+
+![MO Completion](diagrams/04_mo_completion.svg)
+
+### Scenario 7: MO Cancellation — Unblocking
+
+Same mechanism as completion. `stock.move.write()` clears `flowable_production_id` when
+the raw move goes to `cancel`.
+
+![MO Cancellation](diagrams/05_mo_cancellation.svg)
+
+---
+
+## 3. Historical Reference: Example Case: Duplicate MOs on Same Tank
+
+Two PO receptions were validated to the same tank, creating duplicate MOs:
+
+| MO     | Picking   | Origin | Created    |
+| ------ | --------- | ------ | ---------- |
+| MO 001 | WH/IN/001 | PO/001 | 2025-01-15 |
+| MO 002 | WH/IN/002 | PO/002 | 2025-03-01 |
+
+MO 001's `action_assign()` failed (0 available quants — all reserved by other
+operations) → location never blocked → 45 days later PO/002 received into the same tank
+unimpeded.
+
+Two issues contributed:
+
+1. The blocked-location constraint in `stock_move_line.py` skipped non-MO moves, so even
+   blocked locations weren't protected from PO receptions
+2. `action_assign()` failed silently when quants were partially reserved, leaving the
+   location unblocked
+
+Both are now fixed:
+
+1. The constraint checks `location.flowable_production_id` directly — any move to a
+   blocked location is rejected
+2. The `action_assign()` override detects failed reservations and raises `UserError`
+   with details, rolling back the transaction
+
+---
+
+## 4. Future Improvements
+
+- **Auto-unreserve on reception**: Instead of requiring manual unreservation,
+  automatically unreserve outgoing operations when receiving at a flowable location.
+  Deferred to observe how the manual approach works in production first —
+  auto-unreserving could disrupt planned deliveries without the user being aware.
+
+---
+
+## 5. Validation Queries
+
+```sql
+-- Check current state of a flowable location:
+SELECT id, name, flowable_production_id, flowable_storage
+FROM stock_location WHERE id = <location_id>;
+
+-- Check active MOs on a flowable location:
+SELECT mp.id, mp.name, mp.state, sp.name as picking, mp.create_date
+FROM mrp_production mp
+LEFT JOIN stock_picking sp ON sp.id = mp.picking_id
+WHERE mp.location_src_id = <location_id>
+  AND mp.state NOT IN ('done', 'cancel');
+
+-- Check reserved quantities at all flowable locations:
+SELECT sl.name as location,
+       round(COALESCE(SUM(sq.quantity), 0)::numeric, 2) as total_qty,
+       round(COALESCE(SUM(sq.reserved_quantity), 0)::numeric, 2) as reserved,
+       round((COALESCE(SUM(sq.quantity), 0)
+              - COALESCE(SUM(sq.reserved_quantity), 0))::numeric, 2) as available
+FROM stock_location sl
+LEFT JOIN stock_quant sq ON sq.location_id = sl.id AND sq.quantity > 0
+WHERE sl.flowable_storage = true
+GROUP BY sl.id, sl.name
+HAVING COALESCE(SUM(sq.reserved_quantity), 0) > 0
+ORDER BY sl.name;
+
+-- Check who is reserving at a specific flowable location:
+SELECT sml.product_uom_qty as reserved,
+       pp.default_code as product,
+       sm.reference,
+       sp.name as picking,
+       mp.name as mo
+FROM stock_move_line sml
+JOIN stock_move sm ON sm.id = sml.move_id
+JOIN product_product pp ON pp.id = sml.product_id
+LEFT JOIN stock_picking sp ON sp.id = sm.picking_id
+LEFT JOIN mrp_production mp ON mp.id = sm.raw_material_production_id
+WHERE sml.location_id = <location_id>
+  AND sml.product_uom_qty > 0
+  AND sm.state NOT IN ('done', 'cancel', 'draft');
+```

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -63,6 +63,18 @@ msgstr ""
 "%s"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"After completing the mixing order '%s' at flowable location '%s', lot '%s' "
+"still has %s %s of stock. Expected 0 after merging all raw materials into "
+"lot '%s'."
+msgstr ""
+"Després de completar l'ordre de barreja '%s' a la ubicació fluida '%s', el "
+"lot '%s' encara té %s %s d'estoc. S'esperava 0 després de barrejar totes les "
+"matèries primeres al lot '%s'."
+
+#. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Capacity"

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -16,6 +16,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "All allowed products must be tracked by lot"
+msgstr "Tots els productes permesos han de ser rastrejats per lot"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_allowed_product_ids
+msgid "Allowed Products"
+msgstr "Productes Permesos"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Blocked"
+msgstr "Bloquejat"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
 #, python-format
 msgid ""
@@ -46,10 +63,386 @@ msgstr ""
 "%s"
 
 #. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Capacity"
+msgstr "Capacitat"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Capacity must be greater than 0"
+msgstr "La capacitat ha de ser superior a 0"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Capacity must be greater than capacity occupied %s"
+msgstr "La capacitat ha de ser superior a la capacitat ocupada %s"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Create Lots"
+msgstr "Crear Lots"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move_line__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__display_name
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_return_picking__display_name
+msgid "Display Name"
+msgstr "Nom mostrat"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Enable"
+msgstr "Habilitar"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Flowable"
+msgstr "Fluid"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity_occupied
+msgid "Flowable Capacity Occupied"
+msgstr "Capacitat Fluida Ocupada"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Flowable Location Warning"
+msgstr "Avís d'Ubicació Fluida"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__flowable_operation
+msgid "Flowable Operation"
+msgstr "Operació Fluida"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_percentage_occupied
+msgid "Flowable Percentage Occupied"
+msgstr "Percentatge Fluid Ocupat"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_production_id
+msgid "Flowable Production"
+msgstr "Producció de Fluid"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_storage
+msgid "Flowable Storage"
+msgstr "Emmagatzematge de Fluid"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move_line__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type__id
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_return_picking__id
+msgid "ID"
+msgstr "ID"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_location
+msgid "Inventory Locations"
+msgstr "Ubicacions d'inventari"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_blocked_popover
+msgid "JSON data for the popover widget"
+msgstr "Dades JSON per al widget emergent"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_move_line____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking_type____last_update
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_return_picking____last_update
+msgid "Last Modified on"
+msgstr "Última modificació el"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "Location capacity is full"
+msgstr "La capacitat de la ubicació està plena"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "Manufacturing Order"
+msgstr "Ordre de producció"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_picking__flowable_production_ids
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.view_picking_form
+#, python-format
+msgid "Manufacturing Orders"
+msgstr "Ordres de producció"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "More than one flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"Més d'un tipus d'operació de fabricació fluida al magatzem %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Not found flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"No s'ha trobat el tipus d'operació de fabricació fluida al magatzem %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Not found sequence in flowable manufacturing picking type %s"
+msgstr ""
+"No s'ha trobat seqüència al tipus d'operació de fabricació fluida %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking_type.py:0
+#, python-format
+msgid "Only manufacturing picking types can be flowable."
+msgstr "Només els tipus d'operació de fabricació poden ser fluids."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking_type.py:0
+#, python-format
+msgid "Only one picking type can be flowable in a warehouse %s."
+msgstr "Només un tipus d'operació pot ser fluid al magatzem %s."
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_mrp_production__picking_id
+msgid "Picking"
+msgstr "Albarà"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_picking_type
+msgid "Picking Type"
+msgstr "Tipus d'albarà"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Product %s must be tracked by lot"
+msgstr "El producte %s ha de ser rastrejat per lot"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Product %s not allowed in flowable location %s"
+msgstr "Producte %s no permès a la ubicació fluida %s"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr "Moviments de Producte (Stock Move Line)"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_mrp_production
+msgid "Production Order"
+msgstr "Ordre de producció"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_return_picking
+msgid "Return Picking"
+msgstr "Albarà de devolució"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_sequence_id
+msgid "Sequence"
+msgstr "Seqüència"
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_move
+msgid "Stock Move"
+msgstr "Moviment d'inventari"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The allowed products %s cannot have different Unit of Measure than flowable "
+"location %s"
+msgstr ""
+"Els productes permesos %s no poden tenir una unitat de mesura diferent a la "
+"ubicació fluida %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_move_line.py:0
+#, python-format
+msgid ""
+"The location %s is blocked. Probably you need to review the pending "
+"manufacturing orders related to this location"
+msgstr ""
+"La ubicació %s està bloquejada. Probablement necessites revisar les ordres "
+"de producció pendents relacionades amb aquesta ubicació"
+
+#. module: stock_location_flowable
+#: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
+msgid "The location is blocked"
+msgstr "La ubicació està bloquejada"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"The product %s is measured in %s. You can only assign products that have the "
+"allowed unit of measure"
+msgstr ""
+"El producte %s es mesura en %s. Només pots assignar productes que tinguin la "
+"unitat de mesura permesa"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"This location is blocked because it has a manufacturing order assigned."
+msgstr ""
+"Aquesta ubicació està bloquejada perquè té una ordre de producció assignada."
+
+#. module: stock_location_flowable
+#: model:ir.model,name:stock_location_flowable.model_stock_picking
+msgid "Transfer"
+msgstr "Albarà"
+
+#. module: stock_location_flowable
+#: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_uom_id
+msgid "Unit of Measure"
+msgstr "Unitat de Mesura"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
 #, python-format
 msgid "Unknown origin (move %s)"
 msgstr "Origen desconegut (moviment %s)"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"You can only receive one product at location %s because a manufacturing "
+"order must be generated and the location will be blocked. Create a partial "
+"delivery for this product %s."
+msgstr ""
+"Només pots rebre un producte a la ubicació %s perquè s'ha de generar una "
+"ordre de producció i la ubicació quedarà bloquejada. Crea un lliurament "
+"parcial per a aquest producte %s."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot cancel a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No es pot cancel·lar una producció que tingui un albarà associat. La barreja "
+"està en curs."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"products with different units of measure."
+msgstr ""
+"No pots convertir aquesta ubicació en una ubicació fluida perquè hi ha "
+"productes amb diferents unitats de mesura."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"unmixed products."
+msgstr ""
+"No pots convertir aquesta ubicació en una ubicació fluida perquè hi ha "
+"productes sense barrejar."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You cannot disable flowable storage from a blocked location."
+msgstr ""
+"No pots deshabilitar l'emmagatzematge fluid d'una ubicació bloquejada."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_quant.py:0
+#, python-format
+msgid "You cannot have more than one lot in the same location."
+msgstr "No es pot tenir més d'un lot a la mateixa ubicació."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot modify a mix production with a picking associated. The mixing is "
+"in progress."
+msgstr ""
+"No es pot modificar una producció de barreja que tingui un albarà associat. "
+"La barreja està en curs."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_move.py:0
+#, python-format
+msgid ""
+"You cannot modify a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No es pot modificar una producció que tingui un albarà associat. La barreja "
+"està en curs."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot remove a product that is currently stored in this location."
+msgstr ""
+"No pots eliminar un producte que estigui emmagatzemat en aquesta ubicació."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_return_picking.py:0
+#, python-format
+msgid ""
+"You cannot return the following products because they come from a flowable "
+"location: %s"
+msgstr ""
+"No pots retornar els següents productes perquè provenen d'una ubicació "
+"fluida: %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You have stock movements with different unit of measure"
+msgstr "Tens moviments d'estoc amb diferent unitat de mesura"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You must select a sequence"
+msgstr "Has de seleccionar una seqüència"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You must select a unit of measure"
+msgstr "Has de seleccionar una unitat de mesura"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid "You must select products"
+msgstr "Has de seleccionar productes"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* stock_location_flowable
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-11-27 11:13+0000\n"
+"PO-Revision-Date: 2023-11-27 11:13+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Cannot fully reserve the mixing order at flowable location '%s'. Raw "
+"materials are in state '%s'."
+msgstr ""
+"No es pot reservar completament l'ordre de barreja a la ubicació fluida "
+"'%s'. Les matèries primeres estan en estat '%s'."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Cannot merge at flowable location '%s' because there are reserved "
+"quantities. After the merge, the current lot(s) will have 0 stock and these "
+"reservations will become invalid.\n"
+"\n"
+"The following operations must be unreserved or completed first:\n"
+"\n"
+"%s"
+msgstr ""
+"No es pot barrejar a la ubicació fluida '%s' perquè hi ha quantitats "
+"reservades. Després de la barreja, els lots actuals tindran 0 estoc i "
+"aquestes reserves seran invàlides.\n"
+"\n"
+"Les següents operacions s'han d'alliberar o completar primer:\n"
+"\n"
+"%s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid "Unknown origin (move %s)"
+msgstr "Origen desconegut (moviment %s)"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid "no lot"
+msgstr "sense lot"

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -81,6 +81,16 @@ msgid "Capacity must be greater than capacity occupied %s"
 msgstr "La capacitat ha de ser superior a la capacitat ocupada %s"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Initial reception at flowable location '%s' for product '%s': expected 1 "
+"positive quant (empty tank) but found %d."
+msgstr ""
+"Recepció inicial a la ubicació fluida '%s' per al producte '%s': s'esperava "
+"1 quant positiu (tanc buit) però se n'han trobat %d."
+
+#. module: stock_location_flowable
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Create Lots"
 msgstr "Crear Lots"
@@ -194,6 +204,26 @@ msgstr "Ordres de producció"
 msgid "More than one flowable manufacturing picking type in warehouse %s"
 msgstr ""
 "Més d'un tipus d'operació de fabricació fluida al magatzem %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Mixing reception at flowable location '%s' for product '%s': expected 2 "
+"positive quants but found %d."
+msgstr ""
+"Recepció de barreja a la ubicació fluida '%s' per al producte '%s': "
+"s'esperaven 2 quants positius però se n'han trobat %d."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Mixing reception at flowable location '%s' for product '%s': expected "
+"exactly 1 quant for the received lot '%s' but found %d."
+msgstr ""
+"Recepció de barreja a la ubicació fluida '%s' per al producte '%s': "
+"s'esperava exactament 1 quant per al lot rebut '%s' però se n'han trobat %d."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0

--- a/stock_location_flowable/i18n/ca.po
+++ b/stock_location_flowable/i18n/ca.po
@@ -361,13 +361,15 @@ msgstr "Origen desconegut (moviment %s)"
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
 msgid ""
-"You can only receive one product at location %s because a manufacturing "
-"order must be generated and the location will be blocked. Create a partial "
-"delivery for this product %s."
+"Cannot receive multiple product/lot combinations (%s) at flowable location "
+"'%s' in the same receipt. Each combination generates a separate mixing order "
+"and the location is blocked after the first one. Create a backorder to "
+"receive them in separate steps."
 msgstr ""
-"Només pots rebre un producte a la ubicació %s perquè s'ha de generar una "
-"ordre de producció i la ubicació quedarà bloquejada. Crea un lliurament "
-"parcial per a aquest producte %s."
+"No es poden rebre múltiples combinacions de producte/lot (%s) a la ubicació "
+"de fluids '%s' en el mateix albarà. Cada combinació genera una ordre de "
+"mescla separada i la ubicació queda bloquejada després de la primera. Creeu "
+"un albarà parcial per rebre'ls en passos separats."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -65,6 +65,18 @@ msgstr ""
 "%s"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"After completing the mixing order '%s' at flowable location '%s', lot '%s' "
+"still has %s %s of stock. Expected 0 after merging all raw materials into "
+"lot '%s'."
+msgstr ""
+"Después de completar la orden de mezcla '%s' en la ubicación fluida '%s', el "
+"lote '%s' todavía tiene %s %s de stock. Se esperaba 0 después de mezclar "
+"todas las materias primas en el lote '%s'."
+
+#. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Capacity"

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -380,13 +380,15 @@ msgstr "Origen desconocido (movimiento %s)"
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
 msgid ""
-"You can only receive one product at location %s because a manufacturing "
-"order must be generated and the location will be blocked. Create a partial "
-"delivery for this product %s."
+"Cannot receive multiple product/lot combinations (%s) at flowable location "
+"'%s' in the same receipt. Each combination generates a separate mixing order "
+"and the location is blocked after the first one. Create a backorder to "
+"receive them in separate steps."
 msgstr ""
-"Solo puedes recibir un producto en la ubicación %s porque se debe generar "
-"una orden de producción y la ubicación será bloqueada. Crea una entrega "
-"parcial para este producto %s."
+"No se pueden recibir múltiples combinaciones de producto/lote (%s) en la "
+"ubicación de fluidos '%s' en el mismo albarán. Cada combinación genera una "
+"orden de mezcla separada y la ubicación queda bloqueada después de la "
+"primera. Cree un albarán parcial para recibirlos en pasos separados."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -199,14 +199,9 @@ msgstr "Ordenes de producción"
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "More than one manufacturing code in picking type for flowable location %s"
-msgstr "Más de un código de fabricación en el tipo de operación para la ubicación fluida %s"
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_picking.py:0
-#, python-format
-msgid "Not found sequence in manufacturing picking type %s for flowable location %s"
-msgstr "Secuencia no encontrada en el tipo de operación de fabricación %s para la ubicación fluida %s"
+msgid "More than one flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"Más de un tipo de operación de fabricación fluida en el almacén %s"
 
 #. module: stock_location_flowable
 #: model_terms:ir.actions.act_window,help:stock_location_flowable.action_picking_tree_blocked
@@ -216,15 +211,27 @@ msgstr "No se encontró ninguna transferencia. ¡Creemos uno!"
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "Not found manufacturing picking type for flowable location %s to do flowable"
-" mixing in %s"
-msgstr "No se encontró el tipo de operación de producción para la ubicación fluida"
-" %s para realizar la mezcla fluida en %s"
+msgid "Not found flowable manufacturing picking type in warehouse %s"
+msgstr ""
+"No se encontró el tipo de operación de fabricación fluida en el almacén %s"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid "Not found sequence in flowable manufacturing picking type %s"
+msgstr ""
+"No se encontró secuencia en el tipo de operación de fabricación fluida %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking_type.py:0
 #, python-format
-msgid "Only one picking type can be flowable in a warehouse %s.."
+msgid "Only manufacturing picking types can be flowable."
+msgstr "Solo los tipos de operación de fabricación pueden ser fluidos."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking_type.py:0
+#, python-format
+msgid "Only one picking type can be flowable in a warehouse %s."
 msgstr "Sólo un tipo de operación puede ser fluido en el almacén %s."
 
 #. module: stock_location_flowable
@@ -236,12 +243,6 @@ msgstr "Albarán"
 #: model:ir.model,name:stock_location_flowable.model_stock_picking_type
 msgid "Picking Type"
 msgstr "Tipo de albarán"
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_picking.py:0
-#, python-format
-msgid "The allowed products %s cannot have different Unit of Measure than flowable location %s"
-msgstr "Los productos permitidos %s no pueden tener una unidad de medida diferente a la ubicación fluida %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
@@ -281,12 +282,24 @@ msgid "Stock Move"
 msgstr "Movimiento de inventario"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"The allowed products %s cannot have different Unit of Measure than flowable "
+"location %s"
+msgstr ""
+"Los productos permitidos %s no pueden tener una unidad de medida diferente a "
+"la ubicación fluida %s"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_move_line.py:0
 #, python-format
-msgid "The location %s is blocked. Probably you need to review the pending "
+msgid ""
+"The location %s is blocked. Probably you need to review the pending "
 "manufacturing orders related to this location"
-msgstr "La ubicación %s está bloqueada. Probablemente necesites revisar las"
-" órdenes de producción pendientes relacionadas con esta ubicación"
+msgstr ""
+"La ubicación %s está bloqueada. Probablemente necesites revisar las "
+"órdenes de producción pendientes relacionadas con esta ubicación"
 
 #. module: stock_location_flowable
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
@@ -296,16 +309,20 @@ msgstr "La ubicación está bloqueada."
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
-msgid "The product %s is measured in %s. You can only assign products that have the"
-" allowed unit of measure"
-msgstr "El producto %s se mide en %s. Sólo puedes asignar productos que tengan la"
-" unidad de medida permitida"
+msgid ""
+"The product %s is measured in %s. You can only assign products that have the "
+"allowed unit of measure"
+msgstr ""
+"El producto %s se mide en %s. Sólo puedes asignar productos que tengan la "
+"unidad de medida permitida"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
-msgid "This location is blocked because it has a manufacturing order assigned."
-msgstr "Esta ubicación está bloqueada porque tiene una orden de producción asignada."
+msgid ""
+"This location is blocked because it has a manufacturing order assigned."
+msgstr ""
+"Esta ubicación está bloqueada porque tiene una orden de producción asignada."
 
 #. module: stock_location_flowable
 #: model:ir.model,name:stock_location_flowable.model_stock_picking
@@ -331,32 +348,51 @@ msgstr "Origen desconocido (movimiento %s)"
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
-msgid "You can only receive one product at location %s because a manufacturing "
+msgid ""
+"You can only receive one product at location %s because a manufacturing "
 "order must be generated and the location will be blocked. Create a partial "
 "delivery for this product %s."
-msgstr "Solo puedes recibir un producto en la ubicación %s porque se debe generar"
-" una orden de producción y la ubicación será bloqueada. Crea una entrega parcial"
-" para este producto %s."
+msgstr ""
+"Solo puedes recibir un producto en la ubicación %s porque se debe generar "
+"una orden de producción y la ubicación será bloqueada. Crea una entrega "
+"parcial para este producto %s."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot cancel a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No se puede cancelar una producción que tenga un albarán asociado. La mezcla "
+"está en curso."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"products with different units of measure."
+msgstr ""
+"No puedes convertir esta ubicación en una ubicación fluida porque hay "
+"productos con diferentes unidades de medida."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_location.py:0
+#, python-format
+msgid ""
+"You cannot convert this location into a flowable location because there are "
+"unmixed products."
+msgstr ""
+"No puedes convertir esta ubicación en una ubicación fluida porque hay "
+"productos sin mezclar."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
 msgid "You cannot disable flowable storage from a blocked location."
-msgstr "No puedes deshabilitar el almacenamiento fluido de una ubicación bloqueada"
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/mrp_production.py:0
-#, python-format
-msgid "You cannot cancel a production with a picking associated. The mixing is in progress."
-msgstr "No se puede cancelar una producción que tenga un albarán asociado. La mezcla está en curso."
-
-#. module: stock_location_flowable
-#: code:addons/stock_location_flowable/models/stock_location.py:0
-#, python-format
-msgid "You cannot convert this location into a flowable location because there are "
-"unmixed products or products with different units of measure."
-msgstr "No puedes convertir esta ubicación en una ubicación fluida porque hay "
-"productos sin mezclar o productos con diferentes unidades de medida."
+msgstr ""
+"No puedes deshabilitar el almacenamiento fluido de una ubicación bloqueada"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_quant.py:0
@@ -366,22 +402,42 @@ msgstr "No se puede tener más de un lote en la misma ubicación."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"You cannot modify a mix production with a picking associated. The mixing is "
+"in progress."
+msgstr ""
+"No se puede modificar una producción de mezcla que tenga un albarán "
+"asociado. La mezcla está en curso."
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_move.py:0
 #, python-format
-msgid "You cannot modify a mix production with a picking associated. The mixing is in progress."
-msgstr "No se puede modificar una producción de mezcla que tenga un albarán asociado. La mezcla está en curso."
+msgid ""
+"You cannot modify a production with a picking associated. The mixing is in "
+"progress."
+msgstr ""
+"No se puede modificar una producción que tenga un albarán asociado. La "
+"mezcla está en curso."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0
 #, python-format
-msgid "You cannot remove a product that is currently stored in this location."
-msgstr "No puedes eliminar un producto que esté actualmente almacenado en esta ubicación."
+msgid ""
+"You cannot remove a product that is currently stored in this location."
+msgstr ""
+"No puedes eliminar un producto que esté actualmente almacenado en esta "
+"ubicación."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_return_picking.py:0
 #, python-format
-msgid "You cannot return the product %s because it comes from a flowable location %s."
-msgstr "No puedes devolver el producto %s porque proviene de una ubicación fluida %s."
+msgid ""
+"You cannot return the following products because they come from a flowable "
+"location: %s"
+msgstr ""
+"No puedes devolver los siguientes productos porque provienen de una "
+"ubicación fluida: %s"
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_location.py:0

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -35,6 +35,36 @@ msgid "Blocked"
 msgstr "Bloqueado"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Cannot fully reserve the mixing order at flowable location '%s'. Raw "
+"materials are in state '%s'."
+msgstr ""
+"No se puede reservar completamente la orden de mezcla en la ubicación fluida "
+"'%s'. Las materias primas están en estado '%s'."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid ""
+"Cannot merge at flowable location '%s' because there are reserved "
+"quantities. After the merge, the current lot(s) will have 0 stock and these "
+"reservations will become invalid.\n"
+"\n"
+"The following operations must be unreserved or completed first:\n"
+"\n"
+"%s"
+msgstr ""
+"No se puede mezclar en la ubicación fluida '%s' porque hay cantidades "
+"reservadas. Después de la mezcla, los lotes actuales tendrán 0 stock y "
+"estas reservas serán inválidas.\n"
+"\n"
+"Las siguientes operaciones deben ser liberadas o completadas primero:\n"
+"\n"
+"%s"
+
+#. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__flowable_capacity
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Capacity"
@@ -293,6 +323,12 @@ msgid "Unit of Measure"
 msgstr "Unidad de Medida"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid "Unknown origin (move %s)"
+msgstr "Origen desconocido (movimiento %s)"
+
+#. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0
 #, python-format
 msgid "You can only receive one product at location %s because a manufacturing "
@@ -370,3 +406,9 @@ msgstr "Debes seleccionar una unidad de medida."
 #, python-format
 msgid "You must select products"
 msgstr "Debes seleccionar productos."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/mrp_production.py:0
+#, python-format
+msgid "no lot"
+msgstr "sin lote"

--- a/stock_location_flowable/i18n/es.po
+++ b/stock_location_flowable/i18n/es.po
@@ -88,6 +88,16 @@ msgid "Count Picking Blocked"
 msgstr "Conteo de Albarán Bloqueado"
 
 #. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Initial reception at flowable location '%s' for product '%s': expected 1 "
+"positive quant (empty tank) but found %d."
+msgstr ""
+"Recepción inicial en la ubicación fluida '%s' para el producto '%s': se "
+"esperaba 1 quant positivo (tanque vacío) pero se encontraron %d."
+
+#. module: stock_location_flowable
 #: model:ir.model.fields,field_description:stock_location_flowable.field_stock_location__create_lots
 #: model_terms:ir.ui.view,arch_db:stock_location_flowable.stock_location_view_form
 msgid "Create Lots"
@@ -207,6 +217,27 @@ msgstr ""
 #: model_terms:ir.actions.act_window,help:stock_location_flowable.action_picking_tree_blocked
 msgid "No transfer found. Let's create one!"
 msgstr "No se encontró ninguna transferencia. ¡Creemos uno!"
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Mixing reception at flowable location '%s' for product '%s': expected 2 "
+"positive quants but found %d."
+msgstr ""
+"Recepción de mezcla en la ubicación fluida '%s' para el producto '%s': se "
+"esperaban 2 quants positivos pero se encontraron %d."
+
+#. module: stock_location_flowable
+#: code:addons/stock_location_flowable/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Mixing reception at flowable location '%s' for product '%s': expected "
+"exactly 1 quant for the received lot '%s' but found %d."
+msgstr ""
+"Recepción de mezcla en la ubicación fluida '%s' para el producto '%s': se "
+"esperaba exactamente 1 quant para el lote recibido '%s' pero se encontraron "
+"%d."
 
 #. module: stock_location_flowable
 #: code:addons/stock_location_flowable/models/stock_picking.py:0

--- a/stock_location_flowable/models/mrp_production.py
+++ b/stock_location_flowable/models/mrp_production.py
@@ -4,6 +4,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools import float_is_zero
 
 
 class MrpProduction(models.Model):
@@ -56,6 +57,48 @@ class MrpProduction(models.Model):
                     )
                 )
         return super().write(vals)
+
+    def button_mark_done(self):
+        res = super().button_mark_done()
+        for rec in self:
+            if rec.picking_type_id.flowable_operation and rec.state == "done":
+                rec._check_flowable_post_production_quants()
+        return res
+
+    def _check_flowable_post_production_quants(self):
+        """Defensive check — should not be necessary under normal operation
+        and might be removed in the future. After completing a mixing order,
+        all raw-material lots at the flowable location must have 0 stock —
+        only the producing lot should remain. Rounding residuals or manual
+        inventory adjustments could leave non-zero leftovers that silently
+        corrupt stock. Fail loudly so the issue is caught immediately."""
+        self.ensure_one()
+        location = self.location_src_id
+        rounding = self.product_uom_id.rounding
+        quants = self.env["stock.quant"].search(
+            [
+                ("product_id", "=", self.product_id.id),
+                ("location_id", "=", location.id),
+                ("lot_id", "!=", self.lot_producing_id.id),
+                ("company_id", "=", self.company_id.id),
+            ]
+        )
+        for quant in quants:
+            if not float_is_zero(quant.quantity, precision_rounding=rounding):
+                raise ValidationError(
+                    _(
+                        "After completing the mixing order '%s' at"
+                        " flowable location '%s', lot '%s' still has"
+                        " %s %s of stock. Expected 0 after merging"
+                        " all raw materials into lot '%s'.",
+                        self.name,
+                        location.name,
+                        quant.lot_id.name,
+                        quant.quantity,
+                        self.product_uom_id.name,
+                        self.lot_producing_id.name,
+                    )
+                )
 
     def action_assign(self):
         res = super().action_assign()

--- a/stock_location_flowable/models/mrp_production.py
+++ b/stock_location_flowable/models/mrp_production.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class MrpProduction(models.Model):
@@ -56,3 +56,76 @@ class MrpProduction(models.Model):
                     )
                 )
         return super().write(vals)
+
+    def action_assign(self):
+        res = super().action_assign()
+        for rec in self:
+            if rec.picking_type_id.flowable_operation and rec.state not in (
+                "to_close",
+                "done",
+                "cancel",
+            ):
+                rec._check_flowable_reservation()
+        return res
+
+    def _check_flowable_reservation(self):
+        self.ensure_one()
+        if all(m.state == "assigned" for m in self.move_raw_ids):
+            return
+        location = self.location_src_id
+        reserved_move_lines = self.env["stock.move.line"].search(
+            [
+                ("location_id", "=", location.id),
+                ("product_uom_qty", ">", 0),
+                ("state", "not in", ("done", "cancel", "draft")),
+                ("move_id.raw_material_production_id", "!=", self.id),
+            ]
+        )
+        if reserved_move_lines:
+            details = []
+            for ml in reserved_move_lines:
+                move = ml.move_id
+                if move.picking_id:
+                    origin = "%s (%s)" % (
+                        move.picking_id.name,
+                        move.picking_id.picking_type_id.name,
+                    )
+                elif move.raw_material_production_id:
+                    origin = "%s (%s)" % (
+                        move.raw_material_production_id.name,
+                        move.raw_material_production_id.picking_type_id.name,
+                    )
+                else:
+                    origin = _("Unknown origin (move %s)", move.id)
+                details.append(
+                    "  - %s: %s %s (lot %s) - %s"
+                    % (
+                        ml.product_id.display_name,
+                        ml.product_uom_qty,
+                        ml.product_uom_id.name,
+                        ml.lot_id.name or _("no lot"),
+                        origin,
+                    )
+                )
+            raise UserError(
+                _(
+                    "Cannot merge at flowable location '%s'"
+                    " because there are reserved quantities."
+                    " After the merge, the current lot(s) will"
+                    " have 0 stock and these reservations will"
+                    " become invalid.\n\n"
+                    "The following operations must be unreserved"
+                    " or completed first:\n\n%s",
+                    location.name,
+                    "\n".join(details),
+                )
+            )
+        raise UserError(
+            _(
+                "Cannot fully reserve the mixing order at"
+                " flowable location '%s'. Raw materials are"
+                " in state '%s'.",
+                location.name,
+                ", ".join(self.move_raw_ids.mapped("state")),
+            )
+        )

--- a/stock_location_flowable/models/stock_move.py
+++ b/stock_location_flowable/models/stock_move.py
@@ -16,10 +16,12 @@ class StockMove(models.Model):
     def write(self, vals):
         for rec in self:
             production = rec.raw_material_production_id
+            if not production.picking_type_id.flowable_operation:
+                continue
             new_state = vals.get("state")
+            # Guard: block all modifications during active mixing
             if (
-                production.picking_type_id.flowable_operation
-                and production.picking_id
+                production.picking_id
                 and production.state == "to_close"
                 and new_state != "done"
             ):
@@ -29,15 +31,18 @@ class StockMove(models.Model):
                         " The mixing is in progress."
                     )
                 )
-            elif (
-                new_state in ("confirmed", "assigned", "partially_available")
-                and vals.get("move_line_ids", rec.move_line_ids)
-                and production.picking_type_id.flowable_operation
-                and production.location_dest_id.flowable_storage
-                and not production.location_dest_id.flowable_blocked
-            ):
-                production.location_dest_id.flowable_production_id = production
-            elif production.location_dest_id.flowable_production_id == production:
-                if new_state in ("cancel", "done"):
+            if not new_state:
+                continue
+            # Block location when MO raw materials are fully reserved
+            if new_state == "assigned":
+                if (
+                    vals.get("move_line_ids", rec.move_line_ids)
+                    and production.location_dest_id.flowable_storage
+                    and not production.location_dest_id.flowable_blocked
+                ):
+                    production.location_dest_id.flowable_production_id = production
+            # Unblock location when MO raw materials are done or cancelled
+            elif new_state in ("cancel", "done"):
+                if production.location_dest_id.flowable_production_id == production:
                     production.location_dest_id.flowable_production_id = False
         return super().write(vals)

--- a/stock_location_flowable/models/stock_move.py
+++ b/stock_location_flowable/models/stock_move.py
@@ -8,6 +8,11 @@ from odoo.exceptions import UserError
 class StockMove(models.Model):
     _inherit = "stock.move"
 
+    def _trigger_assign(self):
+        if self.env.context.get("flowable_skip_trigger_assign"):
+            return
+        return super()._trigger_assign()
+
     def write(self, vals):
         for rec in self:
             production = rec.raw_material_production_id

--- a/stock_location_flowable/models/stock_move_line.py
+++ b/stock_location_flowable/models/stock_move_line.py
@@ -28,11 +28,14 @@ class StockMoveLine(models.Model):
                 ):
                     locations_to_check |= rec.location_id
                 for location in locations_to_check:
-                    if rec.state == "done":
-                        production = rec.move_id.production_id
-                    else:
-                        production = rec.move_id.raw_material_production_id
-                    if production and location.flowable_production_id != production:
+                    production = (
+                        rec.move_id.raw_material_production_id
+                        or rec.move_id.production_id
+                    )
+                    if (
+                        location.flowable_production_id
+                        and location.flowable_production_id != production
+                    ):
                         raise ValidationError(
                             _(
                                 "The location %s is blocked. Probably you need to"

--- a/stock_location_flowable/models/stock_picking.py
+++ b/stock_location_flowable/models/stock_picking.py
@@ -144,22 +144,31 @@ class StockPicking(models.Model):
                         % mrp_operation_type.display_name
                     )
 
-            # group move lines by product, destination location and lot to check if
-            # there are multiple products for the same location and to sum the
-            # quantity to produce
+            # Group move lines by (product, dest location, lot) and check for
+            # conflicts. The blocking mechanism would catch this too (the first
+            # MO blocks the location, the second hits the constraint), but
+            # that error references a phantom MO created in the same rolled-back
+            # transaction. Pre-checking here gives an actionable message.
             lines = {}
             for line in flowable_lines:
                 key = (line.product_id, line.location_dest_id, line.lot_id)
                 lines[key] = lines.get(key, 0) + line.qty_done
-                if any(k[1] == line.location_dest_id and k != key for k in lines):
+                existing = [k for k in lines if k[1] == line.location_dest_id]
+                if len(existing) > 1:
+                    details = ", ".join(
+                        "%s (%s)" % (k[0].name, k[2].name) if k[2] else k[0].name
+                        for k in existing
+                    )
                     raise UserError(
                         _(
-                            "You can only receive one product at location %s"
-                            " because a manufacturing order must be generated"
-                            " and the location will be blocked. Create a "
-                            "partial delivery for this product %s."
+                            "Cannot receive multiple product/lot combinations"
+                            " (%s) at flowable location '%s' in the same"
+                            " receipt. Each combination generates a separate"
+                            " mixing order and the location is blocked after"
+                            " the first one. Create a backorder to receive"
+                            " them in separate steps."
                         )
-                        % (line.location_dest_id.name, line.product_id.name)
+                        % (details, line.location_dest_id.name)
                     )
 
             # create manufacturing orders

--- a/stock_location_flowable/models/stock_picking.py
+++ b/stock_location_flowable/models/stock_picking.py
@@ -189,6 +189,9 @@ class StockPicking(models.Model):
                         ("company_id", "=", rec.company_id.id),
                     ]
                 )
+                rec._check_flowable_quant_count(
+                    component_quant, location_dest, product, lot
+                )
                 quantity_to_prod = sum(component_quant.mapped("quantity"))
                 production = rec.env["mrp.production"].create(
                     rec._prepare_production_values(
@@ -221,3 +224,36 @@ class StockPicking(models.Model):
                 production.action_assign()
                 production.qty_producing = quantity_to_prod
         return res
+
+    def _check_flowable_quant_count(self, quants, location, product, lot):
+        is_initial = all(q.lot_id == lot for q in quants)
+        if is_initial:
+            if len(quants) != 1:
+                raise UserError(
+                    _(
+                        "Initial reception at flowable location '%s'"
+                        " for product '%s': expected 1 positive quant"
+                        " (empty tank) but found %d."
+                    )
+                    % (location.name, product.name, len(quants))
+                )
+        else:
+            if len(quants) != 2:
+                raise UserError(
+                    _(
+                        "Mixing reception at flowable location '%s'"
+                        " for product '%s': expected 2 positive quants"
+                        " but found %d."
+                    )
+                    % (location.name, product.name, len(quants))
+                )
+            received = quants.filtered(lambda q: q.lot_id == lot)
+            if len(received) != 1:
+                raise UserError(
+                    _(
+                        "Mixing reception at flowable location '%s'"
+                        " for product '%s': expected exactly 1 quant"
+                        " for the received lot '%s' but found %d."
+                    )
+                    % (location.name, product.name, lot.name, len(received))
+                )

--- a/stock_location_flowable/models/stock_picking.py
+++ b/stock_location_flowable/models/stock_picking.py
@@ -99,7 +99,10 @@ class StockPicking(models.Model):
         return super().button_validate()
 
     def _action_done(self):
-        res = super()._action_done()
+        res = super(
+            StockPicking,
+            self.with_context(flowable_skip_trigger_assign=True),
+        )._action_done()
         for rec in self:
             flowable_lines = rec.move_line_ids_without_package.filtered(
                 lambda x: x.location_dest_id.flowable_storage

--- a/stock_location_flowable/readme/CONTRIBUTORS.rst
+++ b/stock_location_flowable/readme/CONTRIBUTORS.rst
@@ -1,4 +1,6 @@
-- [NuoBiT](https://www.nuobit.com):
-  - Frank Cespedes <fcespedes@nuobit.com>
-  - Deniz Gallo <dgallo@nuobit.com>
-  - Bijaya Kumal <bkumal@nuobit.com>
+* `NuoBiT <https://www.nuobit.com>`__:
+
+  * Frank Cespedes <fcespedes@nuobit.com>
+  * Deniz Gallo <dgallo@nuobit.com>
+  * Bijaya Kumal <bkumal@nuobit.com>
+  * Eric Antones <eantones@nuobit.com>

--- a/stock_location_flowable/static/description/index.html
+++ b/stock_location_flowable/static/description/index.html
@@ -399,15 +399,19 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
 <li>NuoBiT Solutions</li>
+<li>S.L.</li>
 </ul>
 </div>
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#toc-entry-4">Contributors</a></h2>
 <ul class="simple">
-<li>[NuoBiT](<a class="reference external" href="https://www.nuobit.com">https://www.nuobit.com</a>):
-- Frank Cespedes &lt;<a class="reference external" href="mailto:fcespedes&#64;nuobit.com">fcespedes&#64;nuobit.com</a>&gt;
-- Deniz Gallo &lt;<a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a>&gt;
-- Bijaya Kumal &lt;<a class="reference external" href="mailto:bkumal&#64;nuobit.com">bkumal&#64;nuobit.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.nuobit.com">NuoBiT</a>:<ul>
+<li>Frank Cespedes &lt;<a class="reference external" href="mailto:fcespedes&#64;nuobit.com">fcespedes&#64;nuobit.com</a>&gt;</li>
+<li>Deniz Gallo &lt;<a class="reference external" href="mailto:dgallo&#64;nuobit.com">dgallo&#64;nuobit.com</a>&gt;</li>
+<li>Bijaya Kumal &lt;<a class="reference external" href="mailto:bkumal&#64;nuobit.com">bkumal&#64;nuobit.com</a>&gt;</li>
+<li>Eric Antones &lt;<a class="reference external" href="mailto:eantones&#64;nuobit.com">eantones&#64;nuobit.com</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/stock_location_flowable/tests/test_common.py
+++ b/stock_location_flowable/tests/test_common.py
@@ -62,7 +62,7 @@ class TestCommon(common.SavepointCase):
 
         cls.product_flowable_1 = cls.env["product.product"].create(
             {
-                "name": "ProductFlowable1",
+                "name": "Liquid O2",
                 "type": "product",
                 "uom_id": cls.env.ref("uom.product_uom_litre").id,
                 "uom_po_id": cls.env.ref("uom.product_uom_litre").id,
@@ -72,7 +72,7 @@ class TestCommon(common.SavepointCase):
 
         cls.product_flowable_2 = cls.env["product.product"].create(
             {
-                "name": "ProductFlowable2",
+                "name": "Liquid N2",
                 "type": "product",
                 "uom_id": cls.env.ref("uom.product_uom_litre").id,
                 "uom_po_id": cls.env.ref("uom.product_uom_litre").id,
@@ -82,7 +82,7 @@ class TestCommon(common.SavepointCase):
 
         cls.location_1 = cls.env["stock.location"].create(
             {
-                "name": "Location1",
+                "name": "Warehouse Shelf",
                 "usage": "internal",
                 "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
             }
@@ -90,7 +90,7 @@ class TestCommon(common.SavepointCase):
 
         cls.location_flowable_1 = cls.env["stock.location"].create(
             {
-                "name": "LocationFlowable1",
+                "name": "O2 Tank 1",
                 "usage": "internal",
                 "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
                 "flowable_storage": True,
@@ -113,7 +113,7 @@ class TestCommon(common.SavepointCase):
 
         cls.location_flowable_2 = cls.env["stock.location"].create(
             {
-                "name": "LocationFlowable2",
+                "name": "O2 Tank 2",
                 "usage": "internal",
                 "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
                 "flowable_storage": True,

--- a/stock_location_flowable/tests/test_common.py
+++ b/stock_location_flowable/tests/test_common.py
@@ -14,6 +14,8 @@ class TestCommon(common.SavepointCase):
     def setUpClass(cls):
         super(TestCommon, cls).setUpClass()
 
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+
         cls.picking_type_incoming_1 = cls.env["stock.picking.type"].create(
             {
                 "name": "Receipt1",
@@ -145,7 +147,7 @@ class TestCommon(common.SavepointCase):
                 "product_uom_id": cls.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": cls.env.ref("stock.stock_location_suppliers").id,
+                "location_id": cls.supplier_location.id,
                 "location_dest_id": cls.incoming_picking.location_dest_id.id,
                 "company_id": cls.env.company.id,
             }
@@ -166,7 +168,7 @@ class TestCommon(common.SavepointCase):
                 "product_uom_id": cls.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": cls.env.ref("stock.stock_location_suppliers").id,
+                "location_id": cls.supplier_location.id,
                 "location_dest_id": cls.outgoing_picking.location_dest_id.id,
                 "company_id": cls.env.company.id,
             }
@@ -206,3 +208,119 @@ class TestCommon(common.SavepointCase):
         escaped_parts = [re.escape(part) for part in parts]
         regex_pattern = ".*".join(escaped_parts)
         return regex_pattern
+
+    def _create_lot(self, product, name):
+        return self.env["stock.production.lot"].create(
+            {
+                "name": name,
+                "product_id": product.id,
+            }
+        )
+
+    def _receive_stock(self, location, product, lot, qty, picking_type=None):
+        """Create and validate an incoming picking to any location."""
+        if picking_type is None:
+            picking_type = self.picking_type_incoming_1
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": location.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": product.id,
+                "product_uom_id": product.uom_id.id,
+                "lot_id": lot.id,
+                "qty_done": qty,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": location.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        picking.button_validate()
+        return picking
+
+    def _create_incoming_picking(self, location, product, lot, qty, picking_type=None):
+        """Create an incoming picking WITHOUT validating it."""
+        if picking_type is None:
+            picking_type = self.picking_type_incoming_1
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": location.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": product.id,
+                "product_uom_id": product.uom_id.id,
+                "lot_id": lot.id,
+                "qty_done": qty,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": location.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        return picking
+
+    def _find_flowable_production(self, location, picking_type=None):
+        if picking_type is None:
+            picking_type = self.picking_type_mrp_operation_1
+        return self.env["mrp.production"].search(
+            [
+                ("picking_type_id", "=", picking_type.id),
+                ("location_dest_id", "=", location.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+
+    def _get_location_quants(self, location, product):
+        return self.env["stock.quant"].search(
+            [
+                ("location_id", "=", location.id),
+                ("product_id", "=", product.id),
+            ]
+        )
+
+    def _get_positive_quantity(self, location, product):
+        quants = self._get_location_quants(location, product)
+        return sum(quants.filtered(lambda q: q.quantity > 0).mapped("quantity"))
+
+    def _seed_flowable_location(
+        self, location, product, lot, qty, picking_type=None, mrp_picking_type=None
+    ):
+        """Receive initial stock and complete the resulting MO."""
+        picking = self._receive_stock(
+            location, product, lot, qty, picking_type=picking_type
+        )
+        production = self._find_flowable_production(
+            location, picking_type=mrp_picking_type
+        )
+        if production:
+            production.button_mark_done()
+        return picking
+
+    def _create_inventory_adjustment(self, location, product, lot, qty):
+        """Create and validate a simple inventory adjustment (1 lot)."""
+        inventory = self.env["stock.inventory"].create(
+            {"name": f"Adjust {product.name} at {location.name}"}
+        )
+        inventory.action_start()
+        self.env["stock.inventory.line"].create(
+            {
+                "inventory_id": inventory.id,
+                "product_id": product.id,
+                "product_uom_id": product.uom_id.id,
+                "location_id": location.id,
+                "prod_lot_id": lot.id,
+                "product_qty": qty,
+            }
+        )
+        inventory.action_validate()
+        return inventory

--- a/stock_location_flowable/tests/test_mrp_production.py
+++ b/stock_location_flowable/tests/test_mrp_production.py
@@ -5,6 +5,7 @@
 import logging
 
 from odoo.exceptions import UserError, ValidationError
+from odoo.tests import common
 from odoo.tools import float_compare, float_round
 
 from .test_common import TestCommon
@@ -829,3 +830,354 @@ class TestMrpProduction(TestCommon):
 
         # ASSERT
         self.assertTrue(production)
+
+
+class TestFlowableBlockingWithReservations(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestFlowableBlockingWithReservations, cls).setUpClass()
+
+        cls.picking_type_incoming = cls.env["stock.picking.type"].create(
+            {
+                "name": "TestReceipt",
+                "sequence_code": "SEQ-TEST-IN",
+                "code": "incoming",
+                "default_location_dest_id": cls.env.ref(
+                    "stock.stock_location_locations_partner"
+                ).id,
+            }
+        )
+
+        cls.picking_type_outgoing = cls.env["stock.picking.type"].create(
+            {
+                "name": "TestDelivery",
+                "sequence_code": "SEQ-TEST-OUT",
+                "code": "outgoing",
+                "default_location_src_id": cls.env.ref(
+                    "stock.stock_location_locations_partner"
+                ).id,
+            }
+        )
+
+        cls.picking_type_mrp = cls.env["stock.picking.type"].create(
+            {
+                "name": "TestProduction",
+                "sequence_code": "SEQ-TEST-MRP",
+                "code": "mrp_operation",
+                "flowable_operation": True,
+            }
+        )
+
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "TestOxygen",
+                "type": "product",
+                "uom_id": cls.env.ref("uom.product_uom_litre").id,
+                "uom_po_id": cls.env.ref("uom.product_uom_litre").id,
+                "tracking": "lot",
+            }
+        )
+
+        cls.location_fl1 = cls.env["stock.location"].create(
+            {
+                "name": "FL1",
+                "usage": "internal",
+                "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
+                "flowable_storage": True,
+                "flowable_capacity": 15000,
+                "flowable_uom_id": cls.env.ref("uom.product_uom_litre").id,
+                "flowable_allowed_product_ids": [(4, cls.product.id)],
+            }
+        )
+
+        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+
+    def _receive_stock(self, location, product, lot, qty):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": location.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": product.id,
+                "product_uom_id": product.uom_id.id,
+                "lot_id": lot.id,
+                "qty_done": qty,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": location.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        picking.button_validate()
+        return picking
+
+    def _find_flowable_production(self, location):
+        return self.env["mrp.production"].search(
+            [
+                ("picking_type_id", "=", self.picking_type_mrp.id),
+                ("location_dest_id", "=", location.id),
+            ],
+            order="id desc",
+            limit=1,
+        )
+
+    def _get_location_quants(self, location, product):
+        return self.env["stock.quant"].search(
+            [
+                ("location_id", "=", location.id),
+                ("product_id", "=", product.id),
+            ]
+        )
+
+    def _get_positive_quantity(self, location, product):
+        quants = self._get_location_quants(location, product)
+        return sum(quants.filtered(lambda q: q.quantity > 0).mapped("quantity"))
+
+    def _seed_flowable_location(self, location, product, lot, qty):
+        self._receive_stock(location, product, lot, qty)
+        production = self._find_flowable_production(location)
+        if production:
+            production.button_mark_done()
+
+    def _create_sale_picking(
+        self,
+        location,
+        product,
+        name,
+        qty,
+        reserve=True,
+        unreserve=False,
+    ):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_outgoing.id,
+                "location_id": location.id,
+                "location_dest_id": self.customer_location.id,
+            }
+        )
+        self.env["stock.move"].create(
+            {
+                "name": name,
+                "picking_id": picking.id,
+                "product_id": product.id,
+                "product_uom": product.uom_id.id,
+                "product_uom_qty": qty,
+                "location_id": location.id,
+                "location_dest_id": self.customer_location.id,
+            }
+        )
+        picking.action_confirm()
+        if reserve:
+            picking.action_assign()
+        if unreserve:
+            picking.do_unreserve()
+        return picking
+
+    def test_flowable_blocking_with_pending_reservations_and_reception(self):
+        """
+        Test that receiving stock at a flowable location is rejected when
+        there are reserved quantities that would become invalid after the
+        merge (the current lot goes to 0 stock).
+
+        Sales 1 and 3 are explicitly reserved (assigned). Sale 2 is only
+        confirmed (not reserved). The mixing MO cannot fully reserve
+        because Sales 1 and 3 hold reservations on the stock.
+
+        PRE:    - Flowable location FL1 (capacity 15000 L), initially empty
+                - Receive 7000 L of lot X1 via reception + MO (seed)
+                - Sale 1: 100 L of X1 confirmed + reserved (assigned)
+                - Sale 2: 200 L of X1 confirmed only (not reserved)
+                - Inventory adjustment: +1000 L on lot X1
+                - Sale 3: 600 L of X1 confirmed + reserved (assigned)
+        ACT:    - Receive 5000 L of lot P1 at FL1
+        POST:   - UserError is raised mentioning Sales 1 and 3
+                  (the only ones with active reservations)
+        """
+        # ARRANGE
+        lot_x1 = self.env["stock.production.lot"].create(
+            {
+                "name": "X1",
+                "product_id": self.product.id,
+            }
+        )
+        self._seed_flowable_location(self.location_fl1, self.product, lot_x1, 7000)
+        self.assertEqual(
+            self._get_positive_quantity(self.location_fl1, self.product), 7000
+        )
+        self.assertFalse(self.location_fl1.flowable_blocked)
+
+        # Sale 1: 100 L of X1, confirmed + reserved (assigned)
+        sale_picking_1 = self._create_sale_picking(
+            self.location_fl1, self.product, "Sale 1 - X1 100L", 100
+        )
+        self.assertEqual(sale_picking_1.state, "assigned")
+
+        # Sale 2: 200 L of X1, confirmed only (not reserved)
+        sale_picking_2 = self._create_sale_picking(
+            self.location_fl1,
+            self.product,
+            "Sale 2 - X1 200L",
+            200,
+            reserve=False,
+        )
+        self.assertEqual(sale_picking_2.state, "confirmed")
+
+        # Inventory adjustment: +1000 L on lot X1
+        inventory = self.env["stock.inventory"].create(
+            {
+                "name": "Adjust +1000L on X1",
+                "location_ids": [(4, self.location_fl1.id)],
+                "product_ids": [(4, self.product.id)],
+            }
+        )
+        inventory.action_start()
+        inv_line = inventory.line_ids.filtered(
+            lambda l: l.location_id == self.location_fl1
+        )
+        inv_line[0].product_qty = inv_line[0].product_qty + 1000
+        inventory.action_validate()
+        self.assertEqual(
+            self._get_positive_quantity(self.location_fl1, self.product), 8000
+        )
+
+        # Sale 3: 600 L of X1, confirmed + reserved (assigned)
+        sale_picking_3 = self._create_sale_picking(
+            self.location_fl1, self.product, "Sale 3 - X1 600L", 600
+        )
+        self.assertEqual(sale_picking_3.state, "assigned")
+        self.assertFalse(self.location_fl1.flowable_blocked)
+
+        # ACT
+        lot_p1 = self.env["stock.production.lot"].create(
+            {
+                "name": "P1",
+                "product_id": self.product.id,
+            }
+        )
+        with self.assertRaises(UserError) as error:
+            self._receive_stock(self.location_fl1, self.product, lot_p1, 5000)
+
+        # ASSERT
+        # Only Sales 1 and 3 appear in the error (the ones with active
+        # reservations). Sale 2 is only confirmed, not reserved.
+        expected_msg = (
+            "Cannot merge at flowable location 'FL1'"
+            " because there are reserved quantities."
+            " After the merge, the current lot(s) will"
+            " have 0 stock and these reservations will"
+            " become invalid.\n\n"
+            "The following operations must be unreserved"
+            " or completed first:\n\n"
+            "  - TestOxygen: 100.0 L (lot X1)"
+            " - %s (TestDelivery)\n"
+            "  - TestOxygen: 600.0 L (lot X1)"
+            " - %s (TestDelivery)"
+        ) % (sale_picking_1.name, sale_picking_3.name)
+        self.assertEqual(str(error.exception), expected_msg)
+
+    def test_flowable_merge_succeeds_with_unreserved_operations(self):
+        """
+        Test that receiving stock at a flowable location succeeds when
+        all sales have been unreserved before the reception.
+
+        _trigger_assign is bypassed for flowable receptions, so the
+        unreserved sales stay confirmed. The mixing MO fully reserves
+        all stock and succeeds.
+
+        PRE:    - Flowable location FL1 (capacity 15000 L), initially empty
+                - Receive 7000 L of lot X1 via reception + MO (seed)
+                - Sale 1: 100 L of X1 reserved then unreserved
+                - Sale 2: 200 L of X1 reserved then unreserved
+                - Inventory adjustment: +1000 L on lot X1
+                - Sale 3: 600 L of X1 reserved then unreserved
+        ACT:    - Receive 5000 L of lot P1 at FL1
+        POST:   - No error is raised
+                - A mixing MO is created and FL1 is blocked
+        """
+        # ARRANGE
+        lot_x1 = self.env["stock.production.lot"].create(
+            {
+                "name": "X1",
+                "product_id": self.product.id,
+            }
+        )
+        self._seed_flowable_location(self.location_fl1, self.product, lot_x1, 7000)
+        self.assertEqual(
+            self._get_positive_quantity(self.location_fl1, self.product), 7000
+        )
+        self.assertFalse(self.location_fl1.flowable_blocked)
+
+        # Sale 1: 100 L of X1, reserved then unreserved
+        sale_picking_1 = self._create_sale_picking(
+            self.location_fl1,
+            self.product,
+            "Sale 1 - X1 100L",
+            100,
+            unreserve=True,
+        )
+        self.assertEqual(sale_picking_1.state, "confirmed")
+
+        # Sale 2: 200 L of X1, reserved then unreserved
+        sale_picking_2 = self._create_sale_picking(
+            self.location_fl1,
+            self.product,
+            "Sale 2 - X1 200L",
+            200,
+            unreserve=True,
+        )
+        self.assertEqual(sale_picking_2.state, "confirmed")
+
+        # Inventory adjustment: +1000 L on lot X1
+        inventory = self.env["stock.inventory"].create(
+            {
+                "name": "Adjust +1000L on X1",
+                "location_ids": [(4, self.location_fl1.id)],
+                "product_ids": [(4, self.product.id)],
+            }
+        )
+        inventory.action_start()
+        inv_line = inventory.line_ids.filtered(
+            lambda l: l.location_id == self.location_fl1
+        )
+        inv_line[0].product_qty = inv_line[0].product_qty + 1000
+        inventory.action_validate()
+        self.assertEqual(
+            self._get_positive_quantity(self.location_fl1, self.product), 8000
+        )
+
+        # Sale 3: 600 L of X1, reserved then unreserved
+        sale_picking_3 = self._create_sale_picking(
+            self.location_fl1,
+            self.product,
+            "Sale 3 - X1 600L",
+            600,
+            unreserve=True,
+        )
+        self.assertEqual(sale_picking_3.state, "confirmed")
+
+        # Verify no reserved quantities remain at FL1
+        quants = self._get_location_quants(self.location_fl1, self.product)
+        self.assertFalse(any(q.reserved_quantity > 0 for q in quants))
+        self.assertFalse(self.location_fl1.flowable_blocked)
+
+        # ACT
+        lot_p1 = self.env["stock.production.lot"].create(
+            {
+                "name": "P1",
+                "product_id": self.product.id,
+            }
+        )
+        self._receive_stock(self.location_fl1, self.product, lot_p1, 5000)
+
+        # ASSERT
+        production = self._find_flowable_production(self.location_fl1)
+        self.assertTrue(production, "A mixing MO should have been created")
+        self.assertTrue(
+            self.location_fl1.flowable_blocked,
+            "FL1 should be blocked after reception triggers a mixing MO",
+        )

--- a/stock_location_flowable/tests/test_mrp_production.py
+++ b/stock_location_flowable/tests/test_mrp_production.py
@@ -5,7 +5,6 @@
 import logging
 
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import common
 from odoo.tools import float_compare, float_round
 
 from .test_common import TestCommon
@@ -45,71 +44,6 @@ class TestMrpProduction(TestCommon):
         msg_error = self.get_error_message_regex(msg_error)
         self.assertRegex(error.exception.args[0], msg_error)
 
-    def _create_flowable_picking_and_validate(self, location, product, lot, qty):
-        """Helper to create and validate an incoming picking to a flowable location."""
-        return self._receive_stock_at_location(location, product, lot, qty)
-
-    def _receive_stock_at_location(
-        self, location, product, lot, qty, picking_type=None
-    ):
-        """Helper to create and validate an incoming picking to any location."""
-        if picking_type is None:
-            picking_type = self.picking_type_incoming_1
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": picking_type.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": location.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": qty,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": location.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
-        return picking
-
-    def _find_flowable_production(self, location):
-        """Helper to find the latest flowable MO for a location."""
-        return self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", location.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
-
-    def _get_location_quants(self, location, product):
-        """Helper to get all quants at a location for a product."""
-        return self.env["stock.quant"].search(
-            [
-                ("location_id", "=", location.id),
-                ("product_id", "=", product.id),
-            ]
-        )
-
-    def _seed_flowable_location(self, location, product, lot, qty):
-        """Receive initial stock at a flowable location and complete the resulting MO.
-
-        This simulates how a user would put initial stock into a flowable
-        location: receiving via an incoming picking, which triggers the
-        creation of a mixing MO, and then completing that MO so the
-        location is unblocked and ready for the actual test.
-        """
-        self._receive_stock_at_location(location, product, lot, qty)
-        production = self._find_flowable_production(location)
-        if production:
-            production.button_mark_done()
-
     def test_flowable_mixing_produces_single_positive_quant(self):
         """
         Test that after completing a mixing MO, the flowable location has
@@ -123,25 +57,15 @@ class TestMrpProduction(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_initial = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-INITIAL-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_initial = self._create_lot(self.product_flowable_1, "TEST-INITIAL-LOT")
         self._seed_flowable_location(
             self.location_flowable_1, self.product_flowable_1, lot_initial, 100
         )
 
-        lot_new = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-NEW-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_new = self._create_lot(self.product_flowable_1, "TEST-NEW-LOT")
 
         # ACT
-        self._create_flowable_picking_and_validate(
+        self._receive_stock(
             self.location_flowable_1, self.product_flowable_1, lot_new, 50
         )
         production = self._find_flowable_production(self.location_flowable_1)
@@ -173,15 +97,10 @@ class TestMrpProduction(TestCommon):
         quantities = [50, 30, 45, 25, 20]
 
         for i, qty in enumerate(quantities):
-            lot = self.env["stock.production.lot"].create(
-                {
-                    "name": f"TEST-MULTI-LOT-{i}",
-                    "product_id": self.product_flowable_1.id,
-                }
-            )
+            lot = self._create_lot(self.product_flowable_1, f"TEST-MULTI-LOT-{i}")
 
             # ACT
-            self._create_flowable_picking_and_validate(
+            self._receive_stock(
                 self.location_flowable_1, self.product_flowable_1, lot, qty
             )
             production = self._find_flowable_production(self.location_flowable_1)
@@ -216,25 +135,15 @@ class TestMrpProduction(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_initial = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-EXACT-ZERO-OLD",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_initial = self._create_lot(self.product_flowable_1, "TEST-EXACT-ZERO-OLD")
         self._seed_flowable_location(
             self.location_flowable_1, self.product_flowable_1, lot_initial, 100
         )
 
-        lot_new = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-EXACT-ZERO-NEW",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_new = self._create_lot(self.product_flowable_1, "TEST-EXACT-ZERO-NEW")
 
         # ACT
-        self._create_flowable_picking_and_validate(
+        self._receive_stock(
             self.location_flowable_1, self.product_flowable_1, lot_new, 50
         )
         production = self._find_flowable_production(self.location_flowable_1)
@@ -268,25 +177,15 @@ class TestMrpProduction(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_initial = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-FRAC-INITIAL",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_initial = self._create_lot(self.product_flowable_1, "TEST-FRAC-INITIAL")
         self._seed_flowable_location(
             self.location_flowable_1, self.product_flowable_1, lot_initial, 33.333
         )
 
-        lot_new = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-FRAC-NEW",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_new = self._create_lot(self.product_flowable_1, "TEST-FRAC-NEW")
 
         # ACT
-        self._create_flowable_picking_and_validate(
+        self._receive_stock(
             self.location_flowable_1, self.product_flowable_1, lot_new, 16.667
         )
         production = self._find_flowable_production(self.location_flowable_1)
@@ -312,36 +211,19 @@ class TestMrpProduction(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_initial = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-NONFLO-INITIAL",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_initial = self._create_lot(self.product_flowable_1, "TEST-NONFLO-INITIAL")
         self._seed_flowable_location(
             self.location_flowable_1, self.product_flowable_1, lot_initial, 100
         )
 
         # Stock at non-flowable location
-        lot_other = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-NONFLO-OTHER",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
-        self._receive_stock_at_location(
-            self.location_1, self.product_flowable_1, lot_other, 200
-        )
+        lot_other = self._create_lot(self.product_flowable_1, "TEST-NONFLO-OTHER")
+        self._receive_stock(self.location_1, self.product_flowable_1, lot_other, 200)
 
-        lot_new = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-NONFLO-NEW",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_new = self._create_lot(self.product_flowable_1, "TEST-NONFLO-NEW")
 
         # ACT
-        self._create_flowable_picking_and_validate(
+        self._receive_stock(
             self.location_flowable_1, self.product_flowable_1, lot_new, 50
         )
         production = self._find_flowable_production(self.location_flowable_1)
@@ -375,25 +257,15 @@ class TestMrpProduction(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         rounding = self.product_flowable_1.uom_id.rounding
 
-        lot_initial = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-ROUND-INITIAL",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_initial = self._create_lot(self.product_flowable_1, "TEST-ROUND-INITIAL")
         self._seed_flowable_location(
             self.location_flowable_1, self.product_flowable_1, lot_initial, 100
         )
 
-        lot_new = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-ROUND-NEW",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_new = self._create_lot(self.product_flowable_1, "TEST-ROUND-NEW")
 
         # ACT
-        self._create_flowable_picking_and_validate(
+        self._receive_stock(
             self.location_flowable_1, self.product_flowable_1, lot_new, 50
         )
         production = self._find_flowable_production(self.location_flowable_1)
@@ -473,12 +345,7 @@ class TestMrpProduction(TestCommon):
             kg_delivery_1 / 1.141, precision_rounding=rounding
         )  # 576.626
 
-        lot_initial = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-O2-INITIAL",
-                "product_id": product_o2.id,
-            }
-        )
+        lot_initial = self._create_lot(product_o2, "TEST-O2-INITIAL")
         self.picking_type_mrp_operation_1.flowable_operation = True
 
         self._seed_flowable_location(
@@ -491,18 +358,13 @@ class TestMrpProduction(TestCommon):
             kg_delivery_2 / 1.141, precision_rounding=rounding
         )  # 511.139
 
-        lot_new = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-O2-NEW",
-                "product_id": product_o2.id,
-            }
-        )
+        lot_new = self._create_lot(product_o2, "TEST-O2-NEW")
 
         # ACT: Receive at the cistern
         picking = self.env["stock.picking"].create(
             {
                 "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": location_cistern.id,
             }
         )
@@ -513,7 +375,7 @@ class TestMrpProduction(TestCommon):
                 "product_uom_id": uom_litro_o2.id,
                 "lot_id": lot_new.id,
                 "qty_done": litres_2,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": location_cistern.id,
                 "company_id": self.env.company.id,
             }
@@ -521,14 +383,7 @@ class TestMrpProduction(TestCommon):
         picking.button_validate()
 
         # Find and complete the mixing MO
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", location_cistern.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
+        production = self._find_flowable_production(location_cistern)
         self.assertTrue(production, "Mixing MO should have been created")
         production.button_mark_done()
 
@@ -622,17 +477,12 @@ class TestMrpProduction(TestCommon):
         for i, kg in enumerate(kg_deliveries):
             litres = float_round(kg / 1.141, precision_rounding=rounding)
 
-            lot = self.env["stock.production.lot"].create(
-                {
-                    "name": f"TEST-O2-MULTI-{i}",
-                    "product_id": product_o2.id,
-                }
-            )
+            lot = self._create_lot(product_o2, f"TEST-O2-MULTI-{i}")
 
             picking = self.env["stock.picking"].create(
                 {
                     "picking_type_id": self.picking_type_incoming_1.id,
-                    "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                    "location_id": self.supplier_location.id,
                     "location_dest_id": location_cistern.id,
                 }
             )
@@ -643,25 +493,14 @@ class TestMrpProduction(TestCommon):
                     "product_uom_id": uom_litro_o2.id,
                     "lot_id": lot.id,
                     "qty_done": litres,
-                    "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                    "location_id": self.supplier_location.id,
                     "location_dest_id": location_cistern.id,
                     "company_id": self.env.company.id,
                 }
             )
             picking.button_validate()
 
-            production = self.env["mrp.production"].search(
-                [
-                    (
-                        "picking_type_id",
-                        "=",
-                        self.picking_type_mrp_operation_1.id,
-                    ),
-                    ("location_dest_id", "=", location_cistern.id),
-                ],
-                order="id desc",
-                limit=1,
-            )
+            production = self._find_flowable_production(location_cistern)
             self.assertTrue(
                 production, f"Mixing MO should be created on delivery {i + 1}"
             )
@@ -832,32 +671,10 @@ class TestMrpProduction(TestCommon):
         self.assertTrue(production)
 
 
-class TestFlowableBlockingWithReservations(common.SavepointCase):
+class TestFlowableBlockingWithReservations(TestCommon):
     @classmethod
     def setUpClass(cls):
         super(TestFlowableBlockingWithReservations, cls).setUpClass()
-
-        cls.picking_type_incoming = cls.env["stock.picking.type"].create(
-            {
-                "name": "TestReceipt",
-                "sequence_code": "SEQ-TEST-IN",
-                "code": "incoming",
-                "default_location_dest_id": cls.env.ref(
-                    "stock.stock_location_locations_partner"
-                ).id,
-            }
-        )
-
-        cls.picking_type_outgoing = cls.env["stock.picking.type"].create(
-            {
-                "name": "TestDelivery",
-                "sequence_code": "SEQ-TEST-OUT",
-                "code": "outgoing",
-                "default_location_src_id": cls.env.ref(
-                    "stock.stock_location_locations_partner"
-                ).id,
-            }
-        )
 
         cls.picking_type_mrp = cls.env["stock.picking.type"].create(
             {
@@ -865,16 +682,6 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
                 "sequence_code": "SEQ-TEST-MRP",
                 "code": "mrp_operation",
                 "flowable_operation": True,
-            }
-        )
-
-        cls.product = cls.env["product.product"].create(
-            {
-                "name": "TestOxygen",
-                "type": "product",
-                "uom_id": cls.env.ref("uom.product_uom_litre").id,
-                "uom_po_id": cls.env.ref("uom.product_uom_litre").id,
-                "tracking": "lot",
             }
         )
 
@@ -886,63 +693,9 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
                 "flowable_storage": True,
                 "flowable_capacity": 15000,
                 "flowable_uom_id": cls.env.ref("uom.product_uom_litre").id,
-                "flowable_allowed_product_ids": [(4, cls.product.id)],
+                "flowable_allowed_product_ids": [(4, cls.product_flowable_1.id)],
             }
         )
-
-        cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
-        cls.customer_location = cls.env.ref("stock.stock_location_customers")
-
-    def _receive_stock(self, location, product, lot, qty):
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming.id,
-                "location_id": self.supplier_location.id,
-                "location_dest_id": location.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": qty,
-                "location_id": self.supplier_location.id,
-                "location_dest_id": location.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
-        return picking
-
-    def _find_flowable_production(self, location):
-        return self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp.id),
-                ("location_dest_id", "=", location.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
-
-    def _get_location_quants(self, location, product):
-        return self.env["stock.quant"].search(
-            [
-                ("location_id", "=", location.id),
-                ("product_id", "=", product.id),
-            ]
-        )
-
-    def _get_positive_quantity(self, location, product):
-        quants = self._get_location_quants(location, product)
-        return sum(quants.filtered(lambda q: q.quantity > 0).mapped("quantity"))
-
-    def _seed_flowable_location(self, location, product, lot, qty):
-        self._receive_stock(location, product, lot, qty)
-        production = self._find_flowable_production(location)
-        if production:
-            production.button_mark_done()
 
     def _create_sale_picking(
         self,
@@ -953,11 +706,12 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
         reserve=True,
         unreserve=False,
     ):
+        customer_location = self.env.ref("stock.stock_location_customers")
         picking = self.env["stock.picking"].create(
             {
-                "picking_type_id": self.picking_type_outgoing.id,
+                "picking_type_id": self.picking_type_outgoing_1.id,
                 "location_id": location.id,
-                "location_dest_id": self.customer_location.id,
+                "location_dest_id": customer_location.id,
             }
         )
         self.env["stock.move"].create(
@@ -968,7 +722,7 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
                 "product_uom": product.uom_id.id,
                 "product_uom_qty": qty,
                 "location_id": location.id,
-                "location_dest_id": self.customer_location.id,
+                "location_dest_id": customer_location.id,
             }
         )
         picking.action_confirm()
@@ -999,28 +753,30 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
                   (the only ones with active reservations)
         """
         # ARRANGE
-        lot_x1 = self.env["stock.production.lot"].create(
-            {
-                "name": "X1",
-                "product_id": self.product.id,
-            }
+        lot_x1 = self._create_lot(self.product_flowable_1, "X1")
+        self._seed_flowable_location(
+            self.location_fl1,
+            self.product_flowable_1,
+            lot_x1,
+            7000,
+            mrp_picking_type=self.picking_type_mrp,
         )
-        self._seed_flowable_location(self.location_fl1, self.product, lot_x1, 7000)
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product), 7000
+            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            7000,
         )
         self.assertFalse(self.location_fl1.flowable_blocked)
 
         # Sale 1: 100 L of X1, confirmed + reserved (assigned)
         sale_picking_1 = self._create_sale_picking(
-            self.location_fl1, self.product, "Sale 1 - X1 100L", 100
+            self.location_fl1, self.product_flowable_1, "Sale 1 - X1 100L", 100
         )
         self.assertEqual(sale_picking_1.state, "assigned")
 
         # Sale 2: 200 L of X1, confirmed only (not reserved)
         sale_picking_2 = self._create_sale_picking(
             self.location_fl1,
-            self.product,
+            self.product_flowable_1,
             "Sale 2 - X1 200L",
             200,
             reserve=False,
@@ -1032,7 +788,7 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
             {
                 "name": "Adjust +1000L on X1",
                 "location_ids": [(4, self.location_fl1.id)],
-                "product_ids": [(4, self.product.id)],
+                "product_ids": [(4, self.product_flowable_1.id)],
             }
         )
         inventory.action_start()
@@ -1042,25 +798,23 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
         inv_line[0].product_qty = inv_line[0].product_qty + 1000
         inventory.action_validate()
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product), 8000
+            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            8000,
         )
 
         # Sale 3: 600 L of X1, confirmed + reserved (assigned)
         sale_picking_3 = self._create_sale_picking(
-            self.location_fl1, self.product, "Sale 3 - X1 600L", 600
+            self.location_fl1, self.product_flowable_1, "Sale 3 - X1 600L", 600
         )
         self.assertEqual(sale_picking_3.state, "assigned")
         self.assertFalse(self.location_fl1.flowable_blocked)
 
         # ACT
-        lot_p1 = self.env["stock.production.lot"].create(
-            {
-                "name": "P1",
-                "product_id": self.product.id,
-            }
-        )
+        lot_p1 = self._create_lot(self.product_flowable_1, "P1")
         with self.assertRaises(UserError) as error:
-            self._receive_stock(self.location_fl1, self.product, lot_p1, 5000)
+            self._receive_stock(
+                self.location_fl1, self.product_flowable_1, lot_p1, 5000
+            )
 
         # ASSERT
         # Only Sales 1 and 3 appear in the error (the ones with active
@@ -1073,10 +827,10 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
             " become invalid.\n\n"
             "The following operations must be unreserved"
             " or completed first:\n\n"
-            "  - TestOxygen: 100.0 L (lot X1)"
-            " - %s (TestDelivery)\n"
-            "  - TestOxygen: 600.0 L (lot X1)"
-            " - %s (TestDelivery)"
+            "  - ProductFlowable1: 100.0 L (lot X1)"
+            " - %s (Delivery1)\n"
+            "  - ProductFlowable1: 600.0 L (lot X1)"
+            " - %s (Delivery1)"
         ) % (sale_picking_1.name, sale_picking_3.name)
         self.assertEqual(str(error.exception), expected_msg)
 
@@ -1100,22 +854,24 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
                 - A mixing MO is created and FL1 is blocked
         """
         # ARRANGE
-        lot_x1 = self.env["stock.production.lot"].create(
-            {
-                "name": "X1",
-                "product_id": self.product.id,
-            }
+        lot_x1 = self._create_lot(self.product_flowable_1, "X1")
+        self._seed_flowable_location(
+            self.location_fl1,
+            self.product_flowable_1,
+            lot_x1,
+            7000,
+            mrp_picking_type=self.picking_type_mrp,
         )
-        self._seed_flowable_location(self.location_fl1, self.product, lot_x1, 7000)
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product), 7000
+            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            7000,
         )
         self.assertFalse(self.location_fl1.flowable_blocked)
 
         # Sale 1: 100 L of X1, reserved then unreserved
         sale_picking_1 = self._create_sale_picking(
             self.location_fl1,
-            self.product,
+            self.product_flowable_1,
             "Sale 1 - X1 100L",
             100,
             unreserve=True,
@@ -1125,7 +881,7 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
         # Sale 2: 200 L of X1, reserved then unreserved
         sale_picking_2 = self._create_sale_picking(
             self.location_fl1,
-            self.product,
+            self.product_flowable_1,
             "Sale 2 - X1 200L",
             200,
             unreserve=True,
@@ -1137,7 +893,7 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
             {
                 "name": "Adjust +1000L on X1",
                 "location_ids": [(4, self.location_fl1.id)],
-                "product_ids": [(4, self.product.id)],
+                "product_ids": [(4, self.product_flowable_1.id)],
             }
         )
         inventory.action_start()
@@ -1147,13 +903,14 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
         inv_line[0].product_qty = inv_line[0].product_qty + 1000
         inventory.action_validate()
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product), 8000
+            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            8000,
         )
 
         # Sale 3: 600 L of X1, reserved then unreserved
         sale_picking_3 = self._create_sale_picking(
             self.location_fl1,
-            self.product,
+            self.product_flowable_1,
             "Sale 3 - X1 600L",
             600,
             unreserve=True,
@@ -1161,21 +918,18 @@ class TestFlowableBlockingWithReservations(common.SavepointCase):
         self.assertEqual(sale_picking_3.state, "confirmed")
 
         # Verify no reserved quantities remain at FL1
-        quants = self._get_location_quants(self.location_fl1, self.product)
+        quants = self._get_location_quants(self.location_fl1, self.product_flowable_1)
         self.assertFalse(any(q.reserved_quantity > 0 for q in quants))
         self.assertFalse(self.location_fl1.flowable_blocked)
 
         # ACT
-        lot_p1 = self.env["stock.production.lot"].create(
-            {
-                "name": "P1",
-                "product_id": self.product.id,
-            }
-        )
-        self._receive_stock(self.location_fl1, self.product, lot_p1, 5000)
+        lot_p1 = self._create_lot(self.product_flowable_1, "P1")
+        self._receive_stock(self.location_fl1, self.product_flowable_1, lot_p1, 5000)
 
         # ASSERT
-        production = self._find_flowable_production(self.location_fl1)
+        production = self._find_flowable_production(
+            self.location_fl1, picking_type=self.picking_type_mrp
+        )
         self.assertTrue(production, "A mixing MO should have been created")
         self.assertTrue(
             self.location_fl1.flowable_blocked,

--- a/stock_location_flowable/tests/test_mrp_production.py
+++ b/stock_location_flowable/tests/test_mrp_production.py
@@ -641,6 +641,80 @@ class TestMrpProduction(TestCommon):
         msg_error = self.get_error_message_regex(msg_error)
         self.assertRegex(error.exception.args[0], msg_error)
 
+    def test_post_production_quant_check_create_lots_false(self):
+        """
+        Test that the defensive post-production quant check passes when
+        create_lots=False (incoming lot becomes the producing lot).
+
+        PRE:    - Flowable location (create_lots=False) seeded with lot A
+        ACT:    - Receive lot B, complete the mixing MO
+        POST:   - No error is raised (all non-producing lots have 0 stock)
+                - Only the producing lot has positive stock
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_a = self._create_lot(self.product_flowable_1, "POST-CHECK-A")
+        self._seed_flowable_location(
+            self.location_flowable_1, self.product_flowable_1, lot_a, 100
+        )
+
+        lot_b = self._create_lot(self.product_flowable_1, "POST-CHECK-B")
+
+        # ACT
+        self._receive_stock(
+            self.location_flowable_1, self.product_flowable_1, lot_b, 50
+        )
+        production = self._find_flowable_production(self.location_flowable_1)
+        # button_mark_done triggers _check_flowable_post_production_quants
+        production.button_mark_done()
+
+        # ASSERT — producing lot is the incoming lot (create_lots=False)
+        self.assertEqual(production.lot_producing_id, lot_b)
+        quants = self._get_location_quants(
+            self.location_flowable_1, self.product_flowable_1
+        )
+        positive_quants = quants.filtered(lambda q: q.quantity > 0)
+        self.assertEqual(len(positive_quants), 1)
+        self.assertEqual(positive_quants.lot_id, lot_b)
+
+    def test_post_production_quant_check_create_lots_true(self):
+        """
+        Test that the defensive post-production quant check passes when
+        create_lots=True (auto-generated lot becomes the producing lot).
+
+        PRE:    - Flowable location (create_lots=True) seeded with lot A
+        ACT:    - Receive lot B, complete the mixing MO
+        POST:   - No error is raised
+                - Only the auto-generated producing lot has positive stock
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_a = self._create_lot(self.product_flowable_1, "POST-CHECK-AUTO-A")
+        self._seed_flowable_location(
+            self.location_flowable_2, self.product_flowable_1, lot_a, 100
+        )
+
+        lot_b = self._create_lot(self.product_flowable_1, "POST-CHECK-AUTO-B")
+
+        # ACT
+        self._receive_stock(
+            self.location_flowable_2, self.product_flowable_1, lot_b, 50
+        )
+        production = self._find_flowable_production(self.location_flowable_2)
+        production.button_mark_done()
+
+        # ASSERT — producing lot is auto-generated (different from both A and B)
+        self.assertNotEqual(production.lot_producing_id, lot_a)
+        self.assertNotEqual(production.lot_producing_id, lot_b)
+        quants = self._get_location_quants(
+            self.location_flowable_2, self.product_flowable_1
+        )
+        positive_quants = quants.filtered(lambda q: q.quantity > 0)
+        self.assertEqual(len(positive_quants), 1)
+        self.assertEqual(positive_quants.lot_id, production.lot_producing_id)
+
     def test_production_without_bom_allowed_for_flowable(self):
         """
         Test that a flowable production can be created without a Bill of

--- a/stock_location_flowable/tests/test_mrp_production.py
+++ b/stock_location_flowable/tests/test_mrp_production.py
@@ -671,6 +671,136 @@ class TestMrpProduction(TestCommon):
         self.assertTrue(production)
 
 
+class TestFlowableReservationConflictFromProduction(TestCommon):
+    @classmethod
+    def setUpClass(cls):
+        super(TestFlowableReservationConflictFromProduction, cls).setUpClass()
+
+        cls.picking_type_mrp = cls.env["stock.picking.type"].create(
+            {
+                "name": "TestFlowableProd",
+                "sequence_code": "SEQ-FLPROD",
+                "code": "mrp_operation",
+                "flowable_operation": True,
+            }
+        )
+
+        cls.location_fl = cls.env["stock.location"].create(
+            {
+                "name": "FLRes",
+                "usage": "internal",
+                "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
+                "flowable_storage": True,
+                "flowable_capacity": 5000,
+                "flowable_uom_id": cls.env.ref("uom.product_uom_litre").id,
+                "flowable_allowed_product_ids": [(4, cls.product_flowable_1.id)],
+            }
+        )
+
+    def test_reservation_conflict_from_production_move(self):
+        """
+        Test that receiving stock at a flowable location is rejected when
+        a regular (non-flowable) MO has reserved stock from that location.
+
+        This covers the `elif move.raw_material_production_id` branch in
+        _check_flowable_reservation (moves that belong to another MO,
+        not to a picking).
+
+        PRE:    - Flowable location FLRes with 500 L of lot A (seeded)
+                - A finished product with a BoM consuming 100 L of the
+                  flowable product
+                - A regular MO confirmed + assigned (reserves 100 L)
+        ACT:    - Receive 200 L of lot B at FLRes
+        POST:   - UserError is raised mentioning the regular MO
+        """
+        # ARRANGE — seed the flowable location
+        lot_a = self._create_lot(self.product_flowable_1, "RES-LOT-A")
+        self._seed_flowable_location(
+            self.location_fl,
+            self.product_flowable_1,
+            lot_a,
+            500,
+            mrp_picking_type=self.picking_type_mrp,
+        )
+        self.assertFalse(self.location_fl.flowable_blocked)
+
+        # Create a finished product with a BoM
+        finished_product = self.env["product.product"].create(
+            {
+                "name": "Finished Product",
+                "type": "product",
+                "uom_id": self.env.ref("uom.product_uom_unit").id,
+                "uom_po_id": self.env.ref("uom.product_uom_unit").id,
+            }
+        )
+        bom = self.env["mrp.bom"].create(
+            {
+                "product_tmpl_id": finished_product.product_tmpl_id.id,
+                "product_qty": 1,
+                "bom_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_flowable_1.id,
+                            "product_qty": 100,
+                        },
+                    )
+                ],
+            }
+        )
+
+        # Create a regular MO sourcing directly from the flowable location
+        regular_picking_type = self.env["stock.picking.type"].search(
+            [
+                ("warehouse_id", "=", self.picking_type_incoming_1.warehouse_id.id),
+                ("code", "=", "mrp_operation"),
+                ("flowable_operation", "=", False),
+            ],
+            limit=1,
+        )
+        if not regular_picking_type:
+            regular_picking_type = self.env["stock.picking.type"].create(
+                {
+                    "name": "RegularProduction",
+                    "sequence_code": "SEQ-REGPROD",
+                    "code": "mrp_operation",
+                }
+            )
+        regular_mo = self.env["mrp.production"].create(
+            {
+                "product_id": finished_product.id,
+                "bom_id": bom.id,
+                "product_qty": 1,
+                "product_uom_id": finished_product.uom_id.id,
+                "picking_type_id": regular_picking_type.id,
+                "location_src_id": self.location_fl.id,
+                "location_dest_id": self.location_fl.location_id.id,
+            }
+        )
+        # Populate raw and finished moves from the BoM
+        self.env["stock.move"].create(regular_mo._get_moves_raw_values())
+        self.env["stock.move"].create(regular_mo._get_moves_finished_values())
+        regular_mo.action_confirm()
+        regular_mo.action_assign()
+
+        # Verify the regular MO reserved stock at the flowable location
+        raw_move = regular_mo.move_raw_ids
+        self.assertGreater(
+            raw_move.reserved_availability,
+            0,
+            "Regular MO should have reserved stock from the flowable location",
+        )
+
+        # ACT — receive new stock at the flowable location
+        lot_b = self._create_lot(self.product_flowable_1, "RES-LOT-B")
+        with self.assertRaises(UserError) as error:
+            self._receive_stock(self.location_fl, self.product_flowable_1, lot_b, 200)
+
+        # ASSERT — error should mention the regular MO
+        self.assertIn(regular_mo.name, str(error.exception))
+
+
 class TestFlowableBlockingWithReservations(TestCommon):
     @classmethod
     def setUpClass(cls):

--- a/stock_location_flowable/tests/test_mrp_production.py
+++ b/stock_location_flowable/tests/test_mrp_production.py
@@ -301,10 +301,10 @@ class TestMrpProduction(TestCommon):
         dp.digits = 5
 
         # Custom UoM with fine rounding (like customer's Litro O2)
-        uom_category_o2 = self.env["uom.category"].create({"name": "Test Volumen O2"})
+        uom_category_o2 = self.env["uom.category"].create({"name": "Liquid O2"})
         uom_litro_o2 = self.env["uom.uom"].create(
             {
-                "name": "Test Litro O2",
+                "name": "Litre O2",
                 "category_id": uom_category_o2.id,
                 "uom_type": "reference",
                 "rounding": 0.001,
@@ -314,7 +314,7 @@ class TestMrpProduction(TestCommon):
 
         product_o2 = self.env["product.product"].create(
             {
-                "name": "Test Oxigeno Liquido",
+                "name": "Liquid O2",
                 "type": "product",
                 "uom_id": uom_litro_o2.id,
                 "uom_po_id": uom_litro_o2.id,
@@ -324,7 +324,7 @@ class TestMrpProduction(TestCommon):
 
         location_cistern = self.env["stock.location"].create(
             {
-                "name": "Test Cisterna O2",
+                "name": "O2 Tank 6",
                 "usage": "internal",
                 "location_id": self.env.ref(
                     "stock.stock_location_locations_partner"
@@ -432,12 +432,10 @@ class TestMrpProduction(TestCommon):
 
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        uom_category_o2 = self.env["uom.category"].create(
-            {"name": "Test Volumen O2 Multi"}
-        )
+        uom_category_o2 = self.env["uom.category"].create({"name": "Liquid O2"})
         uom_litro_o2 = self.env["uom.uom"].create(
             {
-                "name": "Test Litro O2 Multi",
+                "name": "Litre O2",
                 "category_id": uom_category_o2.id,
                 "uom_type": "reference",
                 "rounding": 0.001,
@@ -447,7 +445,7 @@ class TestMrpProduction(TestCommon):
 
         product_o2 = self.env["product.product"].create(
             {
-                "name": "Test Oxigeno Multi",
+                "name": "Liquid O2",
                 "type": "product",
                 "uom_id": uom_litro_o2.id,
                 "uom_po_id": uom_litro_o2.id,
@@ -457,7 +455,7 @@ class TestMrpProduction(TestCommon):
 
         location_cistern = self.env["stock.location"].create(
             {
-                "name": "Test Cisterna O2 Multi",
+                "name": "O2 Tank 6",
                 "usage": "internal",
                 "location_id": self.env.ref(
                     "stock.stock_location_locations_partner"
@@ -685,9 +683,9 @@ class TestFlowableReservationConflictFromProduction(TestCommon):
             }
         )
 
-        cls.location_fl = cls.env["stock.location"].create(
+        cls.location_flowable_3 = cls.env["stock.location"].create(
             {
-                "name": "FLRes",
+                "name": "O2 Tank 3",
                 "usage": "internal",
                 "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
                 "flowable_storage": True,
@@ -706,23 +704,23 @@ class TestFlowableReservationConflictFromProduction(TestCommon):
         _check_flowable_reservation (moves that belong to another MO,
         not to a picking).
 
-        PRE:    - Flowable location FLRes with 500 L of lot A (seeded)
+        PRE:    - Flowable location 'O2 Tank 3' with 500 L of lot A (seeded)
                 - A finished product with a BoM consuming 100 L of the
                   flowable product
                 - A regular MO confirmed + assigned (reserves 100 L)
-        ACT:    - Receive 200 L of lot B at FLRes
+        ACT:    - Receive 200 L of lot B at 'O2 Tank 3'
         POST:   - UserError is raised mentioning the regular MO
         """
         # ARRANGE — seed the flowable location
         lot_a = self._create_lot(self.product_flowable_1, "RES-LOT-A")
         self._seed_flowable_location(
-            self.location_fl,
+            self.location_flowable_3,
             self.product_flowable_1,
             lot_a,
             500,
             mrp_picking_type=self.picking_type_mrp,
         )
-        self.assertFalse(self.location_fl.flowable_blocked)
+        self.assertFalse(self.location_flowable_3.flowable_blocked)
 
         # Create a finished product with a BoM
         finished_product = self.env["product.product"].create(
@@ -774,8 +772,8 @@ class TestFlowableReservationConflictFromProduction(TestCommon):
                 "product_qty": 1,
                 "product_uom_id": finished_product.uom_id.id,
                 "picking_type_id": regular_picking_type.id,
-                "location_src_id": self.location_fl.id,
-                "location_dest_id": self.location_fl.location_id.id,
+                "location_src_id": self.location_flowable_3.id,
+                "location_dest_id": self.location_flowable_3.location_id.id,
             }
         )
         # Populate raw and finished moves from the BoM
@@ -795,7 +793,9 @@ class TestFlowableReservationConflictFromProduction(TestCommon):
         # ACT — receive new stock at the flowable location
         lot_b = self._create_lot(self.product_flowable_1, "RES-LOT-B")
         with self.assertRaises(UserError) as error:
-            self._receive_stock(self.location_fl, self.product_flowable_1, lot_b, 200)
+            self._receive_stock(
+                self.location_flowable_3, self.product_flowable_1, lot_b, 200
+            )
 
         # ASSERT — error should mention the regular MO
         self.assertIn(regular_mo.name, str(error.exception))
@@ -815,9 +815,9 @@ class TestFlowableBlockingWithReservations(TestCommon):
             }
         )
 
-        cls.location_fl1 = cls.env["stock.location"].create(
+        cls.location_flowable_4 = cls.env["stock.location"].create(
             {
-                "name": "FL1",
+                "name": "O2 Tank 4",
                 "usage": "internal",
                 "location_id": cls.env.ref("stock.stock_location_locations_partner").id,
                 "flowable_storage": True,
@@ -872,40 +872,42 @@ class TestFlowableBlockingWithReservations(TestCommon):
         confirmed (not reserved). The mixing MO cannot fully reserve
         because Sales 1 and 3 hold reservations on the stock.
 
-        PRE:    - Flowable location FL1 (capacity 15000 L), initially empty
+        PRE:    - Flowable location 'O2 Tank 4' (capacity 15000 L), initially empty
                 - Receive 7000 L of lot X1 via reception + MO (seed)
                 - Sale 1: 100 L of X1 confirmed + reserved (assigned)
                 - Sale 2: 200 L of X1 confirmed only (not reserved)
                 - Inventory adjustment: +1000 L on lot X1
                 - Sale 3: 600 L of X1 confirmed + reserved (assigned)
-        ACT:    - Receive 5000 L of lot P1 at FL1
+        ACT:    - Receive 5000 L of lot P1 at 'O2 Tank 4'
         POST:   - UserError is raised mentioning Sales 1 and 3
                   (the only ones with active reservations)
         """
         # ARRANGE
         lot_x1 = self._create_lot(self.product_flowable_1, "X1")
         self._seed_flowable_location(
-            self.location_fl1,
+            self.location_flowable_4,
             self.product_flowable_1,
             lot_x1,
             7000,
             mrp_picking_type=self.picking_type_mrp,
         )
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            self._get_positive_quantity(
+                self.location_flowable_4, self.product_flowable_1
+            ),
             7000,
         )
-        self.assertFalse(self.location_fl1.flowable_blocked)
+        self.assertFalse(self.location_flowable_4.flowable_blocked)
 
         # Sale 1: 100 L of X1, confirmed + reserved (assigned)
         sale_picking_1 = self._create_sale_picking(
-            self.location_fl1, self.product_flowable_1, "Sale 1 - X1 100L", 100
+            self.location_flowable_4, self.product_flowable_1, "Sale 1 - X1 100L", 100
         )
         self.assertEqual(sale_picking_1.state, "assigned")
 
         # Sale 2: 200 L of X1, confirmed only (not reserved)
         sale_picking_2 = self._create_sale_picking(
-            self.location_fl1,
+            self.location_flowable_4,
             self.product_flowable_1,
             "Sale 2 - X1 200L",
             200,
@@ -917,49 +919,51 @@ class TestFlowableBlockingWithReservations(TestCommon):
         inventory = self.env["stock.inventory"].create(
             {
                 "name": "Adjust +1000L on X1",
-                "location_ids": [(4, self.location_fl1.id)],
+                "location_ids": [(4, self.location_flowable_4.id)],
                 "product_ids": [(4, self.product_flowable_1.id)],
             }
         )
         inventory.action_start()
         inv_line = inventory.line_ids.filtered(
-            lambda l: l.location_id == self.location_fl1
+            lambda l: l.location_id == self.location_flowable_4
         )
         inv_line[0].product_qty = inv_line[0].product_qty + 1000
         inventory.action_validate()
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            self._get_positive_quantity(
+                self.location_flowable_4, self.product_flowable_1
+            ),
             8000,
         )
 
         # Sale 3: 600 L of X1, confirmed + reserved (assigned)
         sale_picking_3 = self._create_sale_picking(
-            self.location_fl1, self.product_flowable_1, "Sale 3 - X1 600L", 600
+            self.location_flowable_4, self.product_flowable_1, "Sale 3 - X1 600L", 600
         )
         self.assertEqual(sale_picking_3.state, "assigned")
-        self.assertFalse(self.location_fl1.flowable_blocked)
+        self.assertFalse(self.location_flowable_4.flowable_blocked)
 
         # ACT
         lot_p1 = self._create_lot(self.product_flowable_1, "P1")
         with self.assertRaises(UserError) as error:
             self._receive_stock(
-                self.location_fl1, self.product_flowable_1, lot_p1, 5000
+                self.location_flowable_4, self.product_flowable_1, lot_p1, 5000
             )
 
         # ASSERT
         # Only Sales 1 and 3 appear in the error (the ones with active
         # reservations). Sale 2 is only confirmed, not reserved.
         expected_msg = (
-            "Cannot merge at flowable location 'FL1'"
+            "Cannot merge at flowable location 'O2 Tank 4'"
             " because there are reserved quantities."
             " After the merge, the current lot(s) will"
             " have 0 stock and these reservations will"
             " become invalid.\n\n"
             "The following operations must be unreserved"
             " or completed first:\n\n"
-            "  - ProductFlowable1: 100.0 L (lot X1)"
+            "  - Liquid O2: 100.0 L (lot X1)"
             " - %s (Delivery1)\n"
-            "  - ProductFlowable1: 600.0 L (lot X1)"
+            "  - Liquid O2: 600.0 L (lot X1)"
             " - %s (Delivery1)"
         ) % (sale_picking_1.name, sale_picking_3.name)
         self.assertEqual(str(error.exception), expected_msg)
@@ -973,34 +977,36 @@ class TestFlowableBlockingWithReservations(TestCommon):
         unreserved sales stay confirmed. The mixing MO fully reserves
         all stock and succeeds.
 
-        PRE:    - Flowable location FL1 (capacity 15000 L), initially empty
+        PRE:    - Flowable location 'O2 Tank 4' (capacity 15000 L), initially empty
                 - Receive 7000 L of lot X1 via reception + MO (seed)
                 - Sale 1: 100 L of X1 reserved then unreserved
                 - Sale 2: 200 L of X1 reserved then unreserved
                 - Inventory adjustment: +1000 L on lot X1
                 - Sale 3: 600 L of X1 reserved then unreserved
-        ACT:    - Receive 5000 L of lot P1 at FL1
+        ACT:    - Receive 5000 L of lot P1 at 'O2 Tank 4'
         POST:   - No error is raised
-                - A mixing MO is created and FL1 is blocked
+                - A mixing MO is created and 'O2 Tank 4' is blocked
         """
         # ARRANGE
         lot_x1 = self._create_lot(self.product_flowable_1, "X1")
         self._seed_flowable_location(
-            self.location_fl1,
+            self.location_flowable_4,
             self.product_flowable_1,
             lot_x1,
             7000,
             mrp_picking_type=self.picking_type_mrp,
         )
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            self._get_positive_quantity(
+                self.location_flowable_4, self.product_flowable_1
+            ),
             7000,
         )
-        self.assertFalse(self.location_fl1.flowable_blocked)
+        self.assertFalse(self.location_flowable_4.flowable_blocked)
 
         # Sale 1: 100 L of X1, reserved then unreserved
         sale_picking_1 = self._create_sale_picking(
-            self.location_fl1,
+            self.location_flowable_4,
             self.product_flowable_1,
             "Sale 1 - X1 100L",
             100,
@@ -1010,7 +1016,7 @@ class TestFlowableBlockingWithReservations(TestCommon):
 
         # Sale 2: 200 L of X1, reserved then unreserved
         sale_picking_2 = self._create_sale_picking(
-            self.location_fl1,
+            self.location_flowable_4,
             self.product_flowable_1,
             "Sale 2 - X1 200L",
             200,
@@ -1022,24 +1028,26 @@ class TestFlowableBlockingWithReservations(TestCommon):
         inventory = self.env["stock.inventory"].create(
             {
                 "name": "Adjust +1000L on X1",
-                "location_ids": [(4, self.location_fl1.id)],
+                "location_ids": [(4, self.location_flowable_4.id)],
                 "product_ids": [(4, self.product_flowable_1.id)],
             }
         )
         inventory.action_start()
         inv_line = inventory.line_ids.filtered(
-            lambda l: l.location_id == self.location_fl1
+            lambda l: l.location_id == self.location_flowable_4
         )
         inv_line[0].product_qty = inv_line[0].product_qty + 1000
         inventory.action_validate()
         self.assertEqual(
-            self._get_positive_quantity(self.location_fl1, self.product_flowable_1),
+            self._get_positive_quantity(
+                self.location_flowable_4, self.product_flowable_1
+            ),
             8000,
         )
 
         # Sale 3: 600 L of X1, reserved then unreserved
         sale_picking_3 = self._create_sale_picking(
-            self.location_fl1,
+            self.location_flowable_4,
             self.product_flowable_1,
             "Sale 3 - X1 600L",
             600,
@@ -1047,21 +1055,25 @@ class TestFlowableBlockingWithReservations(TestCommon):
         )
         self.assertEqual(sale_picking_3.state, "confirmed")
 
-        # Verify no reserved quantities remain at FL1
-        quants = self._get_location_quants(self.location_fl1, self.product_flowable_1)
+        # Verify no reserved quantities remain at 'O2 Tank 4'
+        quants = self._get_location_quants(
+            self.location_flowable_4, self.product_flowable_1
+        )
         self.assertFalse(any(q.reserved_quantity > 0 for q in quants))
-        self.assertFalse(self.location_fl1.flowable_blocked)
+        self.assertFalse(self.location_flowable_4.flowable_blocked)
 
         # ACT
         lot_p1 = self._create_lot(self.product_flowable_1, "P1")
-        self._receive_stock(self.location_fl1, self.product_flowable_1, lot_p1, 5000)
+        self._receive_stock(
+            self.location_flowable_4, self.product_flowable_1, lot_p1, 5000
+        )
 
         # ASSERT
         production = self._find_flowable_production(
-            self.location_fl1, picking_type=self.picking_type_mrp
+            self.location_flowable_4, picking_type=self.picking_type_mrp
         )
         self.assertTrue(production, "A mixing MO should have been created")
         self.assertTrue(
-            self.location_fl1.flowable_blocked,
-            "FL1 should be blocked after reception triggers a mixing MO",
+            self.location_flowable_4.flowable_blocked,
+            "'O2 Tank 4' should be blocked after reception triggers a mixing MO",
         )

--- a/stock_location_flowable/tests/test_stock_location.py
+++ b/stock_location_flowable/tests/test_stock_location.py
@@ -650,6 +650,78 @@ class TestStockLocation(TestCommon):
         msg_error = self.get_error_message_regex(msg_error)
         self.assertRegex(error.exception.args[0], msg_error)
 
+    def test_reduce_capacity_below_occupied_via_config(self):
+        """
+        Test that reducing a flowable location's capacity below the occupied
+        amount via configuration raises a specific error about capacity
+        vs occupied.
+
+        PRE:    - A flowable location with stock (occupied ~100 L)
+        ACT:    - Try to reduce capacity to 50 (below occupied)
+        POST:   - ValidationError "Capacity must be greater than capacity
+                  occupied" is raised
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+        product = self.location_flowable_1.flowable_allowed_product_ids[0]
+
+        lot = self._create_lot(product, "TEST-CAPCFG-LOT")
+        self._seed_flowable_location(self.location_flowable_1, product, lot, 100)
+
+        # Verify occupied amount is set
+        self.location_flowable_1.invalidate_cache()
+        self.assertGreater(self.location_flowable_1.flowable_capacity_occupied, 0)
+
+        # ACT & ASSERT
+        with self.assertRaises(ValidationError) as error:
+            self.location_flowable_1.write({"flowable_capacity": 50})
+
+        msg_error = "Capacity must be greater than capacity occupied"
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
+    def test_convert_location_with_incompatible_uom_stock(self):
+        """
+        Test that enabling flowable_storage on a location that has stock
+        with a UoM different from the specified flowable_uom_id is blocked.
+
+        PRE:    - A non-flowable location with stock of a product using
+                  Litres as UoM
+        ACT:    - Try to enable flowable_storage with flowable_uom_id set
+                  to Units (different from the product's Litres)
+        POST:   - UserError about products with different units of measure
+        """
+        # ARRANGE — stock the non-flowable location with a Litres product
+        product_litre = self.env["product.product"].create(
+            {
+                "name": "Test Product Litres UoM",
+                "type": "product",
+                "uom_id": self.uom_litre.id,
+                "uom_po_id": self.uom_litre.id,
+                "tracking": "lot",
+            }
+        )
+        lot = self._create_lot(product_litre, "INCOMPAT-UOM-LOT")
+        self._create_inventory_adjustment(self.location_1, product_litre, lot, 50)
+
+        # ACT & ASSERT — try to enable flowable with Units UoM
+        with self.assertRaises(UserError) as error:
+            self.location_1.write(
+                {
+                    "flowable_storage": True,
+                    "flowable_capacity": 1000,
+                    "flowable_uom_id": self.uom_unit.id,
+                    "flowable_allowed_product_ids": [(4, product_litre.id)],
+                }
+            )
+
+        msg_error = (
+            "You cannot convert this location into a flowable location"
+            " because there are products with different units of measure."
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
     def test_capacity_occupied_zero_for_non_flowable_location(self):
         """
         Test that a non-flowable location always has

--- a/stock_location_flowable/tests/test_stock_location.py
+++ b/stock_location_flowable/tests/test_stock_location.py
@@ -19,7 +19,7 @@ class TestStockLocation(TestCommon):
         cls.uom_unit = cls.env.ref("uom.product_uom_unit")
         cls.product_flowable_1 = cls.env["product.product"].create(
             {
-                "name": "Test CO2 1",
+                "name": "Liquid CO2",
                 "type": "product",
                 "uom_id": cls.uom_litre.id,
                 "uom_po_id": cls.uom_litre.id,
@@ -27,13 +27,13 @@ class TestStockLocation(TestCommon):
         )
         cls.warehouse_bcn = cls.env["stock.warehouse"].create(
             {
-                "name": "Test Barcelona",
+                "name": "Warehouse Barcelona",
                 "code": "BCN",
             }
         )
         cls.location_flowable_bcn_1 = cls.env["stock.location"].create(
             {
-                "name": "Test Flowable bcn 1",
+                "name": "O2 Tank 5",
                 "location_id": cls.warehouse_bcn.lot_stock_id.id,
             }
         )
@@ -205,7 +205,7 @@ class TestStockLocation(TestCommon):
         # ARRANGE
         product_flowable_2 = self.env["product.product"].create(
             {
-                "name": "Test CO2 2",
+                "name": "CO2 Cylinder",
                 "type": "product",
                 "uom_id": self.uom_unit.id,
                 "uom_po_id": self.uom_unit.id,
@@ -250,7 +250,7 @@ class TestStockLocation(TestCommon):
         # ARRANGE
         product_flowable_2 = self.env["product.product"].create(
             {
-                "name": "Test CO2 2",
+                "name": "CO2 Cylinder",
                 "type": "product",
                 "uom_id": self.uom_unit.id,
                 "uom_po_id": self.uom_unit.id,
@@ -591,7 +591,7 @@ class TestStockLocation(TestCommon):
         # for the allowed products constraint, isolating _check_flowable_uom_id
         product_unit = self.env["product.product"].create(
             {
-                "name": "Test Product Units",
+                "name": "Ar Cylinder",
                 "type": "product",
                 "uom_id": self.uom_unit.id,
                 "uom_po_id": self.uom_unit.id,
@@ -694,7 +694,7 @@ class TestStockLocation(TestCommon):
         # ARRANGE — stock the non-flowable location with a Litres product
         product_litre = self.env["product.product"].create(
             {
-                "name": "Test Product Litres UoM",
+                "name": "Liquid Ar",
                 "type": "product",
                 "uom_id": self.uom_litre.id,
                 "uom_po_id": self.uom_litre.id,

--- a/stock_location_flowable/tests/test_stock_location.py
+++ b/stock_location_flowable/tests/test_stock_location.py
@@ -387,43 +387,11 @@ class TestStockLocation(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-CAP-LOT",
-                "product_id": product.id,
-            }
-        )
-
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 100,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
+        lot = self._create_lot(product, "TEST-CAP-LOT")
+        self._receive_stock(self.location_flowable_1, product, lot, 100)
 
         # ACT
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_1.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
+        production = self._find_flowable_production(self.location_flowable_1)
         production.button_mark_done()
 
         # ASSERT
@@ -536,42 +504,8 @@ class TestStockLocation(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-REMOVE-LOT",
-                "product_id": product.id,
-            }
-        )
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 50,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
-
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_1.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
-        production.button_mark_done()
+        lot = self._create_lot(product, "TEST-REMOVE-LOT")
+        self._seed_flowable_location(self.location_flowable_1, product, lot, 50)
 
         # ACT & ASSERT
         with self.assertRaises(UserError) as error:
@@ -604,27 +538,9 @@ class TestStockLocation(TestCommon):
         self.location_flowable_1.write({"flowable_capacity": 100})
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {"name": "TEST-FULL-LOT", "product_id": product.id}
-        )
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 101,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
+        lot = self._create_lot(product, "TEST-FULL-LOT")
+        picking = self._create_incoming_picking(
+            self.location_flowable_1, product, lot, 101
         )
 
         # ACT & ASSERT
@@ -648,39 +564,8 @@ class TestStockLocation(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {"name": "TEST-REDUCECAP-LOT", "product_id": product.id}
-        )
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 100,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
-
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_1.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
-        production.button_mark_done()
+        lot = self._create_lot(product, "TEST-REDUCECAP-LOT")
+        self._seed_flowable_location(self.location_flowable_1, product, lot, 100)
 
         # ACT & ASSERT
         with self.assertRaises(ValidationError):
@@ -699,39 +584,8 @@ class TestStockLocation(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {"name": "TEST-UOM-LOT", "product_id": product.id}
-        )
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 50,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
-
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_1.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
-        production.button_mark_done()
+        lot = self._create_lot(product, "TEST-UOM-LOT")
+        self._seed_flowable_location(self.location_flowable_1, product, lot, 50)
 
         # Create a new product with units UoM to make the change valid
         # for the allowed products constraint, isolating _check_flowable_uom_id
@@ -772,36 +626,11 @@ class TestStockLocation(TestCommon):
         # ARRANGE — add two lots via inventory adjustments
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {"name": "UNMIXED-LOT-1", "product_id": product.id}
-        )
-        lot_2 = self.env["stock.production.lot"].create(
-            {"name": "UNMIXED-LOT-2", "product_id": product.id}
-        )
+        lot_1 = self._create_lot(product, "UNMIXED-LOT-1")
+        lot_2 = self._create_lot(product, "UNMIXED-LOT-2")
 
-        inventory = self.env["stock.inventory"].create({"name": "Add unmixed stock"})
-        inventory.action_start()
-        self.env["stock.inventory.line"].create(
-            [
-                {
-                    "inventory_id": inventory.id,
-                    "product_id": product.id,
-                    "product_uom_id": product.uom_id.id,
-                    "location_id": self.location_1.id,
-                    "prod_lot_id": lot_1.id,
-                    "product_qty": 50,
-                },
-                {
-                    "inventory_id": inventory.id,
-                    "product_id": product.id,
-                    "product_uom_id": product.uom_id.id,
-                    "location_id": self.location_1.id,
-                    "prod_lot_id": lot_2.id,
-                    "product_qty": 30,
-                },
-            ]
-        )
-        inventory.action_validate()
+        self._create_inventory_adjustment(self.location_1, product, lot_1, 50)
+        self._create_inventory_adjustment(self.location_1, product, lot_2, 30)
 
         # ACT & ASSERT
         with self.assertRaises(UserError) as error:
@@ -833,24 +662,8 @@ class TestStockLocation(TestCommon):
         # ARRANGE — add stock via inventory adjustment
         product = self.location_flowable_1.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {"name": "NONFLO-LOT", "product_id": product.id}
-        )
-        inventory = self.env["stock.inventory"].create(
-            {"name": "Add stock to non-flowable"}
-        )
-        inventory.action_start()
-        self.env["stock.inventory.line"].create(
-            {
-                "inventory_id": inventory.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "location_id": self.location_1.id,
-                "prod_lot_id": lot.id,
-                "product_qty": 200,
-            }
-        )
-        inventory.action_validate()
+        lot = self._create_lot(product, "NONFLO-LOT")
+        self._create_inventory_adjustment(self.location_1, product, lot, 200)
 
         # ACT & ASSERT
         self.location_1.invalidate_cache()

--- a/stock_location_flowable/tests/test_stock_move.py
+++ b/stock_location_flowable/tests/test_stock_move.py
@@ -32,14 +32,7 @@ class TestStockMove(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         self.incoming_picking.button_validate()
 
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_1.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
+        production = self._find_flowable_production(self.location_flowable_1)
         self.assertTrue(production.picking_id)
         self.assertEqual(production.state, "to_close")
 

--- a/stock_location_flowable/tests/test_stock_move_line.py
+++ b/stock_location_flowable/tests/test_stock_move_line.py
@@ -55,30 +55,9 @@ class TestStockMoveLine(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_2 = self.env["stock.production.lot"].create(
-            {
-                "name": "Lot2",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
-        second_picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": second_picking.id,
-                "product_id": self.product_flowable_1.id,
-                "product_uom_id": self.product_flowable_1.uom_id.id,
-                "lot_id": lot_2.id,
-                "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
+        lot_2 = self._create_lot(self.product_flowable_1, "Lot2")
+        second_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_2, 10
         )
 
         # Block the location by validating the first reception
@@ -109,12 +88,7 @@ class TestStockMoveLine(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_2 = self.env["stock.production.lot"].create(
-            {
-                "name": "LotInternal",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_2 = self._create_lot(self.product_flowable_1, "LotInternal")
         transfer_picking = self.env["stock.picking"].create(
             {
                 "picking_type_id": self.picking_type_internal_1.id,

--- a/stock_location_flowable/tests/test_stock_move_line.py
+++ b/stock_location_flowable/tests/test_stock_move_line.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from odoo.exceptions import ValidationError
+
 from .test_common import TestCommon
 
 _logger = logging.getLogger(__name__)
@@ -32,6 +34,114 @@ class TestStockMoveLine(TestCommon):
         # ACT & ASSERT
         with self.assertRaises(Exception) as error:
             self.outgoing_picking.button_validate()
+
+        msg_error = (
+            "The location %s is blocked. Probably you need to review"
+            " the pending manufacturing orders related to this location"
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
+    def test_blocked_location_rejects_incoming_reception(self):
+        """
+        Test that a second PO reception to a blocked flowable location
+        is rejected even though the reception is not part of any MO.
+
+        PRE:    - A flowable location blocked by a production (from a first reception)
+                - A second incoming picking prepared before the location was blocked
+        ACT:    - Try to validate the second incoming picking
+        POST:   - A ValidationError is raised about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "Lot2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        second_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": second_picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_2.id,
+                "qty_done": 10,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": self.location_flowable_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # Block the location by validating the first reception
+        self.incoming_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT
+        with self.assertRaises(ValidationError) as error:
+            second_picking.button_validate()
+
+        msg_error = (
+            "The location %s is blocked. Probably you need to review"
+            " the pending manufacturing orders related to this location"
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
+    def test_blocked_location_rejects_internal_transfer(self):
+        """
+        Test that an internal transfer from a blocked flowable location
+        is rejected.
+
+        PRE:    - A flowable location blocked by a production
+                - An internal transfer prepared before the location was blocked
+        ACT:    - Try to validate the internal transfer
+        POST:   - An error is raised about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "LotInternal",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        transfer_picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_internal_1.id,
+                "location_id": self.location_flowable_1.id,
+                "location_dest_id": self.location_1.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": transfer_picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_2.id,
+                "qty_done": 5,
+                "location_id": self.location_flowable_1.id,
+                "location_dest_id": self.location_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # Block the location by validating the first reception
+        self.incoming_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT
+        with self.assertRaises(Exception) as error:
+            transfer_picking.button_validate()
 
         msg_error = (
             "The location %s is blocked. Probably you need to review"

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -802,3 +802,92 @@ class TestStockPicking(TestCommon):
         # ASSERT
         msg_error = "expected 2 positive quants but found 3"
         self.assertIn(msg_error, str(error.exception))
+
+    def test_multiple_lines_same_product_aggregated_into_one_mo(self):
+        """
+        Test that multiple move lines with the same product, lot, and
+        destination are aggregated into a single manufacturing order.
+
+        This reproduces the scenario where a PO has N lines of the same
+        product: each line creates a separate stock move on the picking,
+        but when all move lines target the same flowable tank with the same
+        lot, the flowable code must merge them into one MO.
+
+        PRE:    - A flowable location seeded with 100 L of lot A (MO completed)
+                - An incoming picking with 3 move lines of the same product,
+                  same lot B, same destination (simulating 3 PO lines)
+        ACT:    - Validate the picking
+        POST:   - Only 1 MO is created (not 3)
+                - The MO has 2 raw move lines: one for lot A (existing stock)
+                  and one for lot B (sum of the 3 reception lines)
+                - The MO quantity equals existing stock + total received
+                - The location is blocked by that single MO
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        # Seed the tank with 100 L of lot A and complete the initial MO
+        lot_a = self._create_lot(self.product_flowable_1, "TEST-AGGR-LOT-A")
+        self._seed_flowable_location(
+            self.location_flowable_1, self.product_flowable_1, lot_a, 100
+        )
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+        # Create a picking with 3 move lines of the same product, lot B, same tank
+        lot_b = self._create_lot(self.product_flowable_1, "TEST-AGGR-LOT-B")
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+
+        line_qtys = [10, 20, 30]
+        for qty in line_qtys:
+            self.env["stock.move.line"].create(
+                {
+                    "picking_id": picking.id,
+                    "product_id": self.product_flowable_1.id,
+                    "product_uom_id": self.product_flowable_1.uom_id.id,
+                    "lot_id": lot_b.id,
+                    "qty_done": qty,
+                    "location_id": self.supplier_location.id,
+                    "location_dest_id": self.location_flowable_1.id,
+                    "company_id": self.env.company.id,
+                }
+            )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT — only 1 MO created
+        productions = picking.flowable_production_ids
+        self.assertEqual(
+            len(productions),
+            1,
+            "Multiple lines of the same product/lot/dest should produce exactly 1 MO",
+        )
+
+        # The MO quantity should equal existing stock + total received
+        total_received = sum(line_qtys)
+        self.assertEqual(productions.product_qty, 100 + total_received)
+
+        # The MO raw move should have exactly 2 move lines:
+        # one for lot A (existing 100 L) and one for lot B (received 60 L)
+        raw_move_lines = productions.move_raw_ids.move_line_ids
+        self.assertEqual(
+            len(raw_move_lines),
+            2,
+            "MO should have 2 raw move lines: existing lot + received lot",
+        )
+        lot_a_line = raw_move_lines.filtered(lambda ml: ml.lot_id == lot_a)
+        lot_b_line = raw_move_lines.filtered(lambda ml: ml.lot_id == lot_b)
+        self.assertEqual(len(lot_a_line), 1)
+        self.assertEqual(len(lot_b_line), 1)
+        self.assertEqual(lot_a_line.qty_done, 100)
+        self.assertEqual(lot_b_line.qty_done, total_received)
+
+        # The location should be blocked by that MO
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        self.assertEqual(self.location_flowable_1.flowable_production_id, productions)

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -121,10 +121,12 @@ class TestStockPicking(TestCommon):
 
         # ASSERT
         msg_error = (
-            "You can only receive one product at location %s"
-            " because a manufacturing order must be generated"
-            " and the location will be blocked. Create a "
-            "partial delivery for this product %s."
+            "Cannot receive multiple product/lot combinations"
+            " (%s) at flowable location '%s' in the same"
+            " receipt. Each combination generates a separate"
+            " mixing order and the location is blocked after"
+            " the first one. Create a backorder to receive"
+            " them in separate steps."
         )
         msg_error = self.get_error_message_regex(msg_error)
         self.assertRegex(error.exception.args[0], msg_error)

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -751,3 +751,56 @@ class TestStockPicking(TestCommon):
         # ASSERT
         self.assertFalse(self.location_1.flowable_storage)
         self.assertFalse(picking.flowable_production_ids)
+
+    def test_mixing_reception_with_rounding_residual_rejected(self):
+        """
+        Test that receiving stock at a flowable location is rejected when
+        there are 3 positive quants instead of the expected 2 for a mixing
+        scenario.
+
+        This reproduces the rounding residual scenario (like the MO 00310
+        incident): a tiny residual from a previous UoM rounding issue
+        creates an extra quant, making the location state inconsistent.
+
+        PRE:    - Flowable location with lot A (100 L) from completed MO
+                - Inventory adjustment adds 0.01 L of lot B (rounding
+                  residual)
+                - Location now has 2 quants: A (100 L) + B (0.01 L)
+        ACT:    - Receive lot C (50 L) at the flowable location
+        POST:   - After _action_done, there are 3 positive quants
+                - UserError "expected 2 positive quants but found 3"
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        # Seed the flowable location with lot A
+        lot_a = self._create_lot(self.product_flowable_1, "RESIDUAL-LOT-A")
+        self._seed_flowable_location(
+            self.location_flowable_1, self.product_flowable_1, lot_a, 100
+        )
+
+        # Add a rounding residual via inventory adjustment (lot B, 0.01 L)
+        lot_b = self._create_lot(self.product_flowable_1, "RESIDUAL-LOT-B")
+        self._create_inventory_adjustment(
+            self.location_flowable_1, self.product_flowable_1, lot_b, 0.01
+        )
+
+        # Verify we have 2 positive quants now
+        quants = self._get_location_quants(
+            self.location_flowable_1, self.product_flowable_1
+        )
+        positive_quants = quants.filtered(lambda q: q.quantity > 0)
+        self.assertEqual(
+            len(positive_quants), 2, "Should have 2 quants (lot A + residual lot B)"
+        )
+
+        # ACT — receive lot C, which creates a 3rd quant
+        lot_c = self._create_lot(self.product_flowable_1, "RESIDUAL-LOT-C")
+        with self.assertRaises(UserError) as error:
+            self._receive_stock(
+                self.location_flowable_1, self.product_flowable_1, lot_c, 50
+            )
+
+        # ASSERT
+        msg_error = "expected 2 positive quants but found 3"
+        self.assertIn(msg_error, str(error.exception))

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -133,9 +133,9 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        product_zanahoria = self.env["product.product"].create(
+        product_bolts = self.env["product.product"].create(
             {
-                "name": "Zanahoria",
+                "name": "Steel Bolts",
                 "type": "product",
                 "uom_id": self.env.ref("uom.product_uom_unit").id,
                 "uom_po_id": self.env.ref("uom.product_uom_unit").id,
@@ -145,10 +145,10 @@ class TestStockPicking(TestCommon):
 
         moves1 = self.env["stock.move"].create(
             {
-                "name": product_zanahoria.name,
-                "product_id": product_zanahoria.id,
+                "name": product_bolts.name,
+                "product_id": product_bolts.id,
                 "product_uom_qty": 5,
-                "product_uom": product_zanahoria.uom_id.id,
+                "product_uom": product_bolts.uom_id.id,
                 "picking_id": self.incoming_picking.id,
                 "location_id": self.incoming_picking.location_id.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
@@ -157,14 +157,14 @@ class TestStockPicking(TestCommon):
 
         self.incoming_picking.action_confirm()
 
-        lot_zanahoria = self._create_lot(product_zanahoria, "TEST COD-0001")
+        lot_bolts = self._create_lot(product_bolts, "TEST COD-0001")
 
         self.incoming_picking.move_line_ids = self.env["stock.move.line"].create(
             {
                 "move_id": moves1.id,
-                "product_id": product_zanahoria.id,
-                "product_uom_id": product_zanahoria.uom_id.id,
-                "lot_id": lot_zanahoria.id,
+                "product_id": product_bolts.id,
+                "product_uom_id": product_bolts.uom_id.id,
+                "lot_id": lot_bolts.id,
                 "qty_done": 5,
                 "location_id": self.incoming_picking.location_id.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
@@ -184,9 +184,9 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        product_zanahoria = self.env["product.product"].create(
+        product_he = self.env["product.product"].create(
             {
-                "name": "Zanahoria",
+                "name": "Liquid He",
                 "type": "product",
                 "uom_id": self.env.ref("uom.product_uom_litre").id,
                 "uom_po_id": self.env.ref("uom.product_uom_litre").id,
@@ -194,11 +194,9 @@ class TestStockPicking(TestCommon):
             }
         )
 
-        self.location_flowable_1.flowable_allowed_product_ids = [
-            (4, product_zanahoria.id)
-        ]
+        self.location_flowable_1.flowable_allowed_product_ids = [(4, product_he.id)]
 
-        product_zanahoria.write(
+        product_he.write(
             {
                 "uom_id": self.env.ref("uom.product_uom_unit").id,
                 "uom_po_id": self.env.ref("uom.product_uom_unit").id,
@@ -207,10 +205,10 @@ class TestStockPicking(TestCommon):
 
         moves1 = self.env["stock.move"].create(
             {
-                "name": product_zanahoria.name,
-                "product_id": product_zanahoria.id,
+                "name": product_he.name,
+                "product_id": product_he.id,
                 "product_uom_qty": 5,
-                "product_uom": product_zanahoria.uom_id.id,
+                "product_uom": product_he.uom_id.id,
                 "picking_id": self.incoming_picking.id,
                 "location_id": self.incoming_picking.location_id.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
@@ -219,14 +217,14 @@ class TestStockPicking(TestCommon):
 
         self.incoming_picking.action_confirm()
 
-        lot_zanahoria = self._create_lot(product_zanahoria, "TEST COD-0001")
+        lot_he = self._create_lot(product_he, "TEST COD-0001")
 
         self.incoming_picking.move_line_ids = self.env["stock.move.line"].create(
             {
                 "move_id": moves1.id,
-                "product_id": product_zanahoria.id,
-                "product_uom_id": product_zanahoria.uom_id.id,
-                "lot_id": lot_zanahoria.id,
+                "product_id": product_he.id,
+                "product_uom_id": product_he.uom_id.id,
+                "lot_id": lot_he.id,
                 "qty_done": 5,
                 "location_id": self.incoming_picking.location_id.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
@@ -501,7 +499,7 @@ class TestStockPicking(TestCommon):
 
         product_nolot = self.env["product.product"].create(
             {
-                "name": "ProductNoLot",
+                "name": "Liquid H2",
                 "type": "product",
                 "uom_id": self.env.ref("uom.product_uom_litre").id,
                 "uom_po_id": self.env.ref("uom.product_uom_litre").id,

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -648,3 +648,266 @@ class TestStockPicking(TestCommon):
         # ASSERT
         self.assertTrue(production.lot_producing_id)
         self.assertNotEqual(production.lot_producing_id, lot)
+
+    def _create_incoming_picking(self, location, product, lot, qty):
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": location.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": product.id,
+                "product_uom_id": product.uom_id.id,
+                "lot_id": lot.id,
+                "qty_done": qty,
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": location.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        return picking
+
+    def test_reception_blocks_flowable_location(self):
+        """
+        Test that validating a reception to a flowable location blocks it
+        and creates a manufacturing order linked to the location.
+
+        PRE:    - A flowable location with no active production
+        ACT:    - Validate an incoming picking to that location
+        POST:   - The location is blocked (flowable_blocked is True)
+                - A manufacturing order is linked to the location
+                - The MO is linked back to the picking
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+        lot = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-BLOCK-LOT",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot, 10
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        production = self.location_flowable_1.flowable_production_id
+        self.assertTrue(production)
+        self.assertEqual(production.picking_id, picking)
+
+    def test_second_reception_to_blocked_location_rejected(self):
+        """
+        Test that a second reception to a blocked flowable location
+        is rejected.
+
+        PRE:    - A flowable location blocked by a first reception
+                - A second incoming picking prepared before the location
+                  was blocked
+        ACT:    - Try to validate the second incoming picking
+        POST:   - An error is raised about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-BLOCK-LOT1",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        first_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 10
+        )
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-BLOCK-LOT2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        second_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_2, 10
+        )
+
+        first_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT
+        with self.assertRaises(Exception):
+            second_picking.button_validate()
+
+    def test_reception_after_mo_completed_succeeds(self):
+        """
+        Test the full cycle: reception blocks the location, completing
+        the MO unblocks it, and a new reception succeeds.
+
+        PRE:    - A flowable location with no active production
+        ACT:    - Validate a first reception (location gets blocked)
+                - Complete the resulting MO (location gets unblocked)
+                - Validate a second reception
+        POST:   - The location is unblocked after completing the MO
+                - The second reception succeeds and creates a new MO
+                - The location is blocked again by the new MO
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-CYCLE-LOT1",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        first_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 10
+        )
+
+        # ACT 1 - First reception blocks the location
+        first_picking.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        first_production = self.location_flowable_1.flowable_production_id
+
+        # ACT 2 - Complete the MO, location gets unblocked
+        first_production.button_mark_done()
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+        # ACT 3 - Second reception succeeds and blocks again
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-CYCLE-LOT2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        second_picking = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_2, 5
+        )
+        second_picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        second_production = self.location_flowable_1.flowable_production_id
+        self.assertTrue(second_production)
+        self.assertNotEqual(first_production, second_production)
+        self.assertEqual(second_production.picking_id, second_picking)
+
+    def test_blocking_is_per_location(self):
+        """
+        Test that blocking one flowable location does not affect another.
+
+        PRE:    - Two flowable locations with no active production
+        ACT:    - Validate a reception to location 1 (blocks it)
+                - Validate a reception to location 2
+        POST:   - Location 1 is blocked
+                - Location 2 reception succeeds and blocks location 2
+                  independently
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-PERLOC-LOT1",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        picking_1 = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 10
+        )
+
+        lot_2 = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-PERLOC-LOT2",
+                "product_id": self.product_flowable_1.id,
+            }
+        )
+        picking_2 = self._create_incoming_picking(
+            self.location_flowable_2, self.product_flowable_1, lot_2, 10
+        )
+
+        # ACT
+        picking_1.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        self.assertFalse(self.location_flowable_2.flowable_blocked)
+
+        picking_2.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        self.assertTrue(self.location_flowable_2.flowable_blocked)
+        self.assertNotEqual(
+            self.location_flowable_1.flowable_production_id,
+            self.location_flowable_2.flowable_production_id,
+        )
+
+    def test_auto_lot_location_also_gets_blocked(self):
+        """
+        Test that a flowable location with flowable_create_lots=True
+        also gets blocked after a reception.
+
+        PRE:    - location_flowable_2 has flowable_create_lots=True
+        ACT:    - Validate a reception to location_flowable_2
+        POST:   - The location is blocked
+                - The MO uses an auto-generated lot (different from the
+                  incoming lot)
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+        product = self.location_flowable_2.flowable_allowed_product_ids[0]
+
+        lot = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-AUTOLOT-BLOCK",
+                "product_id": product.id,
+            }
+        )
+        picking = self._create_incoming_picking(
+            self.location_flowable_2, product, lot, 50
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_2.flowable_blocked)
+        production = self.location_flowable_2.flowable_production_id
+        self.assertTrue(production)
+        self.assertNotEqual(production.lot_producing_id, lot)
+
+    def test_non_flowable_location_not_affected(self):
+        """
+        Test that receiving stock at a non-flowable location does not
+        trigger any blocking or MO creation.
+
+        PRE:    - A regular (non-flowable) internal location
+        ACT:    - Validate an incoming picking to that location
+        POST:   - No flowable_production_id is set
+                - No MO is created for the picking
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        product = self.product_flowable_1
+        lot = self.env["stock.production.lot"].create(
+            {
+                "name": "TEST-NONFLOW-LOT",
+                "product_id": product.id,
+            }
+        )
+        picking = self._create_incoming_picking(self.location_1, product, lot, 10)
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertFalse(self.location_1.flowable_storage)
+        self.assertFalse(picking.flowable_production_ids)

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -131,6 +131,59 @@ class TestStockPicking(TestCommon):
         msg_error = self.get_error_message_regex(msg_error)
         self.assertRegex(error.exception.args[0], msg_error)
 
+    def test_same_product_different_lots_same_location_rejected(self):
+        """
+        Test that receiving the same product with different lots at
+        the same flowable location in one receipt is rejected.
+
+        PRE:    - A picking with 2 move lines of the same product but
+                  different lots, both targeting the same flowable location
+        ACT:    - Try to validate the picking
+        POST:   - UserError is raised about multiple product/lot combinations
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_a = self._create_lot(self.product_flowable_1, "TEST-DIFFLOT-A")
+        lot_b = self._create_lot(self.product_flowable_1, "TEST-DIFFLOT-B")
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+
+        for lot, qty in [(lot_a, 10), (lot_b, 20)]:
+            self.env["stock.move.line"].create(
+                {
+                    "picking_id": picking.id,
+                    "product_id": self.product_flowable_1.id,
+                    "product_uom_id": self.product_flowable_1.uom_id.id,
+                    "lot_id": lot.id,
+                    "qty_done": qty,
+                    "location_id": self.supplier_location.id,
+                    "location_dest_id": self.location_flowable_1.id,
+                    "company_id": self.env.company.id,
+                }
+            )
+
+        # ACT & ASSERT
+        with self.assertRaises(UserError) as error:
+            picking.button_validate()
+
+        msg_error = (
+            "Cannot receive multiple product/lot combinations"
+            " (%s) at flowable location '%s' in the same"
+            " receipt. Each combination generates a separate"
+            " mixing order and the location is blocked after"
+            " the first one. Create a backorder to receive"
+            " them in separate steps."
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
     def test_only_allowed_product_in_incoming_picking(self):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
@@ -893,3 +946,358 @@ class TestStockPicking(TestCommon):
         # The location should be blocked by that MO
         self.assertTrue(self.location_flowable_1.flowable_blocked)
         self.assertEqual(self.location_flowable_1.flowable_production_id, productions)
+
+    def test_backorder_cascade_three_lots(self):
+        """
+        Test the backorder cascade: 3 lots to the same flowable location,
+        processed one at a time via backorders.
+
+        PRE:    - 3 sequential receptions each with 1 lot, where each creates
+                  a backorder for the remaining
+        ACT:    - Receive lot 0, validate → MO → complete → unblocked
+                - Receive lot 1, validate → MO → complete → unblocked
+                - Receive lot 2, validate → MO → complete → unblocked
+        POST:   - 3 MOs created total, all completed, location unblocked at end
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lots = [
+            self._create_lot(self.product_flowable_1, f"CASCADE-LOT-{i}")
+            for i in range(3)
+        ]
+        qtys = [100, 200, 150]
+
+        completed_productions = self.env["mrp.production"]
+
+        for step, (lot, qty) in enumerate(zip(lots, qtys)):
+            picking = self._create_incoming_picking(
+                self.location_flowable_1, self.product_flowable_1, lot, qty
+            )
+            picking.button_validate()
+
+            production = self._find_flowable_production(self.location_flowable_1)
+            self.assertTrue(production, f"MO should be created at step {step}")
+            production.button_mark_done()
+            completed_productions |= production
+
+        # ASSERT
+        self.assertEqual(len(completed_productions), 3)
+        self.assertTrue(all(p.state == "done" for p in completed_productions))
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+    def test_backorder_remaining_lines_still_rejected(self):
+        """
+        Test that a backorder with 2 remaining flowable lines to the same
+        location is rejected by the pre-check.
+
+        PRE:    - A picking with 2 move lines of different lots, same product,
+                  same flowable location
+                - First line validated (creates backorder with 1 remaining)
+                  and MO completed
+        ACT:    - Add a second line to the backorder and try to validate both
+        POST:   - UserError about multiple product/lot combinations
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_0 = self._create_lot(self.product_flowable_1, "BKORD-LOT-0")
+        lot_1 = self._create_lot(self.product_flowable_1, "BKORD-LOT-1")
+        lot_2 = self._create_lot(self.product_flowable_1, "BKORD-LOT-2")
+
+        # First reception — seed the location
+        self._seed_flowable_location(
+            self.location_flowable_1, self.product_flowable_1, lot_0, 100
+        )
+        self.assertFalse(self.location_flowable_1.flowable_blocked)
+
+        # Create a picking with 2 move lines of different lots
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        for lot, qty in [(lot_1, 200), (lot_2, 150)]:
+            self.env["stock.move.line"].create(
+                {
+                    "picking_id": picking.id,
+                    "product_id": self.product_flowable_1.id,
+                    "product_uom_id": self.product_flowable_1.uom_id.id,
+                    "lot_id": lot.id,
+                    "qty_done": qty,
+                    "location_id": self.supplier_location.id,
+                    "location_dest_id": self.location_flowable_1.id,
+                    "company_id": self.env.company.id,
+                }
+            )
+
+        # ACT & ASSERT — pre-check rejects both lines at the same location
+        with self.assertRaises(UserError) as error:
+            picking.button_validate()
+
+        msg_error = (
+            "Cannot receive multiple product/lot combinations"
+            " (%s) at flowable location '%s' in the same"
+            " receipt."
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)
+
+    def test_backorder_validation_while_location_blocked(self):
+        """
+        Test that validating a second reception while the location is still
+        blocked by an in-progress MO is rejected.
+
+        Simulates 2 deliveries arriving at the warehouse: both pickings are
+        prepared before the first is validated. After validating the first
+        (which blocks the location), validating the second should fail.
+
+        PRE:    - Two incoming pickings prepared for the same flowable location
+        ACT:    - Validate the first picking (blocks the location)
+                - Try to validate the second picking
+        POST:   - Error about the location being blocked
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_1 = self._create_lot(self.product_flowable_1, "BLOCKED-BO-LOT-1")
+        lot_2 = self._create_lot(self.product_flowable_1, "BLOCKED-BO-LOT-2")
+
+        # Both pickings are prepared before any validation
+        picking_1 = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 100
+        )
+        picking_2 = self._create_incoming_picking(
+            self.location_flowable_1, self.product_flowable_1, lot_2, 200
+        )
+
+        # First reception — blocks the location
+        picking_1.button_validate()
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+        # ACT & ASSERT — second reception rejected while location is blocked
+        with self.assertRaises(Exception):
+            picking_2.button_validate()
+
+    def test_mixed_flowable_and_non_flowable_lines(self):
+        """
+        Test that a picking with both flowable and non-flowable destination
+        lines validates correctly: the flowable line creates an MO, the
+        non-flowable line goes through normally.
+
+        PRE:    - A picking with one line to a flowable location and another
+                  line to a non-flowable location
+        ACT:    - Validate the picking
+        POST:   - The flowable location is blocked with an MO
+                - The non-flowable location has stock (no MO)
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_flow = self._create_lot(self.product_flowable_1, "MIXED-FLOW-LOT")
+        lot_nonflow = self._create_lot(self.product_flowable_1, "MIXED-NONFLOW-LOT")
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        # Line 1 → flowable location
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_flow.id,
+                "qty_done": 50,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        # Line 2 → non-flowable location
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_nonflow.id,
+                "qty_done": 30,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        production = self._find_flowable_production(self.location_flowable_1)
+        self.assertTrue(production)
+
+        # Non-flowable location has stock, no MO
+        nonflow_quant = self.env["stock.quant"].search(
+            [
+                ("location_id", "=", self.location_1.id),
+                ("product_id", "=", self.product_flowable_1.id),
+                ("lot_id", "=", lot_nonflow.id),
+            ]
+        )
+        self.assertEqual(nonflow_quant.quantity, 30)
+
+    def test_same_product_different_lots_different_locations_succeeds(self):
+        """
+        Test that receiving the same product with different lots at different
+        flowable locations in one receipt succeeds (no conflict).
+
+        PRE:    - A picking with 2 lines: lot A → location_flowable_1,
+                  lot B → location_flowable_2
+        ACT:    - Validate the picking
+        POST:   - Both locations are blocked with separate MOs
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_a = self._create_lot(self.product_flowable_1, "DIFFLOC-LOT-A")
+        lot_b = self._create_lot(self.product_flowable_1, "DIFFLOC-LOT-B")
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        # Line 1 → location_flowable_1
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_a.id,
+                "qty_done": 50,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        # Line 2 → location_flowable_2
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_b.id,
+                "qty_done": 50,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_2.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT — both locations are blocked independently
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+        self.assertTrue(self.location_flowable_2.flowable_blocked)
+        self.assertNotEqual(
+            self.location_flowable_1.flowable_production_id,
+            self.location_flowable_2.flowable_production_id,
+        )
+
+    def test_zero_qty_done_flowable_lines_ignored(self):
+        """
+        Test that move lines with qty_done=0 at a flowable location are
+        ignored and don't create MOs or trigger conflicts.
+
+        PRE:    - A picking with 2 lines to a flowable location: one with
+                  qty_done=50 and another with qty_done=0
+        ACT:    - Validate the picking
+        POST:   - Only 1 MO is created (for the non-zero line)
+                - No pre-check error about multiple combinations
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_a = self._create_lot(self.product_flowable_1, "ZERO-QTY-LOT-A")
+        lot_b = self._create_lot(self.product_flowable_1, "ZERO-QTY-LOT-B")
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_a.id,
+                "qty_done": 50,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+        self.env["stock.move.line"].create(
+            {
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom_id": self.product_flowable_1.uom_id.id,
+                "lot_id": lot_b.id,
+                "qty_done": 0,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # ACT
+        picking.button_validate()
+
+        # ASSERT
+        productions = picking.flowable_production_ids
+        self.assertEqual(len(productions), 1)
+        self.assertTrue(self.location_flowable_1.flowable_blocked)
+
+    def test_create_lots_true_topup_same_incoming_lot(self):
+        """
+        Test top-up at a create_lots=True location where the incoming lot
+        is the same as the existing lot. The auto-generated producing lot
+        should still be different from the incoming lot.
+
+        PRE:    - Flowable location (create_lots=True) seeded with lot A
+        ACT:    - Receive lot A again (top-up with same lot)
+        POST:   - MO is created with an auto-generated producing lot
+                - The producing lot is different from lot A
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_a = self._create_lot(self.product_flowable_1, "TOPUP-SAME-LOT")
+        self._seed_flowable_location(
+            self.location_flowable_2, self.product_flowable_1, lot_a, 100
+        )
+
+        # ACT — receive lot A again at the same location
+        self._receive_stock(
+            self.location_flowable_2, self.product_flowable_1, lot_a, 50
+        )
+
+        # ASSERT
+        production = self._find_flowable_production(self.location_flowable_2)
+        self.assertTrue(production)
+        self.assertNotEqual(
+            production.lot_producing_id,
+            lot_a,
+            "Auto-generated lot should differ from the incoming lot",
+        )

--- a/stock_location_flowable/tests/test_stock_picking.py
+++ b/stock_location_flowable/tests/test_stock_picking.py
@@ -87,19 +87,9 @@ class TestStockPicking(TestCommon):
 
         self.incoming_picking.action_confirm()
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST LMP-0001",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST LMP-0001")
 
-        lot_ch4 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST LMP-0002",
-                "product_id": self.product_flowable_2.id,
-            }
-        )
+        lot_ch4 = self._create_lot(self.product_flowable_2, "TEST LMP-0002")
 
         self.incoming_picking.move_line_ids = self.env["stock.move.line"].create(
             {
@@ -167,12 +157,7 @@ class TestStockPicking(TestCommon):
 
         self.incoming_picking.action_confirm()
 
-        lot_zanahoria = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST COD-0001",
-                "product_id": product_zanahoria.id,
-            }
-        )
+        lot_zanahoria = self._create_lot(product_zanahoria, "TEST COD-0001")
 
         self.incoming_picking.move_line_ids = self.env["stock.move.line"].create(
             {
@@ -234,12 +219,7 @@ class TestStockPicking(TestCommon):
 
         self.incoming_picking.action_confirm()
 
-        lot_zanahoria = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST COD-0001",
-                "product_id": product_zanahoria.id,
-            }
-        )
+        lot_zanahoria = self._create_lot(product_zanahoria, "TEST COD-0001")
 
         self.incoming_picking.move_line_ids = self.env["stock.move.line"].create(
             {
@@ -281,12 +261,7 @@ class TestStockPicking(TestCommon):
 
         self.incoming_picking.action_confirm()
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST LMP-0001",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST LMP-0001")
 
         self.incoming_picking.move_line_ids = self.env["stock.move.line"].create(
             {
@@ -338,12 +313,7 @@ class TestStockPicking(TestCommon):
         )
         picking_type_mrp_operation_2.invalidate_cache()
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-DUP-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-DUP-LOT")
 
         self.env["stock.move.line"].create(
             {
@@ -352,7 +322,7 @@ class TestStockPicking(TestCommon):
                 "product_uom_id": self.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
                 "company_id": self.env.company.id,
             }
@@ -370,12 +340,7 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST LMP-0001",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST LMP-0001")
 
         self.env["stock.move.line"].create(
             {
@@ -384,7 +349,7 @@ class TestStockPicking(TestCommon):
                 "product_uom_id": self.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
                 "company_id": self.env.company.id,
             }
@@ -407,12 +372,7 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-ACTION-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-ACTION-LOT")
 
         self.env["stock.move.line"].create(
             {
@@ -421,7 +381,7 @@ class TestStockPicking(TestCommon):
                 "product_uom_id": self.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
                 "company_id": self.env.company.id,
             }
@@ -450,12 +410,7 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-MULTI-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-MULTI-LOT")
 
         self.env["stock.move.line"].create(
             {
@@ -464,7 +419,7 @@ class TestStockPicking(TestCommon):
                 "product_uom_id": self.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
                 "company_id": self.env.company.id,
             }
@@ -507,12 +462,7 @@ class TestStockPicking(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         self.picking_type_mrp_operation_1.sequence_id = False
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-NOSEQ-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-NOSEQ-LOT")
 
         self.env["stock.move.line"].create(
             {
@@ -521,7 +471,7 @@ class TestStockPicking(TestCommon):
                 "product_uom_id": self.product_flowable_1.uom_id.id,
                 "lot_id": lot_1.id,
                 "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.incoming_picking.location_dest_id.id,
                 "company_id": self.env.company.id,
             }
@@ -564,27 +514,9 @@ class TestStockPicking(TestCommon):
         # Change tracking after adding to allowed products (bypasses location constraint)
         product_nolot.tracking = "none"
 
-        lot = self.env["stock.production.lot"].create(
-            {"name": "TEST-NOLOT", "product_id": product_nolot.id}
-        )
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product_nolot.id,
-                "product_uom_id": product_nolot.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 10,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
+        lot = self._create_lot(product_nolot, "TEST-NOLOT")
+        picking = self._create_incoming_picking(
+            self.location_flowable_1, product_nolot, lot, 10
         )
 
         # ACT & ASSERT
@@ -610,66 +542,19 @@ class TestStockPicking(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         product = self.location_flowable_2.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {"name": "TEST-AUTOLOT", "product_id": product.id}
-        )
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_2.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 50,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_2.id,
-                "company_id": self.env.company.id,
-            }
+        lot = self._create_lot(product, "TEST-AUTOLOT")
+        picking = self._create_incoming_picking(
+            self.location_flowable_2, product, lot, 50
         )
 
         # ACT
         picking.button_validate()
 
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_2.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
+        production = self._find_flowable_production(self.location_flowable_2)
 
         # ASSERT
         self.assertTrue(production.lot_producing_id)
         self.assertNotEqual(production.lot_producing_id, lot)
-
-    def _create_incoming_picking(self, location, product, lot, qty):
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": location.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": product.id,
-                "product_uom_id": product.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": qty,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": location.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        return picking
 
     def test_reception_blocks_flowable_location(self):
         """
@@ -686,12 +571,7 @@ class TestStockPicking(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         self.assertFalse(self.location_flowable_1.flowable_blocked)
 
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-BLOCK-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot = self._create_lot(self.product_flowable_1, "TEST-BLOCK-LOT")
         picking = self._create_incoming_picking(
             self.location_flowable_1, self.product_flowable_1, lot, 10
         )
@@ -719,22 +599,12 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-BLOCK-LOT1",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-BLOCK-LOT1")
         first_picking = self._create_incoming_picking(
             self.location_flowable_1, self.product_flowable_1, lot_1, 10
         )
 
-        lot_2 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-BLOCK-LOT2",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_2 = self._create_lot(self.product_flowable_1, "TEST-BLOCK-LOT2")
         second_picking = self._create_incoming_picking(
             self.location_flowable_1, self.product_flowable_1, lot_2, 10
         )
@@ -762,12 +632,7 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-CYCLE-LOT1",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-CYCLE-LOT1")
         first_picking = self._create_incoming_picking(
             self.location_flowable_1, self.product_flowable_1, lot_1, 10
         )
@@ -782,12 +647,7 @@ class TestStockPicking(TestCommon):
         self.assertFalse(self.location_flowable_1.flowable_blocked)
 
         # ACT 3 - Second reception succeeds and blocks again
-        lot_2 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-CYCLE-LOT2",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_2 = self._create_lot(self.product_flowable_1, "TEST-CYCLE-LOT2")
         second_picking = self._create_incoming_picking(
             self.location_flowable_1, self.product_flowable_1, lot_2, 5
         )
@@ -814,22 +674,12 @@ class TestStockPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-PERLOC-LOT1",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_1 = self._create_lot(self.product_flowable_1, "TEST-PERLOC-LOT1")
         picking_1 = self._create_incoming_picking(
             self.location_flowable_1, self.product_flowable_1, lot_1, 10
         )
 
-        lot_2 = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-PERLOC-LOT2",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_2 = self._create_lot(self.product_flowable_1, "TEST-PERLOC-LOT2")
         picking_2 = self._create_incoming_picking(
             self.location_flowable_2, self.product_flowable_1, lot_2, 10
         )
@@ -864,12 +714,7 @@ class TestStockPicking(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
         product = self.location_flowable_2.flowable_allowed_product_ids[0]
 
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-AUTOLOT-BLOCK",
-                "product_id": product.id,
-            }
-        )
+        lot = self._create_lot(product, "TEST-AUTOLOT-BLOCK")
         picking = self._create_incoming_picking(
             self.location_flowable_2, product, lot, 50
         )
@@ -897,12 +742,7 @@ class TestStockPicking(TestCommon):
         self.picking_type_mrp_operation_1.flowable_operation = True
 
         product = self.product_flowable_1
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-NONFLOW-LOT",
-                "product_id": product.id,
-            }
-        )
+        lot = self._create_lot(product, "TEST-NONFLOW-LOT")
         picking = self._create_incoming_picking(self.location_1, product, lot, 10)
 
         # ACT

--- a/stock_location_flowable/tests/test_stock_quant.py
+++ b/stock_location_flowable/tests/test_stock_quant.py
@@ -28,38 +28,13 @@ class TestStockQuant(TestCommon):
         POST:   - ValidationError is raised about duplicate lots
         """
         # ARRANGE — first lot via inventory adjustment
-        lot_1 = self.env["stock.production.lot"].create(
-            {
-                "name": "QUANT-LOT-1",
-                "product_id": self.product_flowable_1.id,
-            }
+        lot_1 = self._create_lot(self.product_flowable_1, "QUANT-LOT-1")
+        self._create_inventory_adjustment(
+            self.location_flowable_1, self.product_flowable_1, lot_1, 100
         )
-
-        inventory_1 = self.env["stock.inventory"].create(
-            {
-                "name": "Add first lot",
-            }
-        )
-        inventory_1.action_start()
-        self.env["stock.inventory.line"].create(
-            {
-                "inventory_id": inventory_1.id,
-                "product_id": self.product_flowable_1.id,
-                "product_uom_id": self.product_flowable_1.uom_id.id,
-                "location_id": self.location_flowable_1.id,
-                "prod_lot_id": lot_1.id,
-                "product_qty": 100,
-            }
-        )
-        inventory_1.action_validate()
 
         # ACT — second lot via inventory adjustment
-        lot_2 = self.env["stock.production.lot"].create(
-            {
-                "name": "QUANT-LOT-2",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot_2 = self._create_lot(self.product_flowable_1, "QUANT-LOT-2")
 
         inventory_2 = self.env["stock.inventory"].create(
             {

--- a/stock_location_flowable/tests/test_stock_return_picking.py
+++ b/stock_location_flowable/tests/test_stock_return_picking.py
@@ -27,45 +27,10 @@ class TestStockReturnPicking(TestCommon):
         # ARRANGE
         self.picking_type_mrp_operation_1.flowable_operation = True
 
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-RETURN-LOT",
-                "product_id": self.product_flowable_1.id,
-            }
+        lot = self._create_lot(self.product_flowable_1, "TEST-RETURN-LOT")
+        picking = self._seed_flowable_location(
+            self.location_flowable_1, self.product_flowable_1, lot, 50
         )
-
-        picking = self.env["stock.picking"].create(
-            {
-                "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-            }
-        )
-        self.env["stock.move.line"].create(
-            {
-                "picking_id": picking.id,
-                "product_id": self.product_flowable_1.id,
-                "product_uom_id": self.product_flowable_1.uom_id.id,
-                "lot_id": lot.id,
-                "qty_done": 50,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
-                "location_dest_id": self.location_flowable_1.id,
-                "company_id": self.env.company.id,
-            }
-        )
-        picking.button_validate()
-
-        # Complete the mixing MO so we have a done picking
-        production = self.env["mrp.production"].search(
-            [
-                ("picking_type_id", "=", self.picking_type_mrp_operation_1.id),
-                ("location_dest_id", "=", self.location_flowable_1.id),
-            ],
-            order="id desc",
-            limit=1,
-        )
-        if production:
-            production.button_mark_done()
 
         # ACT
         return_wizard = (
@@ -77,7 +42,7 @@ class TestStockReturnPicking(TestCommon):
             .create(
                 {
                     "picking_id": picking.id,
-                    "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                    "location_id": self.supplier_location.id,
                 }
             )
         )
@@ -104,17 +69,12 @@ class TestStockReturnPicking(TestCommon):
         POST:   - Return picking is created successfully
         """
         # ARRANGE
-        lot = self.env["stock.production.lot"].create(
-            {
-                "name": "TEST-RETURN-NOFLO",
-                "product_id": self.product_flowable_1.id,
-            }
-        )
+        lot = self._create_lot(self.product_flowable_1, "TEST-RETURN-NOFLO")
 
         picking = self.env["stock.picking"].create(
             {
                 "picking_type_id": self.picking_type_incoming_1.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.location_1.id,
             }
         )
@@ -125,7 +85,7 @@ class TestStockReturnPicking(TestCommon):
                 "product_uom_qty": 50,
                 "product_uom": self.product_flowable_1.uom_id.id,
                 "picking_id": picking.id,
-                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_id": self.supplier_location.id,
                 "location_dest_id": self.location_1.id,
             }
         )
@@ -149,7 +109,7 @@ class TestStockReturnPicking(TestCommon):
             .create(
                 {
                     "picking_id": picking.id,
-                    "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                    "location_id": self.supplier_location.id,
                 }
             )
         )

--- a/stock_location_flowable/tests/test_stock_return_picking.py
+++ b/stock_location_flowable/tests/test_stock_return_picking.py
@@ -120,3 +120,111 @@ class TestStockReturnPicking(TestCommon):
         self.assertTrue(new_picking_id)
         return_picking = self.env["stock.picking"].browse(new_picking_id)
         self.assertEqual(return_picking.state, "assigned")
+
+    def test_return_from_mixed_flowable_non_flowable_picking(self):
+        """
+        Test that returning from a picking that delivered to both a flowable
+        and a non-flowable location only blocks the return of the flowable
+        product.
+
+        PRE:    - A completed incoming picking with:
+                  - Line 1: product to flowable location (MO completed)
+                  - Line 2: product to non-flowable location
+        ACT:    - Attempt to return the flowable product
+        POST:   - UserError about the flowable product
+        """
+        # ARRANGE
+        self.picking_type_mrp_operation_1.flowable_operation = True
+
+        lot_flow = self._create_lot(self.product_flowable_1, "RET-MIXED-FLOW")
+        lot_nonflow = self._create_lot(self.product_flowable_1, "RET-MIXED-NOFLOW")
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type_incoming_1.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        # Line 1 → flowable location
+        move_flow = self.env["stock.move"].create(
+            {
+                "name": "Flowable line",
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom": self.product_flowable_1.uom_id.id,
+                "product_uom_qty": 50,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_flowable_1.id,
+            }
+        )
+        # Line 2 → non-flowable location
+        move_nonflow = self.env["stock.move"].create(
+            {
+                "name": "Non-flowable line",
+                "picking_id": picking.id,
+                "product_id": self.product_flowable_1.id,
+                "product_uom": self.product_flowable_1.uom_id.id,
+                "product_uom_qty": 30,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.location_1.id,
+            }
+        )
+        picking.action_confirm()
+        picking.action_assign()
+
+        for move, lot, qty in [
+            (move_flow, lot_flow, 50),
+            (move_nonflow, lot_nonflow, 30),
+        ]:
+            ml = move.move_line_ids
+            if ml:
+                ml.write({"lot_id": lot.id, "qty_done": qty})
+            else:
+                self.env["stock.move.line"].create(
+                    {
+                        "picking_id": picking.id,
+                        "move_id": move.id,
+                        "product_id": self.product_flowable_1.id,
+                        "product_uom_id": self.product_flowable_1.uom_id.id,
+                        "lot_id": lot.id,
+                        "qty_done": qty,
+                        "location_id": self.supplier_location.id,
+                        "location_dest_id": move.location_dest_id.id,
+                        "company_id": self.env.company.id,
+                    }
+                )
+
+        picking.button_validate()
+
+        # Complete the MO so the location is unblocked
+        production = self._find_flowable_production(self.location_flowable_1)
+        if production:
+            production.button_mark_done()
+
+        # ACT — try to return both products
+        return_wizard = (
+            self.env["stock.return.picking"]
+            .with_context(
+                active_id=picking.id,
+                active_model="stock.picking",
+            )
+            .create(
+                {
+                    "picking_id": picking.id,
+                    "location_id": self.supplier_location.id,
+                }
+            )
+        )
+        return_wizard._onchange_picking_id()
+
+        # ASSERT — error mentions the flowable product
+        with self.assertRaises(UserError) as error:
+            return_wizard._create_returns()
+
+        msg_error = (
+            "You cannot return the following products because"
+            " they come from a flowable location: %s"
+        )
+        msg_error = self.get_error_message_regex(msg_error)
+        self.assertRegex(error.exception.args[0], msg_error)


### PR DESCRIPTION
Supersedes #847

## Summary

### Bug fixes
- Fix non-MO moves bypassing blocked location check: production lookup now uses `raw_material_production_id or production_id` instead of state-based logic
- Prevent premature blocking and reservation conflicts: location blocking now only triggers on `assigned` state, `_trigger_assign` is bypassed during picking completion, and a post-reservation check ensures the mixing order can be fully reserved

### Improvements
- Validate quant count before creating flowable MO: pre-check detects rounding residuals and inconsistent quant states before MO creation
- Clarify pre-check error message for conflicting flowable lines (shows product/lot/location details)
- Add defensive post-production quant check: after completing a mixing MO, verify all non-producing lots have exactly 0 stock at the flowable location (uses `float_is_zero` with UoM rounding)

### Refactoring
- Refactor stock move write method for readability: early return, disjoint state branches
- Consolidate duplicated test helpers into TestCommon
- Use domain-consistent names in tests

### Documentation
- Add flowable blocking technical documentation with SVG diagrams explaining the full lifecycle

### Translations
- Add complete Catalan and Spanish translations for all module strings

### Tests
- 84 tests covering: blocking lifecycle, reservation conflicts, mixed flowable/non-flowable lines, sequential receptions with MO completion, pre-check rejection of multiple lots, blocked location preventing second reception, different lots to different locations, zero-qty lines, auto-lot top-up, return from mixed picking, rounding residual detection, post-production quant check, multi-line aggregation, custom UoM rounding, and fractional quantities

## Test plan
- [x] All 84 tests pass (0 failures, 0 errors)
- [x] Pre-commit passes cleanly
- [ ] Verify flowable location blocks on reception and unblocks on MO completion
- [ ] Verify second reception to blocked location is rejected
- [ ] Verify reception with pending reservations raises descriptive error
- [ ] Verify reception succeeds after unreserving all operations
- [ ] Verify rounding residuals are detected before MO creation
- [ ] Verify post-production quant check catches leftover stock