### PR TITLE
[14.0][FIX] account_invoice_same_accounting_date: recompute line balances on multicurrency invoice date change

### DIFF
--- a/account_invoice_same_accounting_date/models/account_move.py
+++ b/account_invoice_same_accounting_date/models/account_move.py
@@ -2,13 +2,27 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-
-from odoo import api, models
+from odoo import models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    @api.onchange("invoice_date")
-    def _onchange_invoice_date_accounting(self):
-        self.date = self.invoice_date
+    def _get_accounting_date(self, invoice_date, has_tax):
+        # For purchase documents, we want the same behavior as sale documents
+        # in super: apply the tax lock date check and return invoice_date
+        # (instead of max(invoice_date, today) which is the purchase default).
+        # The simpler approach would be to duplicate the tax lock date check
+        # from super, but we prefer not to duplicate code. Instead, we
+        # temporarily flag the context so is_sale_document() returns True
+        # during this specific super call, making it take the sale branch
+        # which does exactly what we need. The flag is scoped to this call
+        # only and does not affect any other use of is_sale_document().
+        if self.is_purchase_document(include_receipts=True) and invoice_date:
+            self = self.with_context(_force_invoice_accounting_date=True)
+        return super(AccountMove, self)._get_accounting_date(invoice_date, has_tax)
+
+    def is_sale_document(self, include_receipts=False):
+        if self._context.get("_force_invoice_accounting_date"):
+            return True
+        return super().is_sale_document(include_receipts=include_receipts)

--- a/account_invoice_same_accounting_date_prorate/models/account_move.py
+++ b/account_invoice_same_accounting_date_prorate/models/account_move.py
@@ -2,16 +2,16 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-
 from odoo import api, models
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    @api.onchange("invoice_date")
-    def _onchange_invoice_date_accounting(self):
-        super()._onchange_invoice_date_accounting()
-        self._recompute_dynamic_lines(
-            recompute_all_taxes=True, recompute_tax_base_amount=True
-        )
+    @api.onchange("invoice_date", "highest_name", "company_id")
+    def _onchange_invoice_date(self):
+        super()._onchange_invoice_date()
+        if self.line_ids.tax_ids.filtered("prorate"):
+            self._recompute_dynamic_lines(
+                recompute_all_taxes=True, recompute_tax_base_amount=True
+            )


### PR DESCRIPTION
## Summary

- Override `_get_accounting_date` to return `invoice_date` for purchase documents (same as core does for sales), using a scoped context flag to reuse super's tax lock date logic without code duplication
- Override `_onchange_invoice_date` in the prorate module via `super()` (guaranteed execution order) and add guard to only recompute taxes when prorate taxes exist

## Root cause

When a user set `invoice_date` on a multi-currency vendor bill:

1. **Core** `_onchange_invoice_date` called `_get_accounting_date(invoice_date)` which returned `max(invoice_date, today)` for purchase documents — same as current `date` — so `_onchange_currency()` was NOT called (else branch taken)
2. **NuoBiT base module** (`_onchange_invoice_date_accounting`) set `date = invoice_date` but didn't recompute line amounts
3. **NuoBiT prorate module** unconditionally called `_recompute_dynamic_lines(recompute_all_taxes=True)` which recomputed ONLY tax lines at the new `date` (invoice_date rate)

Result: base lines stayed at the creation rate, tax lines moved to the invoice_date rate. This rate mismatch caused SII error 1242 on intra-community USD invoices (reported on invoice 2026/00934).

## Fix approach

**Base module**: override `_get_accounting_date` so it returns `invoice_date` (after tax lock date check) for purchase documents — the same behavior core already has for sale documents. This makes the core's `_onchange_invoice_date` detect the date change and call `_onchange_currency()`, which recomputes ALL line `debit`/`credit` at the correct exchange rate. To avoid duplicating the tax lock date logic from super, we use a scoped context flag that makes `is_sale_document()` return True during this specific super call only, routing through the sale branch.

**Prorate module**: override `_onchange_invoice_date` via `super()` instead of having a separate onchange handler (which had no guaranteed execution order). Add guard to only call `_recompute_dynamic_lines(recompute_all_taxes=True)` when the invoice has taxes with `prorate=True` — this was the direct cause of the rate mismatch on non-prorate invoices.

## Test plan

- [ ] Create a USD vendor bill with `invoice_date` = today
- [ ] Change `invoice_date` to a past date with a different exchange rate
- [ ] Verify all line debit/credit amounts are recomputed at the new date's rate (check Apuntes contables tab)
- [ ] Verify base and tax lines use the same exchange rate
- [ ] Verify EUR invoices are not affected
- [ ] Verify sale invoices are not affected (use original `_get_accounting_date` logic)
- [ ] Verify tax lock date: set `invoice_date` before `tax_lock_date` on an invoice with taxes → accounting date should be `tax_lock_date + 1`
- [ ] Verify prorate invoices: change `invoice_date` → prorate percentage should recalculate for the new date
- [ ] Verify non-prorate invoices: change `invoice_date` → no unnecessary full tax recomputation