### PR TITLE
[14.0][FIX] account_asset_management_extension: backfill legacy NULL quantity

### DIFF
--- a/account_asset_management_extension/__manifest__.py
+++ b/account_asset_management_extension/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Account Asset Management Extension",
     "summary": "This module adds additional fields in assets",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "category": "Accounting",
     "author": "NuoBiT Solutions, S.L.",
     "website": "https://github.com/nuobit/odoo-addons",

--- a/account_asset_management_extension/migrations/14.0.1.0.3/post-migration.py
+++ b/account_asset_management_extension/migrations/14.0.1.0.3/post-migration.py
@@ -1,0 +1,34 @@
+# Copyright NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    # `quantity` was introduced as required without backfilling existing
+    # assets, so pre-2023 rows kept NULL and the NOT NULL constraint never
+    # installs. Assets linked to an invoice line must take the line quantity
+    # (the _check_invoice constraint enforces equality on write); a line
+    # quantity of NULL/0 is unusable (_check_quantity_on_asset forbids 0).
+    cr.execute(
+        """
+        UPDATE account_asset a
+        SET quantity = l.quantity
+        FROM account_move_line l
+        WHERE l.id = a.invoice_move_line_id
+          AND a.quantity IS NULL
+          AND l.quantity IS NOT NULL
+          AND l.quantity != 0
+        """
+    )
+    _logger.info(
+        "account_asset.quantity backfilled from linked invoice line: %s rows",
+        cr.rowcount,
+    )
+    cr.execute("UPDATE account_asset SET quantity = 1 WHERE quantity IS NULL")
+    _logger.info(
+        "account_asset.quantity defaulted to 1 (no usable invoice line): %s rows",
+        cr.rowcount,
+    )


### PR DESCRIPTION
## Problem

`quantity` was added as `required=True` in an earlier 14.0 revision **without a backfill migration**: assets that already existed at that upgrade keep `NULL`, so Odoo cannot install the `NOT NULL` constraint and logs `Table 'account_asset': unable to set NOT NULL on column 'quantity'` on every registry load.

Both creation paths fill the field ever since it exists (form: required + `_check_quantity_on_asset != 0`; invoice-driven: `_prepare_asset_vals` copies `aml.quantity`), so the NULL population is exactly the pre-upgrade legacy.

## Fix

Post-migration on version bump `14.0.1.0.2 → 14.0.1.0.3`:

1. Assets with a linked invoice line (`invoice_move_line_id`) whose line quantity is usable (not NULL, not 0) take **the line quantity** — anything else would trip the `_check_invoice` equality constraint on the next write of those assets.
2. The rest default to **1** (no linked line, or line quantity NULL/0, which `_check_quantity_on_asset` forbids anyway).

**Idempotent**: both statements filter `WHERE quantity IS NULL` — on an already-clean database they touch 0 rows.

After the update, the NOT NULL installs on the next registry load and the schema warning disappears.