### PR TITLE
[16.0][IMP] partner_document: improve document review UX

### DIFF
--- a/partner_document/__manifest__.py
+++ b/partner_document/__manifest__.py
@@ -26,6 +26,7 @@
         "web.assets_backend": [
             "partner_document/static/src/js/kanban_res_partner_button.js",
             "partner_document/static/src/js/list_res_partner_button.js",
+            "partner_document/static/src/scss/styles.scss",
             "partner_document/static/src/xml/kanban_res_partner_button.xml",
             "partner_document/static/src/xml/list_res_partner_button.xml",
         ],

--- a/partner_document/i18n/ca.po
+++ b/partner_document/i18n/ca.po
@@ -470,6 +470,13 @@ msgstr "Validat per"
 
 #. module: partner_document
 #. odoo-python
+#: code:addons/partner_document/models/partner_document.py:0
+#, python-format
+msgid "Validated documents cannot be manually unvalidated. Change the file or expiration date to reset validation."
+msgstr "No es pot treure manualment la validació dels documents validats. Canvia el fitxer o la data d'expiració per reiniciar la validació."
+
+#. module: partner_document
+#. odoo-python
 #: code:addons/partner_document/models/partner_document_type.py:0
 #: code:addons/partner_document/models/partner_document_type.py:0
 #, python-format

--- a/partner_document/i18n/ca.po
+++ b/partner_document/i18n/ca.po
@@ -464,6 +464,11 @@ msgid "Validated"
 msgstr "Validat"
 
 #. module: partner_document
+#: model:ir.model.fields,field_description:partner_document.field_partner_document__validated_by_id
+msgid "Validated by"
+msgstr "Validat per"
+
+#. module: partner_document
 #. odoo-python
 #: code:addons/partner_document/models/partner_document_type.py:0
 #: code:addons/partner_document/models/partner_document_type.py:0

--- a/partner_document/i18n/es.po
+++ b/partner_document/i18n/es.po
@@ -475,6 +475,13 @@ msgstr "Validado por"
 
 #. module: partner_document
 #. odoo-python
+#: code:addons/partner_document/models/partner_document.py:0
+#, python-format
+msgid "Validated documents cannot be manually unvalidated. Change the file or expiration date to reset validation."
+msgstr "No se puede quitar manualmente la validación de documentos validados. Cambie el archivo o la fecha de expiración para reiniciar la validación."
+
+#. module: partner_document
+#. odoo-python
 #: code:addons/partner_document/models/partner_document_type.py:0
 #: code:addons/partner_document/models/partner_document_type.py:0
 #, python-format

--- a/partner_document/i18n/es.po
+++ b/partner_document/i18n/es.po
@@ -469,6 +469,11 @@ msgid "Validated"
 msgstr "Validado"
 
 #. module: partner_document
+#: model:ir.model.fields,field_description:partner_document.field_partner_document__validated_by_id
+msgid "Validated by"
+msgstr "Validado por"
+
+#. module: partner_document
 #. odoo-python
 #: code:addons/partner_document/models/partner_document_type.py:0
 #: code:addons/partner_document/models/partner_document_type.py:0

--- a/partner_document/models/partner_document.py
+++ b/partner_document/models/partner_document.py
@@ -99,12 +99,20 @@ class PartnerDocument(models.Model):
         default=False,
         tracking=True,
     )
+    validated_by_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Validated by",
+        readonly=True,
+        copy=False,
+        tracking=True,
+    )
 
     @api.depends("datas", "expiration_date")
     def _compute_validated(self):
         for rec in self:
             if rec.validated:
                 rec.validated = False
+                rec.validated_by_id = False
 
     no_expiration = fields.Boolean(related="document_type_id.no_expiration")
 
@@ -139,7 +147,14 @@ class PartnerDocument(models.Model):
                     % {"document_type": rec.document_type_id.display_name}
                 )
 
+    def _prepare_validated_by_values(self, vals):
+        if "validated" in vals:
+            vals = dict(vals)
+            vals["validated_by_id"] = self.env.user.id if vals["validated"] else False
+        return vals
+
     def write(self, vals):
+        vals = self._prepare_validated_by_values(vals)
         res = super().write(vals)
         self._validate_document()
         return res
@@ -166,8 +181,9 @@ class PartnerDocument(models.Model):
                 )
 
     @api.model_create_multi
-    def create(self, vals):
-        res = super().create(vals)
+    def create(self, vals_list):
+        vals_list = [self._prepare_validated_by_values(vals) for vals in vals_list]
+        res = super().create(vals_list)
         res._validate_document()
         return res
 

--- a/partner_document/models/partner_document.py
+++ b/partner_document/models/partner_document.py
@@ -46,6 +46,7 @@ class PartnerDocument(models.Model):
         comodel_name="partner.document.type",
         required=True,
         ondelete="restrict",
