### PR TITLE
[16.0][IMP] connector_extension: run _must_skip before dependency imports

### DIFF
--- a/connector_extension/__manifest__.py
+++ b/connector_extension/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Connector Extension",
     "summary": "This module extends the connector module",
-    "version": "16.0.1.0.2",
+    "version": "16.0.1.1.0",
     "author": "NuoBiT Solutions SL",
     "license": "LGPL-3",
     "category": "Connector",

--- a/connector_extension/components/importer.py
+++ b/connector_extension/components/importer.py
@@ -115,8 +115,16 @@ class ConnectorExtensionGenericDirectImporter(AbstractComponent):
     def _after_import(self, binding):
         return
 
-    def _must_skip(self, binding):
-        """Hook called right after we read the data from the backend.
+    def _must_skip(self, binding, external_data):
+        """Hook called right after we read the data from the backend,
+        before importing the record dependencies: a skipped record must
+        not leave the side effects of its dependency imports behind.
+
+        ``binding`` is resolved by primary key only: a record adoptable
+        via the alternate key is not bound yet at this point (adoption
+        runs later, on the create path, because it consumes the mapped
+        values and mapping the record may need its dependencies already
+        imported).
 
         If the method returns a message giving a reason for the
         skipping, the import will be interrupted and the message
@@ -155,6 +163,15 @@ class ConnectorExtensionGenericDirectImporter(AbstractComponent):
                     % (external_id,)
                 )
 
+        binder = self.binder_for()
+        # find if the external id already exists in odoo
+        binding = binder.to_internal(external_id)
+
+        # skip record
+        skip = self._must_skip(binding, external_data)
+        if skip:
+            return skip
+
         # import the missing linked resources
         self._import_dependencies(external_data, sync_date)
 
@@ -165,18 +182,9 @@ class ConnectorExtensionGenericDirectImporter(AbstractComponent):
         # convert to odoo data
         internal_data = mapper.map_record(external_data)
 
-        binder = self.binder_for()
-        # find if the external id already exists in odoo
-        binding = binder.to_internal(external_id)
-
         # if binding not exists, try to link existing internal object
         if not binding:
             binding = binder.to_binding_from_external_key(internal_data, sync_date)
-
-        # skip binding
-        skip = self._must_skip(binding)
-        if skip:
-            return skip
 
         # passing info to the mapper
         opts = self._mapper_options(binding, sync_date)

--- a/connector_lengow/__manifest__.py
+++ b/connector_lengow/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Connector Lengow",
-    "version": "16.0.1.1.0",
+    "version": "16.0.1.2.0",
     "author": "NuoBiT Solutions SL",
     "license": "AGPL-3",
     "category": "Connector",

--- a/connector_lengow/models/res_partner/import_mapper.py
+++ b/connector_lengow/models/res_partner/import_mapper.py
@@ -10,13 +10,6 @@ from odoo.exceptions import ValidationError
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import mapping, only_create
 
-# Wording heuristic only, no behavior depends on it: from this age on, an
-# empty contact name on an order being imported for the first time is most
-# likely a marketplace GDPR anonymization (they erase buyer data from old
-# orders) rather than a configuration problem, and the empty-name error
-# explains that.
-ANONYMIZATION_LIKELY_AGE_DAYS = 90
-
 
 class ResPartnerImportMapper(Component):
     _name = "lengow.res.partner.import.mapper"
@@ -66,22 +59,19 @@ class ResPartnerImportMapper(Component):
         }
         order_date = record.get("marketplace_order_date")
         if isinstance(order_date, datetime.datetime):
