### PR TITLE
[16.0][FIX] connector_sapb1: truncate Street to SAP 100-char limit

### DIFF
--- a/connector_sapb1/models/res_partner/export_mapper.py
+++ b/connector_sapb1/models/res_partner/export_mapper.py
@@ -61,7 +61,9 @@ class ResPartnerExportMapper(Component):
                 lambda x: x.strip(), filter(None, [record["street"], record["street2"]])
             )
         )
-        return {"Street": street_l and " ".join(street_l) or None}
+        street = street_l and " ".join(street_l) or None
+        # SAP Street is NVARCHAR(100); truncate so an over-long address still exports
+        return {"Street": street and street[:100] or None}
 
     @changed_by("zip")
     @mapping


### PR DESCRIPTION
## Summary
- SAP `Street` is `NVARCHAR(100)`. The partner export mapper concatenates `street` + `street2` into `Street` — deliberately: SAP's second address line is not rendered on the printed order/invoice documents, so line 2 is folded into `Street`, which does print.
- When the concatenation exceeds 100 characters the SAP Service Layer rejects the export (`value too long in property 'Street'`) and the record never reaches SAP.
- Truncate the concatenated value to 100 characters so the export always succeeds. A truncated street still prints; a rejected order does not reach SAP at all.

## Test plan
- [x] pre-commit passes locally (scoped to the changed file)
- [ ] CI green
- [ ] manual: on a dedicated test DB, export a partner whose `street` + `street2` exceeds 100 chars; confirm the SAP address record is created with a 100-char `Street` and no "too long" error
