### PR TITLE
[14.0][IMP] uom_rounding_coherence: block rounding changes that invalidate stock data

### DIFF
--- a/uom_rounding_coherence/README.rst
+++ b/uom_rounding_coherence/README.rst
@@ -43,10 +43,17 @@ transactions.
 
 **The Validation:**
 
-The module checks that converting the UoM's rounding step to reference units
-(rounding / factor) does not exceed the reference UoM's rounding. This ensures
-data consistency and prevents precision-related errors.
+The module performs two checks:
 
+1. **Conversion ratio coherence**: the UoM's rounding step, converted to
+   reference units (rounding / factor), must not exceed the reference UoM's
+   rounding. This prevents precision loss during conversions.
+
+2. **Stock quant coherence**: when changing a UoM's rounding, the module checks
+   that all existing stock quant quantities for products using that UoM fit
+   within the new rounding. This prevents making the rounding coarser than the
+   data allows (e.g., changing from 0.001 to 0.01 when quants with 3 decimals
+   already exist in stock).
 
 **Table of contents**
 

--- a/uom_rounding_coherence/__manifest__.py
+++ b/uom_rounding_coherence/__manifest__.py
@@ -5,11 +5,11 @@
     "name": "UoM Rounding Coherence",
     "summary": "Validates that UoM rounding precision is coherent"
     " with the conversion ratio to prevent precision loss",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",
     "category": "Product",
-    "depends": ["uom"],
+    "depends": ["stock"],
     "license": "AGPL-3",
     "installable": True,
 }

--- a/uom_rounding_coherence/i18n/ca.po
+++ b/uom_rounding_coherence/i18n/ca.po
@@ -19,6 +19,26 @@ msgstr ""
 #: code:addons/uom_rounding_coherence/models/uom_uom.py:0
 #, python-format
 msgid ""
+"Cannot set rounding to %(rounding)s for '%(uom)s': there are stock "
+"quantities with more decimal places than the new rounding allows.\n"
+"\n"
+"Examples:\n"
+"%(examples)s\n"
+"\n"
+"Fix the stock data first or use a finer rounding."
+msgstr ""
+"No es pot establir l'arrodoniment a %(rounding)s per a '%(uom)s': hi ha "
+"quantitats d'estoc amb més decimals dels que permet el nou arrodoniment.\n"
+"\n"
+"Exemples:\n"
+"%(examples)s\n"
+"\n"
+"Corregiu les dades d'estoc primer o utilitzeu un arrodoniment més fi."
+
+#. module: uom_rounding_coherence
+#: code:addons/uom_rounding_coherence/models/uom_uom.py:0
+#, python-format
+msgid ""
 "Cannot validate rounding coherence for category '%(category)s': expected "
 "exactly one active reference unit of measure but found %(count)s."
 msgstr ""

--- a/uom_rounding_coherence/i18n/es.po
+++ b/uom_rounding_coherence/i18n/es.po
@@ -19,6 +19,27 @@ msgstr ""
 #: code:addons/uom_rounding_coherence/models/uom_uom.py:0
 #, python-format
 msgid ""
+"Cannot set rounding to %(rounding)s for '%(uom)s': there are stock "
+"quantities with more decimal places than the new rounding allows.\n"
+"\n"
+"Examples:\n"
+"%(examples)s\n"
+"\n"
+"Fix the stock data first or use a finer rounding."
+msgstr ""
+"No se puede establecer el redondeo a %(rounding)s para '%(uom)s': hay "
+"cantidades de stock con más decimales de los que permite el nuevo "
+"redondeo.\n"
+"\n"
+"Ejemplos:\n"
+"%(examples)s\n"
+"\n"
+"Corrija los datos de stock primero o utilice un redondeo más fino."
+
+#. module: uom_rounding_coherence
+#: code:addons/uom_rounding_coherence/models/uom_uom.py:0
+#, python-format
+msgid ""
 "Cannot validate rounding coherence for category '%(category)s': expected "
 "exactly one active reference unit of measure but found %(count)s."
 msgstr ""

--- a/uom_rounding_coherence/models/uom_uom.py
+++ b/uom_rounding_coherence/models/uom_uom.py
@@ -1,12 +1,67 @@
 # Copyright 2026 NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
+import math
+
 from odoo import _, api, models, tools
 from odoo.exceptions import ValidationError
 
 
 class UoM(models.Model):
     _inherit = "uom.uom"
