### PR TITLE
[16.0][FWP] account_asset_tax_consistency

### DIFF
--- a/account_asset_tax_consistency/models/chart_template.py
+++ b/account_asset_tax_consistency/models/chart_template.py
@@ -17,3 +17,8 @@ class AccountTaxTemplate(models.Model):
         required=True,
         default="ignore",
     )
+
+    def _get_tax_vals(self, company, tax_template_to_tax):
+        vals = super()._get_tax_vals(company, tax_template_to_tax)
+        vals["apply_to_asset"] = self.apply_to_asset
+        return vals


### PR DESCRIPTION
Forward-port of the pending 14.0 commit detected by the migration gate sweep (2026-07-05).

Ported:
- [FIX] propagate template applicability (`_get_tax_vals` carries `apply_to_asset` from the tax template to the generated tax)

Cherry-picked verbatim from 14.0 (812df190).