+        tracking=True,
     )
 
     @api.onchange("partner_classification_id")
@@ -60,15 +61,18 @@ class PartnerDocument(models.Model):
     datas = fields.Binary(
         string="File",
         attachment=True,
+        tracking=True,
     )
     datas_fname = fields.Char(
         string="Filename",
+        tracking=True,
     )
 
     expiration_date = fields.Date(
         compute="_compute_expiration_date",
         store=True,
         readonly=False,
+        tracking=True,
     )
 
     @api.depends("datas")
@@ -77,7 +81,7 @@ class PartnerDocument(models.Model):
             if not rec.datas:
                 rec.expiration_date = False
 
-    description = fields.Text()
+    description = fields.Text(tracking=True)
 
     expired = fields.Boolean(
         compute="_compute_expired",

--- a/partner_document/models/partner_document.py
+++ b/partner_document/models/partner_document.py
@@ -153,7 +153,22 @@ class PartnerDocument(models.Model):
             vals["validated_by_id"] = self.env.user.id if vals["validated"] else False
         return vals
 
+    def _check_validated_deactivation(self, vals):
+        if "validated" not in vals or vals["validated"]:
+            return
+        if not any(self.mapped("validated")):
+            return
+        if {"datas", "expiration_date"} & set(vals):
+            return
+        raise ValidationError(
+            _(
+                "Validated documents cannot be manually unvalidated. "
+                "Change the file or expiration date to reset validation."
+            )
+        )
+
     def write(self, vals):
+        self._check_validated_deactivation(vals)
         vals = self._prepare_validated_by_values(vals)
         res = super().write(vals)
         self._validate_document()

--- a/partner_document/models/partner_document.py
+++ b/partner_document/models/partner_document.py
@@ -127,6 +127,21 @@ class PartnerDocument(models.Model):
             or (self.expiration_date and self.expiration_date >= fields.Date.today())
         )
 
+    def action_show_document_chatter(self):
+        self.ensure_one()
+        view = self.env.ref("partner_document.partner_document_chatter_view_form")
+        return {
+            "name": _("Chatter"),
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "res_model": "partner.document",
+            "views": [(view.id, "form")],
+            "view_id": view.id,
+            "target": "new",
+            "res_id": self.id,
+            "context": dict(self.env.context),
+        }
+
     @api.constrains("expiration_date", "document_type_id")
     def _check_expiration_date_by_type(self):
         for rec in self:

--- a/partner_document/static/src/scss/styles.scss
+++ b/partner_document/static/src/scss/styles.scss
@@ -1,0 +1,3 @@
+.modal .modal-dialog .o_form_view .show-chatter-modal {
+    display: block !important;
+}

--- a/partner_document/tests/test_partner_document_flow.py
+++ b/partner_document/tests/test_partner_document_flow.py
@@ -137,9 +137,25 @@ class TestPartnerDocumentFlow(TransactionCase):
         self._upload_document(document)
         document = self._validate_document(document)
         self.assertTrue(document.validated)
+        self.assertEqual(document.validated_by_id, self.env.user)
+
+        def extend_expiration(document_form, __):
+            document_form.expiration_date = fields.Date.add(
+                fields.Date.today(),
+                days=60,
+            )
+
+        document = self._edit_partner_document(document, extend_expiration)
+        self.assertFalse(document.validated)
+        self.assertFalse(document.validated_by_id)
+
+        document = self._validate_document(document)
+        self.assertTrue(document.validated)
+        self.assertEqual(document.validated_by_id, self.env.user)
 
         self._upload_document(document, filename="new-passport.pdf")
         self.assertFalse(document.validated)
