### PR TITLE
[14.0][FIX] website_sale_extra_fields: slug_name NOT NULL on fresh install

### DIFF
--- a/website_sale_extra_fields/__init__.py
+++ b/website_sale_extra_fields/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import pre_init_hook

--- a/website_sale_extra_fields/__manifest__.py
+++ b/website_sale_extra_fields/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Website Sale Extra Fields",
-    "version": "14.0.0.1.0",
+    "version": "14.0.0.1.1",
     "author": "NuoBiT Solutions, S.L.",
     "license": "AGPL-3",
     "category": "Website",
@@ -16,4 +16,5 @@
         "views/product_template.xml",
         "views/product_product.xml",
     ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/website_sale_extra_fields/hooks.py
+++ b/website_sale_extra_fields/hooks.py
@@ -1,0 +1,20 @@
+# Copyright NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    _logger.info(
+        "Pre-creating slug_name column on product_public_category"
+        " to avoid NOT NULL constraint failure"
+    )
+    cr.execute(
+        "ALTER TABLE product_public_category"
+        " ADD COLUMN IF NOT EXISTS slug_name varchar"
+    )
+    cr.execute(
+        "UPDATE product_public_category SET slug_name = '/' WHERE slug_name IS NULL"
+    )


### PR DESCRIPTION
## Summary

- Add `pre_init_hook` to pre-create the `slug_name` column on `product_public_category` and fill existing NULL rows with a placeholder before `_auto_init` runs
- Prevents `ERROR: column "slug_name" contains null values` when installing on a database that already has `product.public.category` records (e.g. from `website_sale` demo data)
- Standard OCA pattern for required stored computed fields on inherited models

## Test plan

- [ ] Install `website_sale_extra_fields` on a fresh database with demo data enabled — should not crash
- [ ] Verify `slug_name` is computed correctly after install