### PR TITLE
[16.0][FIX] rental_base_extension: resolve sale type before sequence

### DIFF
--- a/rental_base_extension/models/sale_order.py
+++ b/rental_base_extension/models/sale_order.py
@@ -58,6 +58,19 @@ class SaleOrder(models.Model):
         for order in self:
             order.is_rental_order = bool(rental_type and order.type_id == rental_type)
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if not vals.get("type_id"):
+                # sale_order_type assigns the sequence before computed values
+                # are stored. Resolve the in-memory order type first so the
+                # name uses that type's sequence instead of the generic
+                # sale.order fallback, which rental_base also overrides.
+                order_type = self.new(vals).type_id
+                if order_type:
+                    vals["type_id"] = order_type.id
+        return super().create(vals_list)
+
     @api.depends(
         "state",
         "is_rental_order",

--- a/rental_base_extension/tests/__init__.py
+++ b/rental_base_extension/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_rental_status
+from . import test_sale_order_sequence

--- a/rental_base_extension/tests/test_sale_order_sequence.py
+++ b/rental_base_extension/tests/test_sale_order_sequence.py
@@ -14,6 +14,7 @@ class TestSaleOrderSequence(common.TransactionCase):
         cls.partner = cls.env["res.partner"].create(
             {
                 "name": "Test Sequence Partner",
+                "email": "test.sequence@example.com",
             }
         )
 

--- a/rental_base_extension/tests/test_sale_order_sequence.py
+++ b/rental_base_extension/tests/test_sale_order_sequence.py
@@ -1,0 +1,60 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
+
+from odoo.tests import common, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestSaleOrderSequence(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.normal_sale_type = cls.env.ref("sale_order_type.normal_sale_type")
+        cls.rental_sale_type = cls.env.ref("rental_base.rental_sale_type")
+        cls.partner = cls.env["res.partner"].create(
+            {
+                "name": "Test Sequence Partner",
+            }
+        )
+
+    def _expected_name(self, sequence):
+        return sequence.get_next_char(sequence.number_next_actual)
+
+    def test_explicit_normal_type_uses_normal_sequence_with_rental_context(self):
+        expected_name = self._expected_name(self.normal_sale_type.sequence_id)
+        order = (
+            self.env["sale.order"]
+            .with_context(default_type_id=self.rental_sale_type.id)
+            .create(
+                {
+                    "type_id": self.normal_sale_type.id,
+                    "partner_id": self.partner.id,
+                }
+            )
+        )
+        self.assertEqual(order.type_id, self.normal_sale_type)
+        self.assertEqual(order.name, expected_name)
+        self.assertFalse(order.is_rental_order)
+
+    def test_resolved_normal_type_uses_normal_sequence_with_rental_context(self):
+        self.partner.with_company(self.env.company).sale_type = self.normal_sale_type
+        expected_name = self._expected_name(self.normal_sale_type.sequence_id)
+        order = (
+            self.env["sale.order"]
+            .with_context(default_type_id=self.rental_sale_type.id)
+            .create({"partner_id": self.partner.id})
+        )
+        self.assertEqual(order.type_id, self.normal_sale_type)
+        self.assertEqual(order.name, expected_name)
+        self.assertFalse(order.is_rental_order)
+
+    def test_rental_default_type_uses_rental_sequence(self):
+        expected_name = self._expected_name(self.rental_sale_type.sequence_id)
+        order = (
+            self.env["sale.order"]
+            .with_context(default_type_id=self.rental_sale_type.id)
+            .create({"partner_id": self.partner.id})
+        )
+        self.assertEqual(order.type_id, self.rental_sale_type)
+        self.assertEqual(order.name, expected_name)
+        self.assertTrue(order.is_rental_order)


### PR DESCRIPTION
## Summary
- Resolve the computed sale order type before `sale_order_type` assigns the order sequence.
- Prevent stale rental `default_type_id` context from giving normal sale orders an `RO` rental number.
- Add coverage for explicit normal orders, partner-resolved normal orders, and real rental orders.

## Test plan
- [x] `pre-commit run -a`
- [x] Focused `rental_base_extension` Odoo test suite: `10 tests, 0 failed, 0 errors`