### PR TITLE
[16.0][FWP] connector_extension_sql

### DIFF
--- a/connector_extension_sql/components/adapter.py
+++ b/connector_extension_sql/components/adapter.py
@@ -58,7 +58,7 @@ class SQLAdapterCRUD(AbstractComponent):
     def _convert_value(self, v, to_backend=True):
         if isinstance(v, datetime.datetime):
             if to_backend:
-                func = self.backend_record.tz_to_local
+                func = self.backend_record.utc_to_local
             else:
                 func = self.backend_record.tz_to_utc
             return func(v)


### PR DESCRIPTION
Forward-port of the pending 14.0 commit detected by the migration gate sweep (2026-07-05).

Ported:
- [IMP] use utc_to_local instead of deprecated tz_to_local (from PR #884)

Not ported: the copier-template regen commit (16.0 keeps its own generated state).