### PR TITLE
[16.0][IMP] rental_base_extension: post_init_hook for existing records

### DIFF
--- a/rental_base_extension/__init__.py
+++ b/rental_base_extension/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/rental_base_extension/__manifest__.py
+++ b/rental_base_extension/__manifest__.py
@@ -11,6 +11,7 @@
     "author": "NuoBiT Solutions SL",
     "website": "https://github.com/nuobit/odoo-addons",
     "license": "AGPL-3",
+    "post_init_hook": "post_init_hook",
     "depends": [
         "rental_base",
     ],

--- a/rental_base_extension/hooks.py
+++ b/rental_base_extension/hooks.py
@@ -1,0 +1,26 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    normal_type = env.ref("sale_order_type.normal_sale_type")
+    cr.execute(
+        "UPDATE sale_order SET type_id = %s WHERE type_id IS NULL",
+        [normal_type.id],
+    )
+    _logger.info("Updated %d sale orders with default type_id", cr.rowcount)
+    cr.execute("UPDATE sale_order_line SET rental = False WHERE rental IS NULL")
+    _logger.info("Updated %d sale order lines with rental = False", cr.rowcount)
+    cr.execute(
+        "UPDATE sale_order_line SET can_sell_rental = False WHERE can_sell_rental IS NULL"
+    )
+    _logger.info(
+        "Updated %d sale order lines with can_sell_rental = False", cr.rowcount
+    )


### PR DESCRIPTION
## Summary
- When rental modules are installed on a database with existing sale orders, `type_id`, `rental` and `can_sell_rental` fields remain NULL because defaults/computes only apply to new records
- This causes errors when editing old quotations (Order Type radio buttons blank, attrs evaluation fails)
- Adds a `post_init_hook` that sets the correct defaults on existing records via SQL (xmlid resolved via ORM)

## Test plan
- [ ] Install `rental_base_extension` on a database with existing sale orders
- [ ] Verify all orders have `type_id` set to "Normal Order"
- [ ] Verify all order lines have `rental = False` and `can_sell_rental = False`
- [ ] Open an old quotation and confirm no errors, Order Type shows "Pedido Normal"