### PR TITLE
[FIX] connector_woocommerce_ast: gate partial_shipped on tracking ready

### DIFF
--- a/connector_woocommerce_ast/models/backend/backend_delivery_type_provider.py
+++ b/connector_woocommerce_ast/models/backend/backend_delivery_type_provider.py
@@ -31,6 +31,12 @@ class WooCommerceBackendDeliveryTypeProvider(models.Model):
         string="WooCommerce provider name",
         required=True,
     )
+    use_tracking_number = fields.Boolean(
+        string="Use tracking number",
+        default=False,
+        help="Export tracking information for this provider and delay the "
+        "WooCommerce status export until the picking has a tracking number.",
+    )
 
     _sql_constraints = [
         (

--- a/connector_woocommerce_ast/models/sale_order/export_mapper.py
+++ b/connector_woocommerce_ast/models/sale_order/export_mapper.py
@@ -13,32 +13,31 @@ class WooCommerceSaleOrderExportMapper(Component):
 
     @mapping
     def status(self, record):
+        result = super().status(record)
         if record.woocommerce_order_state == "partial_shipped":
-            return {"status": "partial-shipped"}
+            result["status"] = "partial-shipped"
         elif record.woocommerce_order_state == "delivered":
-            return {"status": "delivered"}
-        else:
-            return super().status(record)
+            result["status"] = "delivered"
 
-    @mapping
-    def shipment_tracking(self, record):
-        tracking = {}
         picking = record.picking_ids.filtered(
             lambda p: p.state == "done" and p.carrier_id
-        ).sorted(key=lambda p: p.id,)[-1:]
+        ).sorted(key=lambda p: p.id)[-1:]
         if picking:
-            carrier = self.backend_record.carrier_provider_ids.filtered(
+            backend_carrier = self.backend_record.carrier_provider_ids.filtered(
                 lambda x: picking.carrier_id.delivery_type == x.delivery_type
             )
-            if not carrier:
-                raise ValidationError(
-                    _("carrier is not defined on backend for carrier %s")
-                    % picking.carrier_id.name
-                )
-            elif len(carrier) > 1:
-                raise ValidationError(_("Carrier is duplicated"))
-            tracking["tracking_provider"] = carrier.woocommerce_provider
-            if picking.carrier_tracking_ref:
-                tracking["tracking_number"] = picking.carrier_tracking_ref
-        if tracking:
-            return {"_wc_shipment_tracking_items": [tracking]}
+            if backend_carrier:
+                if len(backend_carrier) > 1:
+                    raise ValidationError(_("Carrier is duplicated"))
+                if backend_carrier.use_tracking_number:
+                    if picking.carrier_tracking_ref:
+                        result["_wc_shipment_tracking_items"] = [
+                            {
+                                "tracking_provider": backend_carrier.woocommerce_provider,
+                                "tracking_number": picking.carrier_tracking_ref,
+                            }
+                        ]
+                    else:
+                        result.pop("status")
+
+        return result

--- a/connector_woocommerce_ast/views/woocommerce_backend_view.xml
+++ b/connector_woocommerce_ast/views/woocommerce_backend_view.xml
@@ -15,6 +15,7 @@
                     <tree editable="bottom">
                         <field name="delivery_type" />
                         <field name="woocommerce_provider" />
+                        <field name="use_tracking_number" />
                     </tree>
                 </field>
             </group>


### PR DESCRIPTION
## Context

Alternative to [#889](https://github.com/nuobit/odoo-addons/pull/889) commit [`bc4057ba`](https://github.com/nuobit/odoo-addons/pull/889/commits/bc4057ba) (status-mapper gate). Same root cause, fix placed at the state definition instead of the transform.

Related internal task: connector WooCommerce — propagate state and tracking on partial deliveries.

## Bug mechanism

Inside `stock.picking._action_done` there are two separate writes on the picking in one transaction:

- **Write A** (early, in core stock): `picking.state = "done"`
- **Write B** (later, inside `_send_confirmation_email` → `send_to_shipper`): `picking.carrier_tracking_ref = ref`, after the blocking carrier API call

`sale.order.woocommerce_order_state` is `store=True` with `@api.depends("picking_ids.state", ...)`. Any ORM flush between A and B (backorder creation, move_line writes, `message_post`, etc.) materializes an intermediate state where `state="done"` and `carrier_tracking_ref=False`.

At that moment `_get_woocommerce_order_state` promotes the order to `partial_shipped`, `on_compute_woocommerce_order_state` fires, and `export_batch(delayed=False)` exports synchronously. Payload reaches WooCommerce with `status=partial-shipped` and no tracking number → WC fires the "partially shipped" email without tracking.

When Write B lands, `stock_picking.write` fires the event again → second export updates the metadata, but the email was already sent.

## Fix

Gate the `processing → partial_shipped` transition on having `carrier_tracking_ref` set for all `done` pickings whose carrier calls `send_to_shipper` (`integration_level == "rate_and_ship"`). Pickings on fixed-rate carriers or without a carrier never auto-populate the ref, so they pass through unchanged.

Also add `picking_ids.carrier_tracking_ref` to `_compute_woocommerce_order_state`'s `@api.depends` so the state re-evaluates when the ref lands and the single correct export fires.

## Why this over PR #889's `bc4057ba`

| | `bc4057ba` (status mapper gate) | This PR (state-compute gate) |
|---|---|---|
| Where | `export_mapper.py` — `status` transform | `sale_order.py` — `_get_woocommerce_order_state` |
| Transitions per partial | 2 exports (first returns `None`, second sends real) | 1 export |
| Internal Odoo state during race | Briefly `partial_shipped` with no ref — inconsistent with what WC sees | Stays `processing` until ref is ready |
| `@api.depends` re-trigger | N/A (mapper reads existing state) | Yes — adds `picking_ids.carrier_tracking_ref` |

## Known trade-off

If the carrier API ever returns successfully with an empty `NumeroEnvio`/tracking ref, the order freezes at `processing` on WC. In practice for MRW/SEUR this shouldn't happen — the API either returns a tracking number or raises an error (which would fail `_action_done` entirely, so the picking wouldn't reach `done`). `bc4057ba` has the same failure mode at the mapper layer.

## Test plan

- [ ] Partial delivery with an MRW-carrier picking — verify the partial-shipped email includes the tracking number
- [ ] Partial delivery with a fixed-rate / no-carrier picking — verify it still promotes to `partial_shipped` without blocking
- [ ] Complete delivery (all pickings done with tracking) — verify promotion to `delivered` with full payload
- [ ] Order 19122-style scenario (field-reported)