### PR TITLE
[16.0][FIX] rental_base_extension: rental service button on multi-variant products

### DIFF
--- a/rental_base_extension/i18n/ca.po
+++ b/rental_base_extension/i18n/ca.po
@@ -57,6 +57,12 @@ msgid "Adopt & Sign"
 msgstr "Adopta i signa"
 
 #. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "All variants already have a rental service."
+msgstr "Totes les variants ja tenen un servei de lloguer."
+
+#. module: rental_base_extension
 #. odoo-javascript
 #: code:addons/rental_base_extension/static/src/xml/signature_dialog.xml:0
 #, python-format
@@ -79,9 +85,20 @@ msgid "Confirm & Sign"
 msgstr "Confirma i signa"
 
 #. module: rental_base_extension
+#: model_terms:ir.ui.view,arch_db:rental_base_extension.product_template_only_form_view
+msgid "Create Rental Services"
+msgstr "Crea serveis de lloguer"
+
+#. module: rental_base_extension
 #: model_terms:ir.actions.act_window,help:rental_base_extension.sale_order_action_rental
 msgid "Create a new rental order!"
 msgstr "Creeu una nova comanda de lloguer!"
+
+#. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "Created Rental Services"
+msgstr "Serveis de lloguer creats"
 
 #. module: rental_base_extension
 #. odoo-javascript

--- a/rental_base_extension/i18n/es.po
+++ b/rental_base_extension/i18n/es.po
@@ -57,6 +57,12 @@ msgid "Adopt & Sign"
 msgstr "Adoptar y firmar"
 
 #. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "All variants already have a rental service."
+msgstr "Todas las variantes ya tienen un servicio de alquiler."
+
+#. module: rental_base_extension
 #. odoo-javascript
 #: code:addons/rental_base_extension/static/src/xml/signature_dialog.xml:0
 #, python-format
@@ -79,9 +85,20 @@ msgid "Confirm & Sign"
 msgstr "Confirmar y firmar"
 
 #. module: rental_base_extension
+#: model_terms:ir.ui.view,arch_db:rental_base_extension.product_template_only_form_view
+msgid "Create Rental Services"
+msgstr "Crear servicios de alquiler"
+
+#. module: rental_base_extension
 #: model_terms:ir.actions.act_window,help:rental_base_extension.sale_order_action_rental
 msgid "Create a new rental order!"
 msgstr "¡Cree un nuevo pedido de alquiler!"
+
+#. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "Created Rental Services"
+msgstr "Servicios de alquiler creados"
 
 #. module: rental_base_extension
 #. odoo-javascript

--- a/rental_base_extension/i18n/rental_base_extension.pot
+++ b/rental_base_extension/i18n/rental_base_extension.pot
@@ -52,6 +52,12 @@ msgid "Adopt & Sign"
 msgstr ""
 
 #. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "All variants already have a rental service."
+msgstr ""
+
+#. module: rental_base_extension
 #. odoo-javascript
 #: code:addons/rental_base_extension/static/src/xml/signature_dialog.xml:0
 #, python-format
@@ -91,8 +97,19 @@ msgid "Create Rental Service"
 msgstr ""
 
 #. module: rental_base_extension
+#: model_terms:ir.ui.view,arch_db:rental_base_extension.product_template_only_form_view
+msgid "Create Rental Services"
+msgstr ""
+
+#. module: rental_base_extension
 #: model_terms:ir.actions.act_window,help:rental_base_extension.sale_order_action_rental
 msgid "Create a new rental order!"
+msgstr ""
+
+#. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "Created Rental Services"
 msgstr ""
 
 #. module: rental_base_extension
@@ -217,6 +234,12 @@ msgid "Quotation Sent"
 msgstr ""
 
 #. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "RENT-{}"
+msgstr ""
+
+#. module: rental_base_extension
 #: model:ir.model.fields,field_description:rental_base_extension.field_sale_order__rental_ids
 #: model_terms:ir.ui.view,arch_db:rental_base_extension.product_normal_form_view
 #: model_terms:ir.ui.view,arch_db:rental_base_extension.product_template_only_form_view
@@ -250,6 +273,12 @@ msgstr ""
 #. module: rental_base_extension
 #: model:ir.model.fields,field_description:rental_base_extension.field_sale_order__rental_status
 msgid "Rental Status"
+msgstr ""
+
+#. module: rental_base_extension
+#: code:addons/rental_base_extension/models/product.py:0
+#, python-format
+msgid "Rental of a {}"
 msgstr ""
 
 #. module: rental_base_extension

--- a/rental_base_extension/models/__init__.py
+++ b/rental_base_extension/models/__init__.py
@@ -1,3 +1,4 @@
+from . import product
 from . import res_company
 from . import res_config_settings
 from . import sale_order

