### PR TITLE
[14.0][FIX] l10n_es_account_capital_asset: allow optional profile type

### DIFF
--- a/l10n_es_account_capital_asset/__manifest__.py
+++ b/l10n_es_account_capital_asset/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Account Capital Asset",
     "summary": "This module adds mapping for capital assets taxes, capital assets"
     " category types and threshold amount on res_config",
-    "version": "14.0.1.0.6",
+    "version": "14.0.1.0.7",
     "category": "Accounting",
     "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",

--- a/l10n_es_account_capital_asset/i18n/ca.po
+++ b/l10n_es_account_capital_asset/i18n/ca.po
@@ -1,0 +1,29 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_es_account_capital_asset
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-22 00:00+0000\n"
+"PO-Revision-Date: 2026-05-22 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_es_account_capital_asset
+#: code:addons/l10n_es_account_capital_asset/models/account_move.py:0
+#, python-format
+msgid ""
+"The asset profile '%s' requires a default capital asset type because the "
+"invoice line amount is equal to or greater than %s. Please configure the "
+"asset profile before posting the invoice."
+msgstr ""
+"El perfil d'actiu '%s' requereix un tipus de be d'inversio per defecte "
+"perque l'import de la linia de factura es igual o superior a %s. Configureu "
+"el perfil d'actiu abans de publicar la factura."

--- a/l10n_es_account_capital_asset/i18n/es.po
+++ b/l10n_es_account_capital_asset/i18n/es.po
@@ -66,6 +66,18 @@ msgid "Default Capital Asset Type"
 msgstr "Tipo de bien de inversión por defecto"
 
 #. module: l10n_es_account_capital_asset
+#: code:addons/l10n_es_account_capital_asset/models/account_move.py:0
+#, python-format
+msgid ""
+"The asset profile '%s' requires a default capital asset type because the "
+"invoice line amount is equal to or greater than %s. Please configure the "
+"asset profile before posting the invoice."
+msgstr ""
+"El perfil de activo '%s' requiere un tipo de bien de inversión por defecto "
+"porque el importe de la línea de factura es igual o superior a %s. Configure "
+"el perfil de activo antes de publicar la factura."
+
+#. module: l10n_es_account_capital_asset
 #: code:addons/l10n_es_account_capital_asset/models/account_asset.py:0
 #, python-format
 msgid "The asset of type ‘%s’ has an unit amount %.2f€ greater than %.2f€, "

--- a/l10n_es_account_capital_asset/models/account_asset.py
+++ b/l10n_es_account_capital_asset/models/account_asset.py
@@ -23,7 +23,7 @@ class AccountAsset(models.Model):
         domain="[('id', '=', profile_capital_asset_type_id)]",
     )
 
-    @api.constrains("capital_asset_type_id", "company_id")
+    @api.constrains("capital_asset_type_id", "company_id", "tax_base_amount")
     def _check_amount_type(self):
         threshold_capital_asset_amount = float(
             self.env["ir.config_parameter"]

--- a/l10n_es_account_capital_asset/models/account_asset_profile.py
+++ b/l10n_es_account_capital_asset/models/account_asset_profile.py
@@ -14,7 +14,6 @@ class AccountAssetProfile(models.Model):
         string="Default Capital Asset Type",
         comodel_name="l10n.es.account.capital.asset.type",
         ondelete="restrict",
-        required=True,
     )
 
     capital_asset_set = fields.Boolean(

--- a/l10n_es_account_capital_asset/models/account_move.py
+++ b/l10n_es_account_capital_asset/models/account_move.py
@@ -2,7 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 
-from odoo import models
+from odoo import _, models
+from odoo.exceptions import UserError
 
 
 class AccountMove(models.Model):
@@ -19,7 +20,16 @@ class AccountMove(models.Model):
                 )
             )
             if aml.balance >= threshold_amount:
-                vals[
-                    "capital_asset_type_id"
-                ] = aml.asset_profile_id.capital_asset_type_id
+                capital_asset_type = aml.asset_profile_id.capital_asset_type_id
+                if not capital_asset_type:
+                    raise UserError(
+                        _(
+                            "The asset profile '%s' requires a default capital asset "
+                            "type because the invoice line amount is equal to or "
+                            "greater than %s. Please configure the asset profile "
+                            "before posting the invoice."
+                        )
+                        % (aml.asset_profile_id.display_name, threshold_amount)
+                    )
+                vals["capital_asset_type_id"] = capital_asset_type
         return vals

--- a/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/__manifest__.py
+++ b/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "AEAT 303 - Special Prorate Regularization Capital Asset",
     "summary": "This module allows to regularize capital assets "
     "prorate differences on 303 report",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "category": "Accounting",
     "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",

--- a/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/i18n/ca.po
+++ b/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/i18n/ca.po
@@ -1,0 +1,27 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_es_aeat_mod303_special_prorate_regularization_capital_asset
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-22 00:00+0000\n"
+"PO-Revision-Date: 2026-05-22 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_es_aeat_mod303_special_prorate_regularization_capital_asset
+#: code:addons/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/mod303.py:0
+#, python-format
+msgid ""
+"The following assets require a capital asset type before creating the "
+"capital asset prorate regularization: %s"
+msgstr ""
+"Els actius seguents requereixen un tipus de be d'inversio abans de crear la "
+"regularitzacio de prorrata de bens d'inversio: %s"

--- a/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/i18n/es.po
+++ b/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/i18n/es.po
@@ -195,6 +195,16 @@ msgstr "El asiento contable no puede ser creado porque ya existe"
 #: code:addons/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/mod303.py:0
 #, python-format
 msgid ""
