### PR TITLE
[16.0][REF] partner_document: pull remain_files + tree decoration from dims_partner_document

### DIFF
--- a/partner_document/__manifest__.py
+++ b/partner_document/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Partner Document",
     "summary": "This module adds the logic to classify and evaluate the partner performance",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.0.3",
     "category": "Website",
     "author": "NuoBiT Solutions SL",
     "website": "https://github.com/nuobit/odoo-addons",

--- a/partner_document/i18n/ca.po
+++ b/partner_document/i18n/ca.po
@@ -387,6 +387,12 @@ msgstr ""
 " ha cap per a l'idioma."
 
 #. module: partner_document
+#: model:ir.model.fields,field_description:partner_document.field_res_partner__remain_files
+#: model:ir.model.fields,field_description:partner_document.field_res_users__remain_files
+msgid "Remain Files"
+msgstr "Arxius pendents"
+
+#. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.partner_document_expired_wizard_view_form
 msgid "Search"
 msgstr "Cerca"

--- a/partner_document/i18n/es.po
+++ b/partner_document/i18n/es.po
@@ -392,6 +392,12 @@ msgstr ""
 "existe para el idioma."
 
 #. module: partner_document
+#: model:ir.model.fields,field_description:partner_document.field_res_partner__remain_files
+#: model:ir.model.fields,field_description:partner_document.field_res_users__remain_files
+msgid "Remain Files"
+msgstr "Archivos pendientes"
+
+#. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.partner_document_expired_wizard_view_form
 msgid "Search"
 msgstr "Buscar"

--- a/partner_document/models/res_partner.py
+++ b/partner_document/models/res_partner.py
@@ -27,6 +27,23 @@ class ResPartner(models.Model):
         store=True,
         readonly=False,
     )
+    remain_files = fields.Boolean(
+        compute="_compute_remain_files",
+    )
+
+    def _get_valid_document(self, doc_type):
+        return self.document_ids.filtered(
+            lambda x: x.document_type_id == doc_type and x.is_valid_document()
+        )
+
+    @api.depends("document_ids", "classification_id")
+    def _compute_remain_files(self):
+        for rec in self:
+            rec.remain_files = False
+            for doc_type in rec.classification_id.document_type_ids:
+                if not self._get_valid_document(doc_type):
+                    rec.remain_files = True
+                    break
 
     @api.depends("classification_id", "classification_id.document_type_ids")
     def _compute_document_ids(self):

--- a/partner_document/views/res_partner_views.xml
+++ b/partner_document/views/res_partner_views.xml
@@ -54,8 +54,12 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_tree" />
         <field name="arch" type="xml">
+            <xpath expr="//tree" position="inside">
+                <field name="remain_files" invisible="1" />
+            </xpath>
             <xpath expr="//tree" position="attributes">
                 <attribute name="js_class">button_expired_documents_tree</attribute>
+                <attribute name="decoration-danger">remain_files == True</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- Move `remain_files` field (boolean: true when the partner is missing at least one valid document required by its classification) from `dims_partner_document.res_partner` → `partner_document.res_partner`.
- Move the red-row decoration on the partner tree (`decoration-danger="remain_files == True"`) from `dims_partner_document.res_partner_view_tree_inherit_document` → `partner_document.view_partner_tree`.
- Add Catalan + Spanish translations.
- Bump partner_document 16.0.1.0.2 → 16.0.1.0.3.

The logic is generic: it only depends on `partner.classification.document_type_ids` and `partner.document.is_valid_document()`, both already in this module. Pulling it here lets any consumer of `partner_document` (e.g. a future colored stat button on res.partner) use the field without depending on DIMS.

## Pairs with
This PR must be merged together with the dims-vertical counterpart that removes the same field/view from `dims_partner_document`. Without the pair, the field is briefly defined in two modules — fine for Odoo but technically a duplicate compute.

## Test plan
- [ ] Install/upgrade `partner_document` on a clean DB → no errors, `partner.remain_files` field exists.
- [ ] Open partner list view → partner rows with incomplete required docs are highlighted red.
- [ ] Verify Catalan + Spanish translations show.
- [ ] Install `dims_partner_document` (paired PR applied) on top → no field-redefinition warnings.