### PR TITLE
[16.0][FWP] account_asset_management_extension

### DIFF
--- a/account_asset_management_extension/models/account_asset.py
+++ b/account_asset_management_extension/models/account_asset.py
@@ -45,7 +45,7 @@ class AccountAsset(models.Model):
     def _get_asset_unit_price(self, amount, quantity):
         if not quantity:
             amount = 0
-        elif abs(quantity) >= 1:
+        elif abs(quantity) > 1:
             prec = self.env["decimal.precision"].precision_get(
                 "Product Unit of Measure"
             )


### PR DESCRIPTION
Forward-port of the pending 14.0 commit detected by the migration gate sweep (2026-07-05).

Ported:
- [REF] optimization to not divide by 1 (`abs(quantity) > 1`)

Not ported (already absorbed on 16.0): the original fix and its revert — 16.0 already carries the unit-price methods; only the final optimization was missing.