+
+    @api.constrains("rounding")
+    def _check_rounding_stock_quant_coherence(self):
+        """Block rounding changes that would invalidate existing stock data.
+
+        When making UoM rounding coarser (e.g. 0.001 -> 0.01), any
+        stock quant whose quantity has more decimal places than the new
+        rounding allows would become invalid and block stock operations.
+        """
+        for uom in self:
+            max_decimals = (
+                0 if uom.rounding >= 1 else -math.floor(math.log10(uom.rounding))
+            )
+            threshold = uom.rounding / 100.0
+            self.env.cr.execute(
+                """
+                SELECT sq.quantity AS value, sl.complete_name AS detail
+                FROM stock_quant sq
+                JOIN product_product pp ON pp.id = sq.product_id
+                JOIN product_template pt ON pt.id = pp.product_tmpl_id
+                JOIN stock_location sl ON sl.id = sq.location_id
+                WHERE pt.uom_id = %(uom_id)s
+                  AND ABS(sq.quantity) > 0.0000001
+                  AND ABS(sq.quantity - ROUND(sq.quantity::numeric, %(dec)s))
+                      > %(threshold)s
+                ORDER BY ABS(sq.quantity - ROUND(sq.quantity::numeric, %(dec)s)) DESC
+                LIMIT 5
+                """,
+                {
+                    "uom_id": uom.id,
+                    "dec": max_decimals,
+                    "threshold": threshold,
+                },
+            )
+            bad_quants = self.env.cr.dictfetchall()
+            if bad_quants:
+                examples = "\n".join(
+                    "  - %s at %s" % (q["value"], q["detail"]) for q in bad_quants
+                )
+                raise ValidationError(
+                    _(
+                        "Cannot set rounding to %(rounding)s for '%(uom)s': "
+                        "there are stock quantities with more decimal places "
+                        "than the new rounding allows.\n\n"
+                        "Examples:\n%(examples)s\n\n"
+                        "Fix the stock data first or use a finer rounding."
+                    )
+                    % {
+                        "rounding": uom.rounding,
+                        "uom": uom.name,
+                        "examples": examples,
+                    }
+                )
 
     @api.constrains("rounding", "factor", "uom_type", "category_id")
     def _check_rounding_factor_coherence(self):

--- a/uom_rounding_coherence/readme/DESCRIPTION.rst
+++ b/uom_rounding_coherence/readme/DESCRIPTION.rst
@@ -15,7 +15,14 @@ transactions.
 
 **The Validation:**
 
-The module checks that converting the UoM's rounding step to reference units
-(rounding / factor) does not exceed the reference UoM's rounding. This ensures
-data consistency and prevents precision-related errors.
+The module performs two checks:
 
+1. **Conversion ratio coherence**: the UoM's rounding step, converted to
+   reference units (rounding / factor), must not exceed the reference UoM's
+   rounding. This prevents precision loss during conversions.
+
+2. **Stock quant coherence**: when changing a UoM's rounding, the module checks
+   that all existing stock quant quantities for products using that UoM fit
+   within the new rounding. This prevents making the rounding coarser than the
+   data allows (e.g., changing from 0.001 to 0.01 when quants with 3 decimals
+   already exist in stock).

--- a/uom_rounding_coherence/static/description/index.html
+++ b/uom_rounding_coherence/static/description/index.html
@@ -387,9 +387,17 @@ has rounding 0.01, each conversion can introduce up to ±0.004 error in
 reference units — enough to accumulate visible discrepancies over multiple
 transactions.</p>
 <p><strong>The Validation:</strong></p>
-<p>The module checks that converting the UoM’s rounding step to reference units
-(rounding / factor) does not exceed the reference UoM’s rounding. This ensures
-data consistency and prevents precision-related errors.</p>
+<p>The module performs two checks:</p>
+<ol class="arabic simple">
+<li><strong>Conversion ratio coherence</strong>: the UoM’s rounding step, converted to
+reference units (rounding / factor), must not exceed the reference UoM’s
+rounding. This prevents precision loss during conversions.</li>
+<li><strong>Stock quant coherence</strong>: when changing a UoM’s rounding, the module checks
+that all existing stock quant quantities for products using that UoM fit
+within the new rounding. This prevents making the rounding coarser than the
+data allows (e.g., changing from 0.001 to 0.01 when quants with 3 decimals
+already exist in stock).</li>
+</ol>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">

