### PR TITLE
[14.0][FIX] account_asset_tax_consistency: propagate template applicability

### DIFF
--- a/account_asset_tax_consistency/models/chart_template.py
+++ b/account_asset_tax_consistency/models/chart_template.py
@@ -17,3 +17,8 @@ class AccountTaxTemplate(models.Model):
         required=True,
         default="ignore",
     )
+
+    def _get_tax_vals(self, company, tax_template_to_tax):
+        vals = super()._get_tax_vals(company, tax_template_to_tax)
+        vals["apply_to_asset"] = self.apply_to_asset
+        return vals


### PR DESCRIPTION
This fixes the propagation of `apply_to_asset` from `account.tax.template` to the generated `account.tax` values.

Without this hook, taxes created from templates keep the default `ignore` value even when the template explicitly sets `always` or `never`. This surfaced while validating chart updates, but the fix belongs to the module that defines the field on both models.

Validation performed:
- `git diff --check -- account_asset_tax_consistency/models/chart_template.py`