+"The following assets require a capital asset type before creating the "
+"capital asset prorate regularization: %s"
+msgstr ""
+"Los siguientes activos requieren un tipo de bien de inversión antes de crear "
+"la regularización de prorrata de bienes de inversión: %s"
+
+#. module: l10n_es_aeat_mod303_special_prorate_regularization_capital_asset
+#: code:addons/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/mod303.py:0
+#, python-format
+msgid ""
 "The following invoices %s have products with capital asset taxes but without"
 " asset"
 msgstr ""

--- a/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/mod303.py
+++ b/l10n_es_aeat_mod303_special_prorate_regularization_capital_asset/models/mod303.py
@@ -129,6 +129,10 @@ class L10nEsAeatMod303Report(models.AbstractModel):
         precision = self.env["decimal.precision"].precision_get("Account")
         lines = []
         move_lines_values = self._prepare_move_lines(tax_lines)
+        assets = self.env["account.asset"].browse(
+            [x["asset_id"][0] for x in move_lines_values]
+        )
+        self._check_assets_have_capital_asset_type(assets)
         for move_line in move_lines_values:
             asset = self.env["account.asset"].browse(move_line["asset_id"][0])
             percent_diff = (
@@ -222,7 +226,19 @@ class L10nEsAeatMod303Report(models.AbstractModel):
         )
         return tax_line_vals
 
+    def _check_assets_have_capital_asset_type(self, assets):
+        missing_assets = assets.filtered(lambda x: not x.capital_asset_type_id)
+        if missing_assets:
+            raise UserError(
+                _(
+                    "The following assets require a capital asset type before "
+                    "creating the capital asset prorate regularization: %s"
+                )
+                % ", ".join(missing_assets.mapped("display_name"))
+            )
+
     def _calculate_amount(self, assets_to_regularize, tax_final_percentage):
+        self._check_assets_have_capital_asset_type(assets_to_regularize)
         precision = self.env["decimal.precision"].precision_get("Account")
         amount = 0
         for asset in assets_to_regularize:

--- a/l10n_es_aeat_prorate_asset/__manifest__.py
+++ b/l10n_es_aeat_prorate_asset/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Prorate Asset",
     "summary": "This module add prorate fields on asset",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Accounting",
     "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",

--- a/l10n_es_aeat_prorate_asset/models/account_asset.py
+++ b/l10n_es_aeat_prorate_asset/models/account_asset.py
@@ -5,6 +5,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.osv import expression
 
 from odoo.addons.account_asset_management.models.account_asset import READONLY_STATES
 
@@ -15,9 +16,10 @@ class AccountAsset(models.Model):
     map_special_prorate_year_id = fields.Many2one(
         comodel_name="aeat.map.special.prorrate.year",
         compute="_compute_map_special_prorate_year_id",
+        search="_search_map_special_prorate_year_id",
     )
 
-    @api.depends("date_start")
+    @api.depends("company_id", "date_start")
     def _compute_map_special_prorate_year_id(self):
         for rec in self:
             if rec.date_start:
@@ -26,6 +28,48 @@ class AccountAsset(models.Model):
                 ].get_by_ukey(rec.company_id.id, rec.date_start.year)
             else:
                 rec.map_special_prorate_year_id = False
+
+    @api.model
+    def _get_map_special_prorate_year_domain(self, prorate_maps):
+        domains = []
+        for prorate_map in prorate_maps:
+            domains.append(
+                [
+                    ("company_id", "=", prorate_map.company_id.id),
+                    ("date_start", ">=", "%s-01-01" % prorate_map.year),
+                    ("date_start", "<=", "%s-12-31" % prorate_map.year),
+                ]
+            )
+        return expression.OR(domains) if domains else expression.FALSE_DOMAIN
+
+    @api.model
+    def _search_map_special_prorate_year_id(self, operator, value):
+        if operator not in ("=", "!=", "in", "not in"):
+            raise NotImplementedError(
+                _("Unsupported operator %s for map special prorate year search")
+                % operator
+            )
+
+        MapSpecialProrateYear = self.env["aeat.map.special.prorrate.year"]
+        is_negative = operator in ("!=", "not in")
+
+        if operator in ("=", "!=") and not value:
+            domain = self._get_map_special_prorate_year_domain(
+                MapSpecialProrateYear.search([])
+            )
+            return domain if is_negative else [expression.NOT_OPERATOR] + domain
+
+        value_ids = value.ids if hasattr(value, "ids") else value
+        if isinstance(value_ids, int):
+            value_ids = [value_ids]
+
+        if not value_ids:
+            return expression.TRUE_DOMAIN if is_negative else expression.FALSE_DOMAIN
+
+        domain = self._get_map_special_prorate_year_domain(
+            MapSpecialProrateYear.browse(value_ids).exists()
+        )
+        return [expression.NOT_OPERATOR] + domain if is_negative else domain
 
     def _compute_prorate_amounts(self, percent, is_deductible=True):
         self.ensure_one()


### PR DESCRIPTION
## Summary

- Keep `account.asset.profile.capital_asset_type_id` optional because it is a default/configuration value, not a mandatory classification for every profile.
- Raise a clear `UserError` when posting an invoice line that creates a capital asset above the threshold and the selected profile has no default capital asset type.
- Re-run the asset amount/type constraint when `tax_base_amount` changes.
- Guard model 303 capital-asset prorate regularization so assets without a capital asset type fail with a business error before `.period` is read.

## Rationale

Backfilling missing profile defaults to `Normal` would silently classify profiles that may not actually be capital assets. The safer behavior is to allow empty profile defaults, but require an explicit type when an actual capital asset or regularization operation needs the type/period.

## Validation

- Focused pre-commit passed for the changed NuoBiT files.
