### PR TITLE
[16.0][FIX] partner_document: translate request data settings

### DIFF
--- a/partner_document/i18n/ca.po
+++ b/partner_document/i18n/ca.po
@@ -415,6 +415,7 @@ msgstr "Arxius pendents"
 #. module: partner_document
 #: model:ir.model.fields,field_description:partner_document.field_res_company__partner_document_request_data_template_id
 #: model:ir.model.fields,field_description:partner_document.field_res_config_settings__partner_document_request_data_template_id
+#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
 msgid "Request Data Email Template"
 msgstr "Plantilla de correu de sol·licitud de dades"
 
@@ -422,11 +423,6 @@ msgstr "Plantilla de correu de sol·licitud de dades"
 #: model_terms:ir.ui.view,arch_db:partner_document.view_partner_documents_form
 msgid "Request data"
 msgstr "Demanar dades"
-
-#. module: partner_document
-#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
-msgid "Request data email template"
-msgstr "Plantilla de correu de sol·licitud de dades"
 
 #. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.partner_document_expired_wizard_view_form

--- a/partner_document/i18n/de.po
+++ b/partner_document/i18n/de.po
@@ -33,6 +33,7 @@ msgstr "Konfigurieren Sie die E-Mail-Vorlage zur Datenanforderung in den Allgeme
 #. module: partner_document
 #: model:ir.model.fields,field_description:partner_document.field_res_company__partner_document_request_data_template_id
 #: model:ir.model.fields,field_description:partner_document.field_res_config_settings__partner_document_request_data_template_id
+#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
 msgid "Request Data Email Template"
 msgstr "E-Mail-Vorlage zur Datenanforderung"
 
@@ -40,11 +41,6 @@ msgstr "E-Mail-Vorlage zur Datenanforderung"
 #: model_terms:ir.ui.view,arch_db:partner_document.view_partner_documents_form
 msgid "Request data"
 msgstr "Daten anfordern"
-
-#. module: partner_document
-#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
-msgid "Request data email template"
-msgstr "E-Mail-Vorlage zur Datenanforderung"
 
 #. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form

--- a/partner_document/i18n/es.po
+++ b/partner_document/i18n/es.po
@@ -420,6 +420,7 @@ msgstr "Archivos pendientes"
 #. module: partner_document
 #: model:ir.model.fields,field_description:partner_document.field_res_company__partner_document_request_data_template_id
 #: model:ir.model.fields,field_description:partner_document.field_res_config_settings__partner_document_request_data_template_id
+#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
 msgid "Request Data Email Template"
 msgstr "Plantilla de correo de solicitud de datos"
 
@@ -427,11 +428,6 @@ msgstr "Plantilla de correo de solicitud de datos"
 #: model_terms:ir.ui.view,arch_db:partner_document.view_partner_documents_form
 msgid "Request data"
 msgstr "Solicitar datos"
-
-#. module: partner_document
-#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
-msgid "Request data email template"
-msgstr "Plantilla de correo de solicitud de datos"
 
 #. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.partner_document_expired_wizard_view_form

--- a/partner_document/i18n/fr.po
+++ b/partner_document/i18n/fr.po
@@ -33,6 +33,7 @@ msgstr "Configurez le modèle d'e-mail de demande de données dans les paramètr
 #. module: partner_document
 #: model:ir.model.fields,field_description:partner_document.field_res_company__partner_document_request_data_template_id
 #: model:ir.model.fields,field_description:partner_document.field_res_config_settings__partner_document_request_data_template_id
+#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
 msgid "Request Data Email Template"
 msgstr "Modèle d'e-mail de demande de données"
 
@@ -40,11 +41,6 @@ msgstr "Modèle d'e-mail de demande de données"
 #: model_terms:ir.ui.view,arch_db:partner_document.view_partner_documents_form
 msgid "Request data"
 msgstr "Demander les données"
-
-#. module: partner_document
-#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
-msgid "Request data email template"
-msgstr "Modèle d'e-mail de demande de données"
 
 #. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form

--- a/partner_document/i18n/nl.po
+++ b/partner_document/i18n/nl.po
@@ -33,6 +33,7 @@ msgstr "Configureer de e-mailsjabloon voor gegevensverzoeken in de algemene inst
 #. module: partner_document
 #: model:ir.model.fields,field_description:partner_document.field_res_company__partner_document_request_data_template_id
 #: model:ir.model.fields,field_description:partner_document.field_res_config_settings__partner_document_request_data_template_id
+#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
 msgid "Request Data Email Template"
 msgstr "E-mailsjabloon voor gegevensverzoek"
 
@@ -40,11 +41,6 @@ msgstr "E-mailsjabloon voor gegevensverzoek"
 #: model_terms:ir.ui.view,arch_db:partner_document.view_partner_documents_form
 msgid "Request data"
 msgstr "Gegevens opvragen"
-
-#. module: partner_document
-#: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form
-msgid "Request data email template"
-msgstr "E-mailsjabloon voor gegevensverzoek"
 
 #. module: partner_document
 #: model_terms:ir.ui.view,arch_db:partner_document.res_config_settings_view_form

--- a/partner_document/views/res_config_settings_views.xml
+++ b/partner_document/views/res_config_settings_views.xml
@@ -15,9 +15,11 @@
                     id="partner_document_request_data"
                 >
                     <div class="o_setting_right_pane">
-                        <span class="o_form_label">
-                            Request data email template
-                        </span>
+                        <label
+                            for="partner_document_request_data_template_id"
+                            string="Request Data Email Template"
+                            class="o_form_label"
+                        />
                         <span
                             class="fa fa-lg fa-building-o"
                             title="Values set here are company-specific."
@@ -26,8 +28,7 @@
                             role="img"
                         />
                         <div class="text-muted">
-                            Template used by the request data button in the contact
-                            documents view.
+                            Template used by the request data button in the contact documents view.
                         </div>
                         <div class="content-group">
                             <div class="mt8">


### PR DESCRIPTION
## Summary
- Use the standard settings pattern for the request-data template label, matching base geolocation: a real `<label string="..." for="..."/>` instead of free text inside `span.o_form_label`.
- Reuse the field label source string `Request Data Email Template` in the view to avoid near-duplicate PO entries that only differ by capitalization.
- Keep Catalan and other loaded language translations in the canonical PO files, including `i18n/ca.po` for Catalan.

## Test plan
- [x] `git diff --check`
- [x] `xmllint --noout partner_document/views/res_config_settings_views.xml`
- [x] `pre-commit run -a`
- [x] deployed to `customers-odoo16-test`
- [x] updated `odoo16-mateuadive-test`
- [x] verified `ir_ui_view.arch_db->>'ca_ES'` contains `string="Plantilla de correu de sol·licitud de dades"`
- [x] second `updateonlychanged.sh odoo16-mateuadive-test` no-op