--- a/uom_rounding_coherence/tests/test_uom_rounding_coherence.py
+++ b/uom_rounding_coherence/tests/test_uom_rounding_coherence.py
@@ -300,3 +300,102 @@ class TestUomRoundingCoherence(SavepointCase):
         # ACT & ASSERT
         with self.assertRaises(ValidationError):
             another.write({"rounding": 0.0001})
+
+    def _create_product_with_uom(self, name, uom):
+        """Create a storable product via SQL to avoid NOT NULL issues
+        from optional modules (sale, purchase) adding required columns."""
+        self.env.cr.execute(
+            """
+            INSERT INTO product_template
+                (name, type, uom_id, uom_po_id, categ_id, active,
+                 sale_ok, purchase_ok, list_price, tracking,
+                 sale_line_warn, purchase_line_warn,
+                 create_uid, write_uid, create_date, write_date)
+            VALUES
+                (%s, 'product', %s, %s, 1, true,
+                 false, false, 0, 'none',
+                 'no-message', 'no-message',
+                 1, 1, now() at time zone 'UTC', now() at time zone 'UTC')
+            RETURNING id
+            """,
+            (name, uom.id, uom.id),
+        )
+        tmpl_id = self.env.cr.fetchone()[0]
+        self.env.cr.execute(
+            """
+            INSERT INTO product_product
+                (product_tmpl_id, active, default_code,
+                 create_uid, write_uid, create_date, write_date)
+            VALUES
+                (%s, true, NULL, 1, 1,
+                 now() at time zone 'UTC', now() at time zone 'UTC')
+            RETURNING id
+            """,
+            (tmpl_id,),
+        )
+        product_id = self.env.cr.fetchone()[0]
+        return self.env["product.product"].browse(product_id)
+
+    def test_coarser_rounding_blocked_by_existing_quants(self):
+        """
+        PRE:    - A product exists with a UoM that has rounding=0.001
+                - A stock quant exists with quantity=5825.949 (3 decimals)
+        ACT:    - Change the UoM rounding to 0.01 (2 decimals)
+        POST:   - ValidationError is raised because the quant value 5825.949
+                  has more decimals than the new rounding allows
+        """
+        # ARRANGE
+        category = self.env["uom.category"].create(
+            {"name": "Test Quant Coherence Category"}
+        )
+        uom = self.env["uom.uom"].create(
+            {
+                "name": "Quant Test Unit",
+                "category_id": category.id,
+                "uom_type": "reference",
+                "rounding": 0.001,
+            }
+        )
+        product = self._create_product_with_uom("Quant Test Product", uom)
+        location = self.env.ref("stock.stock_location_stock")
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": location.id,
+                "quantity": 5825.949,
+            }
+        )
+        # ACT & ASSERT
+        with self.assertRaises(ValidationError):
+            uom.write({"rounding": 0.01})
+
+    def test_finer_rounding_allowed_with_existing_quants(self):
+        """
+        PRE:    - A product exists with a UoM that has rounding=0.01
+                - A stock quant exists with quantity=5825.95 (2 decimals)
+        ACT:    - Change the UoM rounding to 0.001 (3 decimals)
+        POST:   - No error is raised because 5825.95 fits within 0.001
+        """
+        # ARRANGE
+        category = self.env["uom.category"].create(
+            {"name": "Test Finer Rounding Category"}
+        )
+        uom = self.env["uom.uom"].create(
+            {
+                "name": "Finer Test Unit",
+                "category_id": category.id,
+                "uom_type": "reference",
+                "rounding": 0.01,
+            }
+        )
+        product = self._create_product_with_uom("Finer Test Product", uom)
+        location = self.env.ref("stock.stock_location_stock")
+        self.env["stock.quant"].create(
+            {
+                "product_id": product.id,
+                "location_id": location.id,
+                "quantity": 5825.95,
+            }
+        )
+        # ACT — should not raise
+        uom.write({"rounding": 0.001})


### PR DESCRIPTION
## Summary
- Add stock quant coherence constraint: when changing a UoM rounding, checks that all existing stock quant quantities fit within the new rounding
- Prevents making rounding coarser than the data allows (e.g., changing from 0.001 to 0.01 when quants with 3 decimals exist)
- Add `stock` as dependency (was `uom` only)
- Bump version to 14.0.1.1.0

## Test plan
- [x] 13 tests pass (11 existing + 2 new)
- [x] Pre-commit passes cleanly
- [ ] Verify on production: changing CO2 UoM rounding from 0.001 to 0.01 is blocked
- [ ] Verify on production: changing CO2 UoM rounding from 0.001 to 0.0001 is allowed