### PR TITLE
[16.0][FIX] connector_sapb1: enforce SAP Street length in the partner adapter

### DIFF
--- a/connector_extension/components/adapter.py
+++ b/connector_extension/components/adapter.py
@@ -234,6 +234,17 @@ class ConnectorExtensionAdapterCRUD(AbstractComponent):
             for ch in elem:
                 self._convert_format(ch, mapper, path)
 
+    def _convert_format_domain_values(self, domain, conv_mapper):
+        res = []
+        for k, op, v in domain:
+            if k in conv_mapper:
+                if isinstance(v, (list, tuple)):
+                    v = type(v)(conv_mapper[k](x) for x in v)
+                else:
+                    v = conv_mapper[k](v)
+            res.append((k, op, v))
+        return res
+
     def _convert_format_domain(self, domain):
         res = []
         for k, op, v in domain:

--- a/connector_extension/components/adapter.py
+++ b/connector_extension/components/adapter.py
@@ -254,6 +254,8 @@ class ConnectorExtensionAdapterCRUD(AbstractComponent):
                 v = v.strftime(self._date_format)
             elif isinstance(v, (int, str, list, tuple, bool)):
                 pass
+            elif v is None:
+                pass
             else:
                 raise Exception("Type '%s' not supported" % type(v))
             res.append((k, op, v))

--- a/connector_extension/components/binder.py
+++ b/connector_extension/components/binder.py
@@ -43,6 +43,12 @@ class ConnectorExtensionBinderComposite(AbstractComponent):
 
     _default_binding_field = None
 
+    # Alternate-id components listed here may be null and still match on
+    # null as a value (an address without zip stores NULL there). The rest
+    # are mandatory: a null on them means the record has no usable identity
+    # and the export fails. At least one component must stay mandatory.
+    external_alt_id_nullable_fields = []
+
     def idhash(self, external_id):
         odoo_hash = hashlib.sha256()
         for e in external_id:
@@ -464,6 +470,59 @@ class ConnectorExtensionBinderComposite(AbstractComponent):
                 return res[0]
         return {}
 
