### PR TITLE
[14.0][IMP] connector_woocommerce: show archived records in binding views

### DIFF
--- a/connector_woocommerce/views/product_product.xml
+++ b/connector_woocommerce/views/product_product.xml
@@ -109,5 +109,6 @@
         <field name="name">Products</field>
         <field name="res_model">woocommerce.product.product</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'active_test': False}</field>
     </record>
 </odoo>

--- a/connector_woocommerce/views/res_partner_views.xml
+++ b/connector_woocommerce/views/res_partner_views.xml
@@ -57,5 +57,6 @@
         <field name="name">Partner</field>
         <field name="res_model">woocommerce.res.partner</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'active_test': False}</field>
     </record>
 </odoo>

--- a/connector_woocommerce/views/woocommerce_product_template.xml
+++ b/connector_woocommerce/views/woocommerce_product_template.xml
@@ -41,5 +41,6 @@
         <field name="name">Product Template</field>
         <field name="res_model">woocommerce.product.template</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'active_test': False}</field>
     </record>
 </odoo>


### PR DESCRIPTION
Product template, product variant and partner bindings delegate to their Odoo record via _inherits, so they inherit its active field and the implicit active_test filter hides the bindings of archived records in the binding list views. Bindings are technical synchronization records: hiding part of them makes stale bindings invisible and impossible to purge from the UI while exports keep resolving them, failing against already deleted external ids. Disable active_test on the binding window actions so administrators always see the complete list.