-            age_days = (fields.Datetime.now() - order_date).days
-            if age_days >= ANONYMIZATION_LIKELY_AGE_DAYS:
-                message += _(
-                    " Note that this order was placed on %(order_date)s, "
-                    "%(age_days)s days ago, and it does not exist in Odoo "
-                    "yet: marketplaces erase buyer contact data from old "
-                    "orders (GDPR anonymization), so most likely the name "
-                    "no longer exists in any field Lengow sends and cannot "
-                    "be recovered by re-importing. If this order still "
-                    "needs to be imported, its contact data must be "
-                    "recovered outside Lengow (marketplace back office, "
-                    "invoices, ...)."
-                ) % {
-                    "order_date": fields.Date.to_string(order_date.date()),
-                    "age_days": age_days,
-                }
+            message += _(
+                " Note that this order was placed on %(order_date)s, "
+                "%(age_days)s days ago. If it is an old order, the likely "
+                "cause is marketplace anonymization (GDPR): the buyer name "
+                "no longer exists in what Lengow sends and cannot be "
+                "recovered by re-importing. In that case, if the order "
+                "still needs to be imported, its contact data must be "
+                "recovered outside Lengow (marketplace back office, "
+                "invoices, ...)."
+            ) % {
+                "order_date": fields.Date.to_string(order_date.date()),
+                "age_days": (fields.Datetime.now() - order_date).days,
+            }
         raise ValidationError(message)
 
     @mapping

--- a/connector_lengow/models/res_partner/import_mapper.py
+++ b/connector_lengow/models/res_partner/import_mapper.py
@@ -2,11 +2,20 @@
 # Copyright NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import _
+import datetime
+
+from odoo import _, fields
 from odoo.exceptions import ValidationError
 
 from odoo.addons.component.core import Component
 from odoo.addons.connector.components.mapper import mapping, only_create
+
+# Wording heuristic only, no behavior depends on it: from this age on, an
+# empty contact name on an order being imported for the first time is most
+# likely a marketplace GDPR anonymization (they erase buyer data from old
+# orders) rather than a configuration problem, and the empty-name error
+# explains that.
+ANONYMIZATION_LIKELY_AGE_DAYS = 90
 
 
 class ResPartnerImportMapper(Component):
@@ -38,26 +47,42 @@ class ResPartnerImportMapper(Component):
             )
             for field_name in ["full_name", "first_name", "last_name"]
         )
-        raise ValidationError(
-            _(
-                "No contact name found on the %(address_type)s address of "
-                "order %(order)s from marketplace %(marketplace)s: its "
-                'configured contact name source "%(source)s" came empty '
-                "(%(fields_state)s). If this marketplace publishes contact "
-                'names in the other field, change "Contact name source" on '
-                "the marketplace mapping and import the order again from "
-                "the backend (the data carried by an already-failed job "
-                "keeps the values read at download time). Otherwise, fix "
-                "the order data on Lengow and import it again."
-            )
-            % {
-                "address_type": record["type"],
-                "order": record["marketplace_order_id"],
-                "marketplace": record["marketplace"],
-                "source": source_labels[marketplace_map.name_source],
-                "fields_state": fields_state,
-            }
-        )
+        message = _(
+            "No contact name found on the %(address_type)s address of "
+            "order %(order)s from marketplace %(marketplace)s: its "
+            'configured contact name source "%(source)s" came empty '
+            "(%(fields_state)s). If this marketplace publishes contact "
+            'names in the other field, change "Contact name source" on '
+            "the marketplace mapping and import the order again from "
+            "the backend (the data carried by an already-failed job "
+            "keeps the values read at download time). Otherwise, fix "
+            "the order data on Lengow and import it again."
+        ) % {
+            "address_type": record["type"],
+            "order": record["marketplace_order_id"],
+            "marketplace": record["marketplace"],
+            "source": source_labels[marketplace_map.name_source],
+            "fields_state": fields_state,
+        }
+        order_date = record.get("marketplace_order_date")
+        if isinstance(order_date, datetime.datetime):
+            age_days = (fields.Datetime.now() - order_date).days
+            if age_days >= ANONYMIZATION_LIKELY_AGE_DAYS:
+                message += _(
+                    " Note that this order was placed on %(order_date)s, "
+                    "%(age_days)s days ago, and it does not exist in Odoo "
+                    "yet: marketplaces erase buyer contact data from old "
+                    "orders (GDPR anonymization), so most likely the name "
+                    "no longer exists in any field Lengow sends and cannot "
+                    "be recovered by re-importing. If this order still "
+                    "needs to be imported, its contact data must be "
+                    "recovered outside Lengow (marketplace back office, "
+                    "invoices, ...)."
+                ) % {
+                    "order_date": fields.Date.to_string(order_date.date()),
+                    "age_days": age_days,
+                }
+        raise ValidationError(message)
 
     @mapping
     def name(self, record):