--- a/rental_base_extension/models/product.py
+++ b/rental_base_extension/models/product.py
@@ -26,14 +26,14 @@ class ProductTemplate(models.Model):
                 "uom_id": day_uom.id,
                 "uom_po_id": day_uom.id,
                 "list_price": 1.0,
-                "name": _("Rental of %s") % variant_ctx.display_name,
+                "name": _("Rental of a {}").format(variant_ctx.display_name),
                 "rented_product_id": variant.id,
                 "must_have_dates": True,
                 "categ_id": self.categ_id.id,
                 "invoice_policy": "order",
             }
             if variant.default_code:
-                vals["default_code"] = _("RENT-%s") % variant.default_code
+                vals["default_code"] = _("RENT-{}").format(variant.default_code)
             created_products |= self.env["product.product"].create(vals)
         return {
             "type": "ir.actions.act_window",

--- a/rental_base_extension/models/product.py
+++ b/rental_base_extension/models/product.py
@@ -1,0 +1,45 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def action_create_rental_services(self):
+        self.ensure_one()
+        day_uom = self.env.ref("uom.product_uom_day")
+        variants_without_service = self.product_variant_ids.filtered(
+            lambda v: not v.rental_service_ids
+        )
+        if not variants_without_service:
+            raise UserError(_("All variants already have a rental service."))
+        created_products = self.env["product.product"]
+        for variant in variants_without_service:
+            variant_ctx = variant.with_context(display_default_code=False)
+            vals = {
+                "type": "service",
+                "sale_ok": True,
+                "purchase_ok": False,
+                "uom_id": day_uom.id,
+                "uom_po_id": day_uom.id,
+                "list_price": 1.0,
+                "name": _("Rental of %s") % variant_ctx.display_name,
+                "rented_product_id": variant.id,
+                "must_have_dates": True,
+                "categ_id": self.categ_id.id,
+                "invoice_policy": "order",
+            }
+            if variant.default_code:
+                vals["default_code"] = _("RENT-%s") % variant.default_code
+            created_products |= self.env["product.product"].create(vals)
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Created Rental Services"),
+            "res_model": "product.product",
+            "view_mode": "tree,form",
+            "domain": [("id", "in", created_products.ids)],
+            "target": "current",
+        }

--- a/rental_base_extension/views/product_views.xml
+++ b/rental_base_extension/views/product_views.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
      License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
 <odoo>
-    <!-- Hide 'Can be Rented' checkbox on service products -->
+    <!-- Hide 'Can be Rented' checkbox on non-storable products -->
     <record id="product_template_form_view" model="ir.ui.view">
         <field name="name">product.template.form.inherit.rental_base_extension</field>
         <field name="model">product.template</field>
@@ -13,7 +13,7 @@
                 position="attributes"
             >
                 <attribute name="attrs">
-                    {'invisible': [('type', '=', 'service')]}
+                    {'invisible': [('type', '!=', 'product')]}
                 </attribute>
             </xpath>
         </field>
@@ -56,7 +56,7 @@
                 <group
                     name="rental"
                     string="Rentals"
-                    attrs="{'invisible': [('type', '=', 'service')]}"
+                    attrs="{'invisible': [('type', '!=', 'product')]}"
                 >
                     <field name="rental_service_ids" nolabel="1" colspan="2" />
                     <button
@@ -108,13 +108,20 @@
                 <group
                     name="rental"
                     string="Rentals"
-                    attrs="{'invisible': ['|', ('type', '=', 'service'), ('product_variant_count', '&gt;', 1)]}"
+                    attrs="{'invisible': [('type', '!=', 'product')]}"
                 >
                     <field name="rental_service_tmpl_ids" nolabel="1" colspan="2" />
                     <button
                         type="action"
                         name="%(sale_rental.create_rental_product_action)d"
                         string="Create Rental Service"
+                        attrs="{'invisible': [('product_variant_count', '&gt;', 1)]}"
+                    />
+                    <button
+                        name="action_create_rental_services"
+                        type="object"
+                        string="Create Rental Services"
+                        attrs="{'invisible': [('product_variant_count', '&lt;=', 1)]}"
                     />
                 </group>
             </group>


### PR DESCRIPTION
## Summary
- Show the "Create Rental Services" button on product templates with multiple variants, allowing batch creation of rental services for all variants at once
- Restrict the "Can be Rented" checkbox and "Rentals" section to storable products only (hide for consumables and services)
- Single-variant products keep the original wizard; multi-variant products get a new batch action

## Test plan
- [ ] Open an existing storable product with variants (e.g. "Regulador Rover S25"), enable "Es pot llogar", save, and verify the "Create Rental Services" button appears in the Rentals section
- [ ] Click the button and verify rental services are created for all variants
- [ ] Verify the button does NOT appear on consumable or service products
- [ ] Verify single-variant storable products still show the original "Create Rental Service" wizard