+        self.assertFalse(document.validated_by_id)
 
     def test_user_can_change_classification_without_losing_uploaded_documents(self):
         partner = self._create_partner(

--- a/partner_document/tests/test_partner_document_flow.py
+++ b/partner_document/tests/test_partner_document_flow.py
@@ -139,6 +139,11 @@ class TestPartnerDocumentFlow(TransactionCase):
         self.assertTrue(document.validated)
         self.assertEqual(document.validated_by_id, self.env.user)
 
+        with self.assertRaises(ValidationError):
+            document.write({"validated": False})
+        self.assertTrue(document.validated)
+        self.assertEqual(document.validated_by_id, self.env.user)
+
         def extend_expiration(document_form, __):
             document_form.expiration_date = fields.Date.add(
                 fields.Date.today(),

--- a/partner_document/views/partner_document_views.xml
+++ b/partner_document/views/partner_document_views.xml
@@ -72,6 +72,7 @@
                     <field name="document_ids">
                         <tree
                             create="false"
+                            delete="false"
                             editable="bottom"
                             decoration-danger="expired"
                         >

--- a/partner_document/views/partner_document_views.xml
+++ b/partner_document/views/partner_document_views.xml
@@ -61,7 +61,27 @@
                     force_save="1"
                 />
                 <field name="validated_by_id" widget="many2one_avatar_user" />
+                <button
+                    name="action_show_document_chatter"
+                    icon="fa-info-circle fa-lg"
+                    type="object"
+                    title="Info"
+                />
             </tree>
+        </field>
+    </record>
+
+    <record id="partner_document_chatter_view_form" model="ir.ui.view">
+        <field name="name">partner.document.chatter.form</field>
+        <field name="model">partner.document</field>
+        <field name="arch" type="xml">
+            <form string="Document Chatter" edit="0" create="0">
+                <sheet>
+                    <div class="oe_chatter show-chatter-modal">
+                        <field name="message_ids" />
+                    </div>
+                </sheet>
+            </form>
         </field>
     </record>
 
@@ -109,6 +129,12 @@
                             <field
                                 name="validated_by_id"
                                 widget="many2one_avatar_user"
+                            />
+                            <button
+                                name="action_show_document_chatter"
+                                icon="fa-info-circle fa-lg"
+                                type="object"
+                                title="Info"
                             />
                         </tree>
                     </field>

--- a/partner_document/views/partner_document_views.xml
+++ b/partner_document/views/partner_document_views.xml
@@ -44,6 +44,7 @@
                 <field
                     name="document_type_id"
                     readonly="1"
+                    force_save="1"
                     options="{'no_create': True, 'no_create_edit': True}"
                 />
                 <field name="description" />
@@ -110,6 +111,7 @@
                             <field
                                 name="document_type_id"
                                 readonly="1"
+                                force_save="1"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field name="description" />

--- a/partner_document/views/partner_document_views.xml
+++ b/partner_document/views/partner_document_views.xml
@@ -54,7 +54,11 @@
                     attrs="{'readonly': [('no_expiration', '=', True)]}"
                 />
                 <field name="expired" invisible="1" />
-                <field name="validated" />
+                <field
+                    name="validated"
+                    attrs="{'readonly': [('validated', '=', True)]}"
+                    force_save="1"
+                />
                 <field name="validated_by_id" widget="many2one_avatar_user" />
             </tree>
         </field>
@@ -95,7 +99,11 @@
                                 attrs="{'readonly': [('no_expiration', '=', True)]}"
                             />
                             <field name="expired" invisible="1" />
-                            <field name="validated" />
+                            <field
+                                name="validated"
+                                attrs="{'readonly': [('validated', '=', True)]}"
+                                force_save="1"
+                            />
                             <field
                                 name="validated_by_id"
                                 widget="many2one_avatar_user"

--- a/partner_document/views/partner_document_views.xml
+++ b/partner_document/views/partner_document_views.xml
@@ -43,6 +43,7 @@
                 <field name="no_expiration" invisible="1" />
                 <field
                     name="document_type_id"
+                    readonly="1"
                     options="{'no_create': True, 'no_create_edit': True}"
                 />
                 <field name="description" />
@@ -88,6 +89,7 @@
                             <field name="no_expiration" invisible="1" />
                             <field
                                 name="document_type_id"
+                                readonly="1"
                                 options="{'no_create': True, 'no_create_edit': True}"
                             />
                             <field name="description" />

--- a/partner_document/views/partner_document_views.xml
+++ b/partner_document/views/partner_document_views.xml
@@ -55,6 +55,7 @@
                 />
                 <field name="expired" invisible="1" />
                 <field name="validated" />
+                <field name="validated_by_id" widget="many2one_avatar_user" />
             </tree>
         </field>
     </record>
@@ -95,6 +96,10 @@
                             />
                             <field name="expired" invisible="1" />
                             <field name="validated" />
+                            <field
+                                name="validated_by_id"
+                                widget="many2one_avatar_user"
+                            />
                         </tree>
                     </field>
                 </sheet>


### PR DESCRIPTION
## Summary
- Hide the misleading delete control in the contact documents one2many view.
- Show the validating user with the standard avatar widget and clear it when automatic invalidation resets validation.
- Prevent users from manually unchecking validation once active; validation now resets only through file or expiration-date changes.
- Make document type readonly in editable document trees while preserving saves with `force_save`.
- Track relevant document field changes: expiration date, filename, file content, document type, and description.
- Add an info button that opens the document chatter in a modal.

## Test plan
- [x] xmllint --noout partner_document/views/partner_document_views.xml
- [x] python3 ast.parse() syntax check for partner_document.py and manifest
- [x] git diff --check
- [x] pre-commit run -a
- [x] GitHub CI: pre-commit, analyzers, CodeQL, dependency check, Codecov
- [x] GitHub CI: test with OCB
- [x] GitHub CI: test with Odoo