### PR TITLE
[14.0][IMP] connector_extension: add user_id field and work_on override

### DIFF
--- a/connector_extension/models/backend/backend.py
+++ b/connector_extension/models/backend/backend.py
@@ -3,6 +3,7 @@
 # Copyright 2025 NuoBiT - Deniz Gallo <dgallo@nuobit.com>
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html)
 import logging
+from contextlib import contextmanager
 
 import pytz
 
@@ -45,6 +46,13 @@ class ConnectorBackend(models.AbstractModel):
         required=True,
         default=lambda self: self.env.company,
         string="Company",
+    )
+    user_id = fields.Many2one(
+        comodel_name="res.users",
+        string="User",
+        help="User used as the default responsible for records created by "
+        "this backend. If set, all operations (imports, exports, jobs) "
+        "will run under this user context.",
     )
 
     lang_ids = fields.Many2many(
@@ -121,6 +129,14 @@ class ConnectorBackend(models.AbstractModel):
         datetime_local = datetime_utc.astimezone(local_tz)
         datetime_local_naive = datetime_local.replace(tzinfo=None)
         return datetime_local_naive
+
+    @contextmanager
+    def work_on(self, model_name, **kwargs):
+        backend = self
+        if self.user_id:
+            backend = self.with_user(self.user_id)
+        with super(ConnectorBackend, backend).work_on(model_name, **kwargs) as work:
+            yield work
 
     # Scheduler methods
     @api.model


### PR DESCRIPTION
## Summary

- Add optional `user_id` field on the connector backend to configure a default user for all sync operations
- Override `work_on` to switch to this user before creating the WorkContext, ensuring all components, record creation, and child jobs (including delayed ones) run under the configured user context
- Prevents records from being created under the session user when imports are triggered manually from the backend form

## Test plan

- [ ] Set `user_id` on a backend, trigger import manually — verify records are created under the configured user
- [ ] Leave `user_id` empty — verify behavior is unchanged (records created under session user)
- [ ] Trigger import via cron — verify the backend's `user_id` overrides the cron's user