### PR TITLE
[16.0][IMP] connector_lengow: keep order addresses on anonymized re-syncs

### DIFF
--- a/connector_lengow/__manifest__.py
+++ b/connector_lengow/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Connector Lengow",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "author": "NuoBiT Solutions SL",
     "license": "AGPL-3",
     "category": "Connector",

--- a/connector_lengow/models/sale_order/import_mapper.py
+++ b/connector_lengow/models/sale_order/import_mapper.py
@@ -49,6 +49,13 @@ class SaleOrderImportMapper(Component):
     @mapping
     def delivery_address(self, record):
         if record["delivery_address"]:
+            # Anonymized re-sync: the contact name was erased upstream and
+            # the partner import was skipped (see
+            # SaleOrderImporter._import_dependencies) -- keep the partner
+            # of the original import.
+            binding = self.options.get("binding")
+            if binding and not record["delivery_address"]["complete_name"]:
+                return None
             binder = self.binder_for("lengow.res.partner")
             external_id = binder.dict2id(record["delivery_address"], in_field=False)
             if not external_id:
@@ -74,6 +81,13 @@ class SaleOrderImportMapper(Component):
     @mapping
     def billing_address(self, record):
         if record["billing_address"]:
+            # Anonymized re-sync: the contact name was erased upstream and
+            # the partner import was skipped (see
+            # SaleOrderImporter._import_dependencies) -- keep the partner
+            # of the original import.
+            binding = self.options.get("binding")
+            if binding and not record["billing_address"]["complete_name"]:
+                return None
             binder = self.binder_for("lengow.res.partner")
             external_id = binder.dict2id(record["billing_address"], in_field=False)
             partner = binder.to_internal(external_id, unwrap=True)

--- a/connector_lengow/models/sale_order/importer.py
+++ b/connector_lengow/models/sale_order/importer.py
@@ -42,26 +42,54 @@ class LengowSaleOrderImporter(Component):
     _apply_on = "lengow.sale.order"
 
     def _import_dependencies(self, external_data, sync_date):
+        # A contact name erased on a re-sync of an already-imported order
+        # is upstream anonymization: the marketplace wiped the buyer data,
+        # so there is no valid partner to import and no user action can
+        # bring the name back -- a raise would leave the job failing
+        # forever. Skip the partner import instead; the order mapper then
+        # leaves the order partners untouched. On a first import there is
+        # nothing to preserve: the partner import raises the actionable
+        # empty-name error (see the lengow.res.partner import mapper).
+        order_binder = self.binder_for()
+        order_binding = order_binder.to_internal(
+            order_binder.dict2id(external_data, in_field=False)
+        )
         # Customer
         billing_address = external_data["billing_address"]
         binder = self.binder_for("lengow.res.partner")
         if billing_address:
-            self._import_dependency(
-                binder.dict2id(billing_address, in_field=False),
-                "lengow.res.partner",
-                sync_date,
-                external_data=billing_address,
-                always=False,
-            )
+            if order_binding and not billing_address["complete_name"]:
+                _logger.info(
+                    "Order %s: billing address contact name came empty on "
+                    "a re-sync (anonymized upstream); keeping the partner "
+                    "of the original import",
+                    external_data["marketplace_order_id"],
+                )
+            else:
+                self._import_dependency(
+                    binder.dict2id(billing_address, in_field=False),
+                    "lengow.res.partner",
+                    sync_date,
+                    external_data=billing_address,
+                    always=False,
+                )
         delivery_address = external_data["delivery_address"]
         if delivery_address:
-            self._import_dependency(
-                binder.dict2id(delivery_address, in_field=False),
-                "lengow.res.partner",
-                sync_date,
-                external_data=delivery_address,
-                always=False,
-            )
+            if order_binding and not delivery_address["complete_name"]:
+                _logger.info(
+                    "Order %s: delivery address contact name came empty on "
+                    "a re-sync (anonymized upstream); keeping the partner "
+                    "of the original import",
+                    external_data["marketplace_order_id"],
+                )
+            else:
+                self._import_dependency(
+                    binder.dict2id(delivery_address, in_field=False),
+                    "lengow.res.partner",
+                    sync_date,
+                    external_data=delivery_address,
+                    always=False,
+                )
         # Products
         order_lines = external_data["items"]
         for line in order_lines:

