### PR TITLE
[14.0][FIX] connector_woocommerce: compute picking states per order

### DIFF
--- a/connector_woocommerce/models/sale_order/sale_order.py
+++ b/connector_woocommerce/models/sale_order/sale_order.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import api, fields, models
@@ -64,7 +65,7 @@ class SaleOrder(models.Model):
     def _compute_woocommerce_order_state(self):
         for rec in self:
             if rec.is_woocommerce:
-                picking_states = self.picking_ids.mapped(
+                picking_states = rec.picking_ids.mapped(
                     "woocommerce_stock_picking_state"
                 )
                 woocommerce_order_state = rec._get_woocommerce_order_state(

--- a/connector_woocommerce/tests/__init__.py
+++ b/connector_woocommerce/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order

--- a/connector_woocommerce/tests/test_sale_order.py
+++ b/connector_woocommerce/tests/test_sale_order.py
@@ -17,33 +17,34 @@ class TestSaleOrder(SavepointCase):
         cls.customer_location = cls.env.ref("stock.stock_location_customers")
         cls.stock_location = cls.picking_type.default_location_src_id
 
-    def _create_woocommerce_order(self, picking_state):
+    def _create_woocommerce_order(self, cancel_picking=False):
         order = self.env["sale.order"].create(
             {
                 "partner_id": self.partner.id,
                 "is_woocommerce": True,
             }
         )
-        self.env["stock.picking"].create(
+        picking = self.env["stock.picking"].create(
             {
                 "partner_id": self.partner.id,
                 "picking_type_id": self.picking_type.id,
                 "location_id": self.stock_location.id,
                 "location_dest_id": self.customer_location.id,
                 "sale_id": order.id,
-                "state": picking_state,
             }
         )
+        if cancel_picking:
+            picking.action_cancel()
         return order
 
     def test_compute_woocommerce_order_state_uses_current_order_pickings(self):
-        processing_order = self._create_woocommerce_order("assigned")
-        done_order = self._create_woocommerce_order("done")
-        orders = processing_order | done_order
+        processing_order = self._create_woocommerce_order()
+        cancel_order = self._create_woocommerce_order(cancel_picking=True)
+        orders = processing_order | cancel_order
 
         orders._compute_woocommerce_order_state()
 
         self.assertEqual(processing_order.woocommerce_order_state, "processing")
-        self.assertEqual(done_order.woocommerce_order_state, "done")
+        self.assertEqual(cancel_order.woocommerce_order_state, "cancel")
         self.assertEqual(processing_order.done_picking_count, 0)
-        self.assertEqual(done_order.done_picking_count, 1)
+        self.assertEqual(cancel_order.done_picking_count, 0)

--- a/connector_woocommerce/tests/test_sale_order.py
+++ b/connector_woocommerce/tests/test_sale_order.py
@@ -1,0 +1,49 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import SavepointCase
+
+
+class TestSaleOrder(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "WooCommerce Test Customer",
+            }
+        )
+        cls.picking_type = cls.env.ref("stock.picking_type_out")
+        cls.customer_location = cls.env.ref("stock.stock_location_customers")
+        cls.stock_location = cls.picking_type.default_location_src_id
+
+    def _create_woocommerce_order(self, picking_state):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "is_woocommerce": True,
+            }
+        )
+        self.env["stock.picking"].create(
+            {
+                "partner_id": self.partner.id,
+                "picking_type_id": self.picking_type.id,
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.customer_location.id,
+                "sale_id": order.id,
+                "state": picking_state,
+            }
+        )
+        return order
+
+    def test_compute_woocommerce_order_state_uses_current_order_pickings(self):
+        processing_order = self._create_woocommerce_order("assigned")
+        done_order = self._create_woocommerce_order("done")
+        orders = processing_order | done_order
+
+        orders._compute_woocommerce_order_state()
+
+        self.assertEqual(processing_order.woocommerce_order_state, "processing")
+        self.assertEqual(done_order.woocommerce_order_state, "done")
+        self.assertEqual(processing_order.done_picking_count, 0)
+        self.assertEqual(done_order.done_picking_count, 1)


### PR DESCRIPTION
## Summary
- Fix the WooCommerce sale order state compute to read picking states from the current sale order, not the whole compute batch.
- Avoid wrong per-order state evaluation and unnecessary batch-wide picking reads during stored-field recompute.

## Test plan
- [x] `pre-commit run -a` passes locally in `/home/eantones/Documents/NuoBiT/dev/odoo/guijarron14/addons/nuobit-odoo-addons`
- [ ] CI green
- [ ] Manual review by Eric