### PR TITLE
[14.0][FIX] connector_woocommerce: read discount precision via precision_get

### DIFF
--- a/connector_woocommerce/models/sale_order_line/sale_order_line.py
+++ b/connector_woocommerce/models/sale_order_line/sale_order_line.py
@@ -29,7 +29,7 @@ class SaleOrderLine(models.Model):
     )
 
     def write(self, vals):
-        prec = self.env.ref("product.decimal_discount").digits
+        prec = self.env["decimal.precision"].precision_get("Discount")
         if "woocommerce_discount" in vals:
             vals["discount"] = vals["woocommerce_discount"]
         elif "discount" in vals and not self.woocommerce_discount:
@@ -38,7 +38,7 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        prec = self.env.ref("product.decimal_discount").digits
+        prec = self.env["decimal.precision"].precision_get("Discount")
         for values in vals_list:
             if "woocommerce_discount" in values:
                 values["discount"] = values["woocommerce_discount"]

--- a/connector_woocommerce/models/sale_order_line/sale_order_line.py
+++ b/connector_woocommerce/models/sale_order_line/sale_order_line.py
@@ -29,20 +29,24 @@ class SaleOrderLine(models.Model):
     )
 
     def write(self, vals):
-        prec = self.env["decimal.precision"].precision_get("Discount")
+        # if/elif, not two ifs: a WooCommerce discount (the importer sets both
+        # keys) is kept verbatim (digits=False); a manual discount is rounded.
         if "woocommerce_discount" in vals:
             vals["discount"] = vals["woocommerce_discount"]
         elif "discount" in vals and not self.woocommerce_discount:
+            prec = self.env["decimal.precision"].precision_get("Discount")
             vals["discount"] = float_round(vals["discount"], precision_digits=prec)
         return super().write(vals)
 
     @api.model_create_multi
     def create(self, vals_list):
-        prec = self.env["decimal.precision"].precision_get("Discount")
+        # if/elif, not two ifs: a WooCommerce discount (the importer sets both
+        # keys) is kept verbatim (digits=False); a manual discount is rounded.
         for values in vals_list:
             if "woocommerce_discount" in values:
                 values["discount"] = values["woocommerce_discount"]
             elif "discount" in values:
+                prec = self.env["decimal.precision"].precision_get("Discount")
                 values["discount"] = float_round(
                     values["discount"], precision_digits=prec
                 )

--- a/connector_woocommerce/tests/test_sale_order.py
+++ b/connector_woocommerce/tests/test_sale_order.py
@@ -61,3 +61,39 @@ class TestSaleOrder(SavepointCase):
         self.assertFalse(sale_order.woocommerce_status_write_date)
         self.assertFalse(sale_order.woocommerce_order_state)
         self.assertEqual(sale_order.done_picking_count, 0)
+
+    def test_create_line_as_salesperson_without_settings_group(self):
+        """Saving a sale order line must not require ORM access to
+        ``decimal.precision``.
+
+        Regression: ``create``/``write`` read the Discount precision via
+        ``self.env.ref("product.decimal_discount").digits`` (an ORM read of a
+        ``decimal.precision`` record), which raised AccessError for users
+        without the Settings group (``base.group_system``).
+        """
+        salesperson = self.env["res.users"].create(
+            {
+                "name": "Salesperson Without Settings",
+                "login": "wc_salesperson_no_settings",
+                "groups_id": [
+                    (6, 0, [self.env.ref("sales_team.group_sale_salesman").id])
+                ],
+            }
+        )
+        product = self.env["product.product"].create({"name": "WC Test Product"})
+        line_vals = {
+            "product_id": product.id,
+            "product_uom_qty": 1.0,
+            "discount": 10.0,
+        }
+        order = (
+            self.env["sale.order"]
+            .with_user(salesperson)
+            .create(
+                {
+                    "partner_id": self.partner.id,
+                    "order_line": [(0, 0, line_vals)],
+                }
+            )
+        )
+        self.assertEqual(len(order.order_line), 1)


### PR DESCRIPTION
## Summary
- `SaleOrderLine.create`/`write` in `connector_woocommerce` read the *Discount* precision via `self.env.ref("product.decimal_discount").digits` — an ORM read of a `decimal.precision` record.
- Stock Odoo restricts ORM access to `decimal.precision` to the Settings group (`base.group_system`), so saving any sale order line raised `AccessError` for internal users without it (e.g. salespeople).
- Use `decimal.precision.precision_get("Discount")` instead (raw SQL, ACL-safe — the standard way Odoo resolves `Float` digits). Same value, behaviour unchanged.
- Add a regression test: a salesperson without `group_system` can save a sale order line.

Ref: NuoBiT task #2690.

## Test plan
- [x] pre-commit passes locally
- [ ] CI green
- [ ] manual: a salesperson without Settings saves a quotation line without `AccessError`