--- a/connector_lengow/tests/test_order_import.py
+++ b/connector_lengow/tests/test_order_import.py
@@ -244,6 +244,49 @@ class TestOrderImport(TransactionCase):
         self.assertFalse(self._get_order("TEST-7"))
         self.assertFalse(self._get_buyer_partners())
 
+    def test_anonymized_resync_keeps_partners(self):
+        """A late re-sync of an already-imported order whose contact names
+        were erased upstream (GDPR anonymization) must not fail the job:
+        the update proceeds and the order keeps the partners of the
+        original import. Nobody can bring the erased name back, so a
+        failure here would stay red forever."""
+        person = {"full_name": "", "first_name": "Jane", "last_name": "Doe"}
+        self._run_import(self._order_payload("TEST-9", person, person))
+        binding = self._get_order("TEST-9")
+        self.assertEqual(len(binding), 1)
+        order = binding.odoo_id
+        partners_before = self._get_buyer_partners()
+        shipping_before = order.partner_shipping_id
+        invoice_before = order.partner_invoice_id
+        erased = {"full_name": "", "first_name": "", "last_name": ""}
+        payload = self._order_payload("TEST-9", erased, erased)
+        payload["marketplace_status"] = "closed"
+        self._run_import(payload)
+        # the re-sync went through: the status update landed...
+        self.assertEqual(binding.marketplace_status, "closed")
+        # ...and the partners stayed exactly as originally imported
+        self.assertEqual(order.partner_shipping_id, shipping_before)
+        self.assertEqual(order.partner_invoice_id, invoice_before)
+        self.assertEqual(self._get_buyer_partners(), partners_before)
+
+    def test_partially_anonymized_resync(self):
+        """Each address is judged on its own: a re-sync erasing only the
+        delivery contact name skips only that partner; the billing one
+        follows the normal flow."""
+        person = {"full_name": "", "first_name": "Jane", "last_name": "Doe"}
+        self._run_import(self._order_payload("TEST-10", person, person))
+        binding = self._get_order("TEST-10")
+        self.assertEqual(len(binding), 1)
+        order = binding.odoo_id
+        partners_before = self._get_buyer_partners()
+        shipping_before = order.partner_shipping_id
+        invoice_before = order.partner_invoice_id
+        erased = {"full_name": "", "first_name": "", "last_name": ""}
+        self._run_import(self._order_payload("TEST-10", person, erased))
+        self.assertEqual(order.partner_shipping_id, shipping_before)
+        self.assertEqual(order.partner_invoice_id, invoice_before)
+        self.assertEqual(self._get_buyer_partners(), partners_before)
+
     def test_import_record_without_external_data_reads_backend(self):
         """import_record without external_data falls back to the adapter
         read() (e.g. a manual single-order import) and imports normally."""


### PR DESCRIPTION
Marketplaces anonymize old orders upstream (GDPR): a late re-sync of an already-imported order can arrive with the contact names erased. The configured contact name source then resolves to an empty `complete_name` and the partner import fails the job asking to fix the name source — but there is nothing to fix here: no configuration change nor Lengow data brings the erased name back, so the job stays red forever and the rest of the re-sync never lands.

With this change, on a re-sync of an **already-imported** order, an address whose contact name came empty:
- skips its partner import (`SaleOrderImporter._import_dependencies`), logging the reason, and
- leaves the order partner fields untouched (the order import mapper omits `partner_shipping_id` / `partner_invoice_id` / `partner_id` for that address),

so the re-sync proceeds and the order keeps the real buyer data of the original import. Each address is judged on its own: a partially anonymized re-sync only skips the erased address.

The empty-name error remains on **first import**, where there is nothing to preserve and it points at a real, fixable problem (wrong "Contact name source" on the marketplace mapping, or broken order data on Lengow).

Tests: two new cases (fully and partially anonymized re-sync) on top of the existing suite — 10/10 green with the repo-wide CI constraint modules installed.