+    def _check_external_alt_id(self, id_values):
+        alt_id_fields = self.get_id_fields(in_field=False, alt_field=True)
+        nullable_fields = self.external_alt_id_nullable_fields
+        unknown_fields = set(nullable_fields) - set(alt_id_fields)
+        if unknown_fields:
+            raise ValidationError(
+                _(
+                    "Nullable fields %(FIELDS)s are not components of the "
+                    "alternate id %(ALT_ID)s of %(MODEL)s"
+                )
+                % {
+                    "FIELDS": sorted(unknown_fields),
+                    "ALT_ID": alt_id_fields,
+                    "MODEL": self.model._name,
+                }
+            )
+        if not set(alt_id_fields) - set(nullable_fields):
+            raise ValidationError(
+                _(
+                    "At least one component of the alternate id %(ALT_ID)s "
+                    "of %(MODEL)s must be mandatory"
+                )
+                % {
+                    "ALT_ID": alt_id_fields,
+                    "MODEL": self.model._name,
+                }
+            )
+        external_alt_id = self.dict2id(id_values, in_field=False, alt_field=True)
+        if external_alt_id is None:
+            missing_fields = [
+                f for f in alt_id_fields if f.split(".")[0] not in id_values
+            ]
+            raise ValidationError(
+                _(
+                    "Components %(FIELDS)s of the alternate id of %(MODEL)s "
+                    "are not produced by the export mapper"
+                )
+                % {
+                    "FIELDS": missing_fields,
+                    "MODEL": self.model._name,
+                }
+            )
+        null_mandatory_fields = [
+            field
+            for field, value in zip(alt_id_fields, external_alt_id)
+            if value is None and field not in nullable_fields
+        ]
+        if null_mandatory_fields:
+            raise InvalidDataError(
+                "Mandatory components %s of the alternate id of %s are null"
+                % (null_mandatory_fields, self.model._name)
+            )
+
     def to_binding_from_internal_key(self, relation):
         """
         Given an odoo object (not binding object) without binding related
@@ -493,10 +552,7 @@ class ConnectorExtensionBinderComposite(AbstractComponent):
                 binding=self.model,
                 ignore_required_fields=True,
             )
-            # TODO: check if we can put this in a hook
-            external_alt_id = self.dict2id(id_values, in_field=False, alt_field=True)
-            if self.is_id_null(external_alt_id):
-                return self.model
+            self._check_external_alt_id(id_values)
         record = self._get_external_record_alt(relation, id_values)
         if record:
             external_id = self.dict2id(record, in_field=False)

--- a/connector_sapb1/components/adapter.py
+++ b/connector_sapb1/components/adapter.py
@@ -122,6 +122,7 @@ class SapB1Adapter(AbstractComponent):
             else:
                 raise ValidationError(r.text)
         self._logout(session)
+        return result
 
     def _create_order(self, session, params):
         self._login(session)

--- a/connector_sapb1/models/res_partner/adapter.py
+++ b/connector_sapb1/models/res_partner/adapter.py
@@ -43,7 +43,8 @@ class SapB1ResPartnerAdapter(Component):
             "City": lambda x: x or None,
             "AddressName3": lambda x: x or None,
         }
-        return self._convert_format_domain(domain, conv_mapper)
+        domain = self._convert_format_domain(domain)
+        return self._convert_format_domain_values(domain, conv_mapper)
 
     def _reorg_partner_data(self, values):
         for address in values["BPAddresses"]:

--- a/connector_sapb1/models/res_partner/adapter.py
+++ b/connector_sapb1/models/res_partner/adapter.py
@@ -27,7 +27,6 @@ class SapB1ResPartnerAdapter(Component):
 
     def _format_partner_values(self, values):
         conv_mapper = {
-            "/Block": lambda x: x or None,
             "/Street": lambda x: x or None,
             "/ZipCode": lambda x: x or None,
             "/City": lambda x: x or None,
@@ -37,7 +36,6 @@ class SapB1ResPartnerAdapter(Component):
 
     def _format_partner_domain(self, domain):
         conv_mapper = {
-            "Block": lambda x: x or None,
             "Street": lambda x: x or None,
             "ZipCode": lambda x: x or None,
             "City": lambda x: x or None,

--- a/connector_sapb1/models/res_partner/adapter.py
+++ b/connector_sapb1/models/res_partner/adapter.py
@@ -25,6 +25,10 @@ class SapB1ResPartnerAdapter(Component):
             **self._prepare_parameters(kw_base_params, [], filters_values)
         )
         res = self._reorg_partner_data(res)
+        # normalize like written values so empty backend strings compare
+        # equal to the None values used in lookup domains
+        for address in res:
+            self._format_partner_values(address)
         filtered_res = self._filter(res, common_domain)
         return filtered_res
 

--- a/connector_sapb1/models/res_partner/adapter.py
+++ b/connector_sapb1/models/res_partner/adapter.py
@@ -3,6 +3,9 @@
 
 from odoo.addons.component.core import Component
 
+# SAP stores BP address streets in CRD1.Street, an NVARCHAR(100) column
+SAP_STREET_MAXLEN = 100
+
 
 class SapB1ResPartnerAdapter(Component):
     _name = "sapb1.res.partner.adapter"
@@ -27,7 +30,7 @@ class SapB1ResPartnerAdapter(Component):
 
     def _format_partner_values(self, values):
         conv_mapper = {
-            "/Street": lambda x: x or None,
+            "/Street": lambda x: x and x[:SAP_STREET_MAXLEN] or None,
             "/ZipCode": lambda x: x or None,
             "/City": lambda x: x or None,
             "/AddressName3": lambda x: x or None,
@@ -36,7 +39,7 @@ class SapB1ResPartnerAdapter(Component):
 
     def _format_partner_domain(self, domain):
         conv_mapper = {
-            "Street": lambda x: x or None,
+            "Street": lambda x: x and x[:SAP_STREET_MAXLEN] or None,
             "ZipCode": lambda x: x or None,
             "City": lambda x: x or None,
             "AddressName3": lambda x: x or None,
@@ -60,5 +63,6 @@ class SapB1ResPartnerAdapter(Component):
         """Update records on the external system"""
         values.pop("CardCode")
         values.pop("AddressName")
+        self._format_partner_values(values)
         res = self._exec("update_address", external_id=external_id, values=values)
         return res

--- a/connector_sapb1/models/res_partner/binder.py
+++ b/connector_sapb1/models/res_partner/binder.py
@@ -21,3 +21,13 @@ class ResPartnerBinder(Component):
         "ZipCode",
         "City",
     ]
+    # CardCode and AddressName2 identify the account and the addressee and
+    # are mandatory; the remaining components describe the address and may
+    # be null: an address without email, street, zip or city stores NULL
+    # there, and null is part of its identity, not a reason to skip matching
+    external_alt_id_nullable_fields = [
+        "AddressName3",
+        "Street",
+        "ZipCode",
+        "City",
+    ]

--- a/connector_sapb1/models/res_partner/binder.py
+++ b/connector_sapb1/models/res_partner/binder.py
@@ -18,7 +18,6 @@ class ResPartnerBinder(Component):
         "AddressName2",
         "AddressName3",
         "Street",
-        "Block",
         "ZipCode",
         "City",
     ]

--- a/connector_sapb1/models/res_partner/export_mapper.py
+++ b/connector_sapb1/models/res_partner/export_mapper.py
@@ -61,9 +61,7 @@ class ResPartnerExportMapper(Component):
                 lambda x: x.strip(), filter(None, [record["street"], record["street2"]])
             )
         )
-        street = street_l and " ".join(street_l) or None
-        # SAP Street is NVARCHAR(100); truncate so an over-long address still exports
-        return {"Street": street and street[:100] or None}
+        return {"Street": street_l and " ".join(street_l) or None}
 
     @changed_by("zip")
     @mapping


### PR DESCRIPTION
## Summary

SAP B1 rejects a whole document export with `Value too long for column 'Street'` when the concatenated `street` + `street2` exceeds `CRD1.Street` (`NVARCHAR(100)`). #937 capped the value in the export mapper; this PR moves that concern to its proper layer, removes a dead field, and makes the partner address matching this uncovers actually work. Nine commits, each incremental:

1. **Revert** of the mapper-level truncation (#937), in git's default revert format: column sizes are a backend schema constraint, not a mapping concern — the adapter is the facade that knows the backend database.
2. **[IMP] connector_extension**: add `_convert_format_domain_values()`, the domain-side counterpart of `_convert_format()`: it applies a per-field converter mapping per clause (element-wise on `in` lists) and nothing else. Backend type formatting stays in `_convert_format_domain()` — one concern per function.
3. **[FIX] connector_sapb1**: `_format_partner_domain()` passed its converter mapping as a second positional argument to `_convert_format_domain()`, which accepts none: any execution raised `TypeError` (latent, unreachable until now — see below). Compose the two base helpers instead: format the domain types, then apply the partner converters.
4. **[FIX] connector_sapb1**: `_get_partner()` performed the request and parsed the response but fell off the end without returning it — every consumer needing the payload dereferences `None`. Latent for the same reason as the other two fixes; the revived matching reads the partner's addresses from it. Return the parsed partner.
5. **[REM] connector_sapb1**: drop `Block` from the partner adapter converters and the binder `external_alt_id`. The export mapper never produces `Block`, so the alternate-key resolution always contained a null component and aborted: **partner alternate-key matching has never executed** — every unbound partner address went straight to create. Measured on a production dataset (19 mapped partner accounts, 7,515 address rows): distinct match keys with vs. without `Block` are identical (7,019 = 7,019), so `Block` adds zero discrimination; 6.6% of rows (496) are duplicates accumulated precisely because matching never ran.
6. **[FIX] connector_sapb1**: enforce the 100-char cap in the partner adapter on all Street paths: create values, search domain (so lookups compare exactly what create writes), and `write()`, which previously bypassed value normalization entirely.
7. **[FIX] connector_sapb1**: normalize the rows fetched by `search_read` with the same value converters used for writing. The lookup domain converts empty values to None while fetched rows kept empty strings, so the two sides of the comparison followed different conventions and an address with any empty component could never match — latent for the same reason as the `TypeError` above.
8. **[IMP] connector_extension**: per-field null semantics for the alternate id (`external_alt_id_nullable_fields`) — a null on a declared-nullable component is a legitimate identity value (an address without zip stores NULL, so NULL is what an identical existing record contains); a null on a **mandatory** component raises `InvalidDataError` (a record with incomplete identity can neither be matched now nor ever be matched later — silently creating it would plant a permanently unmatchable row; the all-null key is the extreme case of the same rule); a component **missing from the mapper output** raises `ValidationError` (binder/mapper configuration error that silently disables matching for the whole model — exactly how the `Block` issue stayed invisible for years). At least one component must remain mandatory and nullable declarations must belong to the key, both enforced.
9. **[IMP] connector_sapb1**: partner alternate id declares `AddressName3`, `Street`, `ZipCode`, `City` nullable; `CardCode` and `AddressName2` stay mandatory.

## Review notes

1. Alternate-key matching for partner addresses becomes live for the first time: repeat addresses now link to the existing backend row instead of duplicating it, including addresses with empty nullable fields.
2. Where identical duplicates **already** exist in the backend (the 496 legacy rows), the lookup raises `"the alternate external id ... is not unique"` and the job fails visibly — consistent with how every other backend anomaly surfaces (e.g. a locked posting period). A one-off backend dedup of those legacy rows ends these failures permanently; the exact row list can be extracted on request.
3. Since this path has never run in production, a functional pass on a test database before deploying is recommended.
4. If a deployment extends the partner export mapper to produce `Block`, dropping it from `external_alt_id` changes that deployment's match key; no in-tree module does.

5. **Deployment dependency**: this PR must run together with #895 (already aggregated in production via `refs/pull/895/head`): the revived matching path persists bindings through `bind_export()`, whose eager commit needs #895's `allow_commit` job functions plus its cursor-rebind of job args. Without #895, every match ends in "Commit is forbidden in queue jobs".

## Test plan

- [x] pre-commit passes locally on every commit
- [ ] CI green
- [ ] manual test on a dedicated test database: export a partner with a >100-char street (create); repeat an identical address (match instead of duplicate); an address with empty zip/email (match on NULL); a legacy-duplicated address (job fails with "not unique")


