### PR TITLE
[14.0][FIX] connector_woocommerce: avoid install recompute prefetch

### DIFF
--- a/connector_woocommerce/models/sale_order/sale_order.py
+++ b/connector_woocommerce/models/sale_order/sale_order.py
@@ -22,11 +22,26 @@ class SaleOrder(models.Model):
         store=True,
     )
 
-    @api.depends("state", "picking_ids", "picking_ids.state")
+    def _filter_woocommerce_orders(self):
+        """Avoid ORM prefetching all sale.order columns during install recompute."""
+        if not self:
+            return self
+        self.env.cr.execute(
+            """
+            SELECT id
+            FROM sale_order
+            WHERE id = ANY(%s)
+                AND is_woocommerce
+            """,
+            (self.ids,),
+        )
+        return self.browse([row[0] for row in self.env.cr.fetchall()])
+
+    @api.depends("is_woocommerce", "state", "picking_ids", "picking_ids.state")
     def _compute_woocommerce_status_write_date(self):
-        for rec in self:
-            if rec.is_woocommerce:
-                rec.woocommerce_status_write_date = fields.Datetime.now()
+        woocommerce_orders = self._filter_woocommerce_orders()
+        (self - woocommerce_orders).woocommerce_status_write_date = False
+        woocommerce_orders.woocommerce_status_write_date = fields.Datetime.now()
 
     woocommerce_order_state = fields.Selection(
         compute="_compute_woocommerce_order_state",
@@ -55,6 +70,7 @@ class SaleOrder(models.Model):
         return woocommerce_order_state
 
     @api.depends(
+        "is_woocommerce",
         "state",
         "order_line.qty_delivered",
         "order_line.product_uom_qty",
@@ -63,24 +79,23 @@ class SaleOrder(models.Model):
         "picking_ids.state",
     )
     def _compute_woocommerce_order_state(self):
-        for rec in self:
-            if rec.is_woocommerce:
-                picking_states = rec.picking_ids.mapped(
-                    "woocommerce_stock_picking_state"
+        woocommerce_orders = self._filter_woocommerce_orders()
+        non_woocommerce_orders = self - woocommerce_orders
+        non_woocommerce_orders.woocommerce_order_state = False
+        non_woocommerce_orders.done_picking_count = 0
+        for rec in woocommerce_orders:
+            picking_states = rec.picking_ids.mapped("woocommerce_stock_picking_state")
+            woocommerce_order_state = rec._get_woocommerce_order_state(picking_states)
+            new_count = len(rec.picking_ids.filtered(lambda p: p.state == "done"))
+            if (
+                woocommerce_order_state != rec.woocommerce_order_state
+                or new_count != rec.done_picking_count
+            ):
+                rec.woocommerce_order_state = woocommerce_order_state
+                rec.done_picking_count = new_count
+                self._event("on_compute_woocommerce_order_state").notify(
+                    rec, fields={"woocommerce_order_state"}
                 )
-                woocommerce_order_state = rec._get_woocommerce_order_state(
-                    picking_states
-                )
-                new_count = len(rec.picking_ids.filtered(lambda p: p.state == "done"))
-                if (
-                    woocommerce_order_state != rec.woocommerce_order_state
-                    or new_count != rec.done_picking_count
-                ):
-                    rec.woocommerce_order_state = woocommerce_order_state
-                    rec.done_picking_count = new_count
-                    self._event("on_compute_woocommerce_order_state").notify(
-                        rec, fields={"woocommerce_order_state"}
-                    )
 
     def action_confirm(self):
         res = super().action_confirm()

--- a/connector_woocommerce/tests/test_sale_order.py
+++ b/connector_woocommerce/tests/test_sale_order.py
@@ -17,13 +17,12 @@ class TestSaleOrder(SavepointCase):
         cls.customer_location = cls.env.ref("stock.stock_location_customers")
         cls.stock_location = cls.picking_type.default_location_src_id
 
-    def _create_woocommerce_order(self, cancel_picking=False):
-        order = self.env["sale.order"].create(
-            {
-                "partner_id": self.partner.id,
-                "is_woocommerce": True,
-            }
-        )
+    def _create_order(self, is_woocommerce=True, cancel_picking=False):
+        vals = {
+            "partner_id": self.partner.id,
+            "is_woocommerce": is_woocommerce,
+        }
+        order = self.env["sale.order"].create(vals)
         picking = self.env["stock.picking"].create(
             {
                 "partner_id": self.partner.id,
@@ -38,8 +37,8 @@ class TestSaleOrder(SavepointCase):
         return order
 
     def test_compute_woocommerce_order_state_uses_current_order_pickings(self):
-        processing_order = self._create_woocommerce_order()
-        cancel_order = self._create_woocommerce_order(cancel_picking=True)
+        processing_order = self._create_order()
+        cancel_order = self._create_order(cancel_picking=True)
         orders = processing_order | cancel_order
 
         orders._compute_woocommerce_order_state()
@@ -48,3 +47,17 @@ class TestSaleOrder(SavepointCase):
         self.assertEqual(cancel_order.woocommerce_order_state, "cancel")
         self.assertEqual(processing_order.done_picking_count, 0)
         self.assertEqual(cancel_order.done_picking_count, 0)
+
+    def test_compute_woocommerce_fields_ignore_non_woocommerce_orders(self):
+        woocommerce_order = self._create_order()
+        sale_order = self._create_order(is_woocommerce=False)
+        orders = woocommerce_order | sale_order
+
+        orders._compute_woocommerce_status_write_date()
+        orders._compute_woocommerce_order_state()
+
+        self.assertTrue(woocommerce_order.woocommerce_status_write_date)
+        self.assertEqual(woocommerce_order.woocommerce_order_state, "processing")
+        self.assertFalse(sale_order.woocommerce_status_write_date)
+        self.assertFalse(sale_order.woocommerce_order_state)
+        self.assertEqual(sale_order.done_picking_count, 0)


### PR DESCRIPTION
## Summary
- Avoid reading `is_woocommerce` through the ORM for every `sale.order` during stored-field recompute.
- Filter WooCommerce orders with a targeted SQL query, assign neutral values to non-WooCommerce orders, and keep the existing export notification behavior for WooCommerce orders.
- Add regression coverage for mixed WooCommerce/non-WooCommerce batches.

## Test plan
- [x] `pre-commit run -a`
- [x] `git diff --check`
- [x] GitHub CI green: pre-commit, CodeQL, Odoo, OCB, dependency detection, Codecov patch/project
- [ ] Local install test: blocked before this module's code by missing `python-magic` dependency from `connector_wordpress` in the `guijarron14` conda env.