### PR TITLE
[16.0][FIX] sale_order_report_zero_qty: handle section/note lines

### DIFF
--- a/sale_order_report_zero_qty/models/sale_order.py
+++ b/sale_order_report_zero_qty/models/sale_order.py
@@ -1,5 +1,5 @@
 # Copyright NuoBiT 2025 - Bijaya Kumal <bkumal@nuobit.com>
-
+# Copyright 2026 NuoBiT Solutions SL - Deniz Gallo <dgallo@nuobit.com
 from odoo import models
 from odoo.tools import float_is_zero
 
@@ -10,7 +10,8 @@ class SaleOrder(models.Model):
     def _get_order_lines_to_report(self):
         lines = super()._get_order_lines_to_report()
         return lines.filtered(
-            lambda l: not float_is_zero(
+            lambda l: l.display_type
+            or not float_is_zero(
                 l.product_uom_qty, precision_rounding=l.product_uom.rounding
             )
         )


### PR DESCRIPTION
Section and note lines (display_type) have no product_uom, so product_uom.rounding evaluates to 0.0 and float_is_zero raises "precision_rounding must be positive". Skip the qty check for these lines so they always render in the report.