--- a/connector_lengow/models/res_partner/importer.py
+++ b/connector_lengow/models/res_partner/importer.py
@@ -42,6 +42,49 @@ class LengowResPartnerImporter(Component):
             raise ValidationError(_("External data is mandatory"))
         return super().run(external_id, sync_date, external_data=external_data)
 
+    def _must_skip(self, binding, external_data):
+        """Skip the buyer import on anonymized re-syncs of existing orders.
+
+        Marketplaces re-send old orders with the buyer contact erased
+        (GDPR anonymization), sometimes together with a legitimate order
+        update (e.g. a refund). The contact name is part of the partner
+        identity (it feeds the address hash used by both binder keys), so
+        an erased name can never resolve to the partner created at first
+        import: letting the import proceed would try to create a nameless
+        duplicate and fail the whole order update in the name mapping.
+        The order keeps pointing to the partners of its first import, so
+        there is nothing to import here - skip, and let the order update
+        land.
+
+        This cannot be solved upstream: filtering those orders out at
+        download would eat the legitimate update they carry, and the
+        payload anonymized flag lags the actual data wipe, so the erased
+        name itself is the only reliable signal at import time.
+
+        Only re-syncs are skipped (the order must already exist): the
+        first import of an order with an empty contact name still fails
+        loudly in the partner mapper, because there a real partner must
+        be created and there is no data to create it with - that is a
+        configuration or source-data problem to surface, not to skip.
+        """
+        if not binding and not (external_data.get("complete_name") or "").strip():
+            order_binder = self.binder_for("lengow.sale.order")
+            order_external_id = order_binder.dict2id(external_data, in_field=False)
+            if order_binder.is_complete_id(
+                order_external_id, in_field=False
+            ) and order_binder.to_internal(order_external_id):
+                return _(
+                    "Skipped %(address_type)s address of order %(order)s "
+                    "(marketplace %(marketplace)s): the contact name was "
+                    "erased upstream (anonymized re-sync) and the order "
+                    "keeps the partners of its first import."
+                ) % {
+                    "address_type": external_data.get("type"),
+                    "order": external_data.get("marketplace_order_id"),
+                    "marketplace": external_data.get("marketplace"),
+                }
+        return super()._must_skip(binding, external_data)
+
     def _import_dependencies(self, external_data, sync_date):
         # County
         model = "lengow.res.country.state"

--- a/connector_lengow/models/sale_order/adapter.py
+++ b/connector_lengow/models/sale_order/adapter.py
@@ -117,6 +117,7 @@ class LengowSaleOrderTypeAdapter(Component):
                         ]
                     value[f]["marketplace"] = value["marketplace"]
                     value[f]["marketplace_order_id"] = value["marketplace_order_id"]
+                    value[f]["marketplace_order_date"] = value["marketplace_order_date"]
                     # complete_name (and the identity hash derived from it)
                     # comes strictly from the contact name source configured
                     # on the marketplace mapping. No resolvable mapping or

--- a/connector_lengow/models/sale_order/import_mapper.py
+++ b/connector_lengow/models/sale_order/import_mapper.py
@@ -48,7 +48,14 @@ class SaleOrderImportMapper(Component):
 
     @mapping
     def delivery_address(self, record):
+        binding = self.options.get("binding")
         if record["delivery_address"]:
+            # Anonymized re-sync: the contact name was erased upstream and
+            # the partner import was skipped (see
+            # LengowResPartnerImporter._must_skip) -- keep the partner of
+            # the original import.
+            if binding and not record["delivery_address"]["complete_name"]:
+                return None
             binder = self.binder_for("lengow.res.partner")
             external_id = binder.dict2id(record["delivery_address"], in_field=False)
             if not external_id:
@@ -64,7 +71,6 @@ class SaleOrderImportMapper(Component):
             )
             return {"partner_shipping_id": partner.id}
         else:
-            binding = self.options.get("binding")
             if not binding:
                 parent = self.backend_record.get_marketplace_map(
                     record["marketplace"], record["parent_country_iso_a2"]
@@ -73,7 +79,14 @@ class SaleOrderImportMapper(Component):
 
     @mapping
     def billing_address(self, record):
+        binding = self.options.get("binding")
         if record["billing_address"]:
+            # Anonymized re-sync: the contact name was erased upstream and
+            # the partner import was skipped (see
+            # LengowResPartnerImporter._must_skip) -- keep the partner of
+            # the original import.
+            if binding and not record["billing_address"]["complete_name"]:
+                return None
             binder = self.binder_for("lengow.res.partner")
             external_id = binder.dict2id(record["billing_address"], in_field=False)
             partner = binder.to_internal(external_id, unwrap=True)
@@ -95,7 +108,6 @@ class SaleOrderImportMapper(Component):
                 partner_return["partner_id"] = partner.id
             return partner_return
         else:
-            binding = self.options.get("binding")
             if not binding:
                 country = record.get("parent_country_iso_a2")
                 if not country:

--- a/connector_lengow/tests/test_order_import.py
+++ b/connector_lengow/tests/test_order_import.py
@@ -1,6 +1,7 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import datetime
 from unittest import mock
 
 from odoo import fields
@@ -201,6 +202,33 @@ class TestOrderImport(TransactionCase):
         self.assertIn("last_name is empty", str(cm.exception))
         self.assertFalse(self._get_order("TEST-4"))
         self.assertFalse(self._get_buyer_partners())
+
+    def test_old_order_empty_name_explains_probable_anonymization(self):
+        """A first import of an OLD order with no contact name anywhere is
+        most likely a marketplace GDPR anonymization (the connector met the
+        order too late): the error explains it, with the order date, and
+        states the name cannot be recovered from Lengow. A recent order
+        keeps the plain configuration-oriented message."""
+        self.marketplace_map.name_source = "full_name"
+        empty = {"full_name": "", "first_name": "", "last_name": ""}
+        payload = self._order_payload("TEST-11", empty, empty)
+        payload["marketplace_order_date"] = "2024-04-16T10:00:00Z"
+        with self.assertRaisesRegex(ValidationError, "Contact name source") as cm:
+            self._run_import(payload)
+        self.assertIn("2024-04-16", str(cm.exception))
+        self.assertIn("GDPR anonymization", str(cm.exception))
+        self.assertIn("cannot be recovered", str(cm.exception))
+        self.assertFalse(self._get_order("TEST-11"))
+        self.assertFalse(self._get_buyer_partners())
+        # recent order: same failure, no anonymization hypothesis
+        recent = self._order_payload("TEST-12", empty, empty)
+        recent["marketplace_order_date"] = (
+            fields.Datetime.now() - datetime.timedelta(days=10)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with self.assertRaisesRegex(ValidationError, "Contact name source") as cm:
+            self._run_import(recent)
+        self.assertNotIn("GDPR anonymization", str(cm.exception))
+        self.assertFalse(self._get_order("TEST-12"))
 
     def test_reconfigure_and_reimport_heals(self):
         """The remediation the error message instructs: wrong source ->

--- a/connector_lengow/tests/test_order_import.py
+++ b/connector_lengow/tests/test_order_import.py
@@ -244,6 +244,49 @@ class TestOrderImport(TransactionCase):
         self.assertFalse(self._get_order("TEST-7"))
         self.assertFalse(self._get_buyer_partners())
 
+    def test_anonymized_resync_keeps_partners(self):
+        """A late re-sync of an already-imported order whose contact names
+        were erased upstream (GDPR anonymization) must not fail the job:
+        the update proceeds and the order keeps the partners of the
+        original import. Nobody can bring the erased name back, so a
+        failure here would stay red forever."""
+        person = {"full_name": "", "first_name": "Jane", "last_name": "Doe"}
+        self._run_import(self._order_payload("TEST-9", person, person))
+        binding = self._get_order("TEST-9")
+        self.assertEqual(len(binding), 1)
+        order = binding.odoo_id
+        partners_before = self._get_buyer_partners()
+        shipping_before = order.partner_shipping_id
+        invoice_before = order.partner_invoice_id
+        erased = {"full_name": "", "first_name": "", "last_name": ""}
+        payload = self._order_payload("TEST-9", erased, erased)
+        payload["marketplace_status"] = "closed"
+        self._run_import(payload)
+        # the re-sync went through: the status update landed...
+        self.assertEqual(binding.marketplace_status, "closed")
+        # ...and the partners stayed exactly as originally imported
+        self.assertEqual(order.partner_shipping_id, shipping_before)
+        self.assertEqual(order.partner_invoice_id, invoice_before)
+        self.assertEqual(self._get_buyer_partners(), partners_before)
+
+    def test_partially_anonymized_resync(self):
+        """Each address is judged on its own: a re-sync erasing only the
+        delivery contact name skips only that partner; the billing one
+        follows the normal flow."""
+        person = {"full_name": "", "first_name": "Jane", "last_name": "Doe"}
+        self._run_import(self._order_payload("TEST-10", person, person))
+        binding = self._get_order("TEST-10")
+        self.assertEqual(len(binding), 1)
+        order = binding.odoo_id
+        partners_before = self._get_buyer_partners()
+        shipping_before = order.partner_shipping_id
+        invoice_before = order.partner_invoice_id
+        erased = {"full_name": "", "first_name": "", "last_name": ""}
+        self._run_import(self._order_payload("TEST-10", person, erased))
+        self.assertEqual(order.partner_shipping_id, shipping_before)
+        self.assertEqual(order.partner_invoice_id, invoice_before)
+        self.assertEqual(self._get_buyer_partners(), partners_before)
+
     def test_import_record_without_external_data_reads_backend(self):
         """import_record without external_data falls back to the adapter
         read() (e.g. a manual single-order import) and imports normally."""

--- a/connector_lengow/tests/test_order_import.py
+++ b/connector_lengow/tests/test_order_import.py
@@ -1,7 +1,6 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-import datetime
 from unittest import mock
 
 from odoo import fields
@@ -203,12 +202,11 @@ class TestOrderImport(TransactionCase):
         self.assertFalse(self._get_order("TEST-4"))
         self.assertFalse(self._get_buyer_partners())
 
-    def test_old_order_empty_name_explains_probable_anonymization(self):
-        """A first import of an OLD order with no contact name anywhere is
-        most likely a marketplace GDPR anonymization (the connector met the
-        order too late): the error explains it, with the order date, and
-        states the name cannot be recovered from Lengow. A recent order
-        keeps the plain configuration-oriented message."""
+    def test_empty_name_error_states_order_age_and_anonymization(self):
+        """A first import with no contact name anywhere also states the
+        order date and age and explains that on old orders the likely
+        cause is marketplace anonymization (GDPR), unrecoverable from
+        Lengow -- the reader judges from the age."""
         self.marketplace_map.name_source = "full_name"
         empty = {"full_name": "", "first_name": "", "last_name": ""}
         payload = self._order_payload("TEST-11", empty, empty)
@@ -216,19 +214,11 @@ class TestOrderImport(TransactionCase):
         with self.assertRaisesRegex(ValidationError, "Contact name source") as cm:
             self._run_import(payload)
         self.assertIn("2024-04-16", str(cm.exception))
-        self.assertIn("GDPR anonymization", str(cm.exception))
+        self.assertIn("days ago", str(cm.exception))
+        self.assertIn("(GDPR)", str(cm.exception))
         self.assertIn("cannot be recovered", str(cm.exception))
         self.assertFalse(self._get_order("TEST-11"))
         self.assertFalse(self._get_buyer_partners())
-        # recent order: same failure, no anonymization hypothesis
-        recent = self._order_payload("TEST-12", empty, empty)
-        recent["marketplace_order_date"] = (
-            fields.Datetime.now() - datetime.timedelta(days=10)
-        ).strftime("%Y-%m-%dT%H:%M:%SZ")
-        with self.assertRaisesRegex(ValidationError, "Contact name source") as cm:
-            self._run_import(recent)
-        self.assertNotIn("GDPR anonymization", str(cm.exception))
-        self.assertFalse(self._get_order("TEST-12"))
 
     def test_reconfigure_and_reimport_heals(self):
         """The remediation the error message instructs: wrong source ->


### PR DESCRIPTION
Framework change + first consumer. Supersedes #942.

## Commit 1 — connector_extension: run `_must_skip` before dependency imports

`_must_skip` fired at the end of `run()`, after dependency imports and alternate-key adoption: a refused record left every dependency import committed (there is no rollback on skip), and no hook could prevent those side effects.

- The gate moves right after the primary-key binding lookup, **before** `_import_dependencies`.
- New signature: `_must_skip(binding, external_data)` — inputs passed by `run()` as parameters.
- Alternate-key adoption stays on the create path (it consumes mapped values, and mapping may need the dependencies already imported). The only semantic delta: the gate sees the primary-key binding instead of a possibly-adopted one.
- The docstring ("right after we read the data") finally matches the call site again — it always described the early position of the classic OCA pattern the hook was copied from.

Audited before changing (every branch + every open PR head of nuobit/odoo-addons, oxigensalud/odoo-addons and nuobit/lighting-vertical): `_must_skip` is invoked only from framework `run()` bodies, nobody forks `run()` (only thin wrappers delegating to `super()`), and **16.0 has zero overrides** — this commit is behavior-neutral on 16.0 by itself. The only overrides anywhere (connector_woocommerce 14.0/#874, connector_oxigesti_spms #169) decide on `binding` alone and regain their original own-framework semantics with the early gate; they must add the new parameter when this reaches their branch (18.0 FWP / optional 14.0 BP).

## Commit 2 — connector_lengow: keep order addresses on anonymized re-syncs

Marketplaces re-send old orders with the buyer contact erased (GDPR anonymization), sometimes carrying a legitimate update (e.g. a refund). The contact name feeds the partner identity hash, so an erased name can never match the partner created at first import: the job failed in the partner name mapping and the real update was lost with it.

- Partner importer `_must_skip`: contact name erased + not bound + the order already in Odoo → skip; the order keeps the partners of its first import.
- Order mapper: on update, an anonymized incoming address keeps the stored partner pointers untouched.
- First import of an order with an empty contact name keeps failing loudly in the partner mapper (configuration or source-data problem to surface, not to skip).
- Detection is the erased name only: the payload `anonymized` flag lags the actual wipe on the stored payload waves, and the `lengow_status` values carried by anonymized re-syncs are exactly the ones whose updates must not be lost.

## Tests

`connector_lengow` suite on a dedicated test DB with both modules upgraded: **10/10 green**, including the two new tests (fully and partially anonymized re-sync) exercising the new pipeline end to end.

## Follow-ups (separate PRs)

- 18.0 FWP coordinated with #891/#892, adapting the #874/#169 override signatures.
- Optional 14.0 backport (connector_woocommerce's create-only guard stops importing all dependencies of orders it then refuses).
