### PR TITLE
[14.0][FIX] l10n_es_asset_extension: add search to computed vat_tax_id

### DIFF
--- a/l10n_es_asset_extension/models/account_asset.py
+++ b/l10n_es_asset_extension/models/account_asset.py
@@ -5,6 +5,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.osv import expression
 
 
 class AccountAsset(models.Model):
@@ -14,6 +15,7 @@ class AccountAsset(models.Model):
         string="VAT Tax",
         comodel_name="account.tax",
         compute="_compute_vat_tax_id",
+        search="_search_vat_tax_id",
     )
 
     @api.depends("tax_ids", "tax_ids.tax_group_id", "tax_ids.tax_group_id.is_vat")
@@ -25,6 +27,38 @@ class AccountAsset(models.Model):
                     _("Asset has more than 1 VAT tax. Please, review the taxes")
                 )
             rec.vat_tax_id = taxes._origin
+
+    @api.model
+    def _search_vat_tax_id(self, operator, value):
+        if operator not in ("=", "!=", "in", "not in"):
+            raise NotImplementedError(
+                _("Unsupported operator %s for VAT tax search") % operator
+            )
+
+        is_negative = operator in ("!=", "not in")
+
+        if operator in ("=", "!=") and not value:
+            domain = [("tax_ids.tax_group_id.is_vat", "=", True)]
+            return domain if is_negative else [expression.NOT_OPERATOR] + domain
+
+        value_ids = value.ids if hasattr(value, "ids") else value
+        if isinstance(value_ids, int):
+            value_ids = [value_ids]
+
+        if not value_ids:
+            return expression.TRUE_DOMAIN if is_negative else expression.FALSE_DOMAIN
+
+        vat_taxes = (
+            self.env["account.tax"]
+            .browse(value_ids)
+            .exists()
+            .filtered(lambda t: t.tax_group_id.is_vat)
+        )
+        if not vat_taxes:
+            return expression.TRUE_DOMAIN if is_negative else expression.FALSE_DOMAIN
+
+        domain = [("tax_ids", "in", vat_taxes.ids)]
+        return [expression.NOT_OPERATOR] + domain if is_negative else domain
 
     vat_tax_amount = fields.Float(
         string="VAT Tax Amount",

--- a/l10n_es_asset_extension/tests/__init__.py
+++ b/l10n_es_asset_extension/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_vat_tax_search

--- a/l10n_es_asset_extension/tests/test_vat_tax_search.py
+++ b/l10n_es_asset_extension/tests/test_vat_tax_search.py
@@ -1,0 +1,155 @@
+# Copyright NuoBiT - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.osv import expression
+from odoo.tests.common import SavepointCase
+
+
+class TestVatTaxSearch(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # ARRANGE
+        account_type_asset = cls.env.ref("account.data_account_type_fixed_assets")
+        account_type_expense = cls.env.ref("account.data_account_type_expenses")
+        account_asset = cls.env["account.account"].create(
+            {
+                "name": "Test Fixed Asset",
+                "code": "TEST220000",
+                "user_type_id": account_type_asset.id,
+            }
+        )
+        account_depreciation = cls.env["account.account"].create(
+            {
+                "name": "Test Depreciation",
+                "code": "TEST281000",
+                "user_type_id": account_type_asset.id,
+            }
+        )
+        account_expense = cls.env["account.account"].create(
+            {
+                "name": "Test Depreciation Expense",
+                "code": "TEST681000",
+                "user_type_id": account_type_expense.id,
+            }
+        )
+        journal = cls.env["account.journal"].create(
+            {"name": "Test Assets Journal", "code": "TASSET", "type": "general"}
+        )
+        profile = cls.env["account.asset.profile"].create(
+            {
+                "name": "Test Asset Profile",
+                "journal_id": journal.id,
+                "account_asset_id": account_asset.id,
+                "account_depreciation_id": account_depreciation.id,
+                "account_expense_depreciation_id": account_expense.id,
+            }
+        )
+        vat_group = cls.env["account.tax.group"].create(
+            {"name": "Test VAT Group", "is_vat": True}
+        )
+        other_group = cls.env["account.tax.group"].create(
+            {"name": "Test Non-VAT Group", "is_vat": False}
+        )
+        # modules outside this module's dependency tree may constrain taxes
+        # further when co-installed in a shared test database (e.g.
+        # account_asset_tax_consistency requires apply_to_asset == "always")
+        extra_tax_vals = {}
+        if "apply_to_asset" in cls.env["account.tax"]._fields:
+            extra_tax_vals["apply_to_asset"] = "always"
+        cls.vat_tax = cls.env["account.tax"].create(
+            {
+                "name": "Test VAT 21%",
+                "amount": 21.0,
+                "type_tax_use": "purchase",
+                "tax_group_id": vat_group.id,
+                **extra_tax_vals,
+            }
+        )
+        cls.other_tax = cls.env["account.tax"].create(
+            {
+                "name": "Test Surcharge 5.2%",
+                "amount": 5.2,
+                "type_tax_use": "purchase",
+                "tax_group_id": other_group.id,
+                **extra_tax_vals,
+            }
+        )
+        cls.asset = cls.env["account.asset"].create(
+            {
+                "name": "Test Asset",
+                "profile_id": profile.id,
+                "purchase_value": 1000.0,
+                "date_start": "2021-01-01",
+                "quantity": 1.0,
+                "tax_ids": [(6, 0, (cls.vat_tax + cls.other_tax).ids)],
+            }
+        )
+        cls.asset_no_vat = cls.env["account.asset"].create(
+            {
+                "name": "Test Asset without VAT",
+                "profile_id": profile.id,
+                "purchase_value": 500.0,
+                "date_start": "2021-01-01",
+                "quantity": 1.0,
+                "tax_ids": [(6, 0, cls.other_tax.ids)],
+            }
+        )
+
+    def test_compute_vat_tax(self):
+        self.assertEqual(self.asset.vat_tax_id, self.vat_tax)
+        self.assertFalse(self.asset_no_vat.vat_tax_id)
+
+    def test_search_by_vat_tax(self):
+        assets = self.env["account.asset"].search(
+            [("vat_tax_id", "in", self.vat_tax.ids)]
+        )
+        self.assertIn(self.asset, assets)
+        self.assertNotIn(self.asset_no_vat, assets)
+
+    def test_search_by_non_vat_tax_matches_nothing(self):
+        domain = self.env["account.asset"]._search_vat_tax_id("in", self.other_tax.ids)
+        self.assertEqual(domain, expression.FALSE_DOMAIN)
+        self.assertFalse(
+            self.env["account.asset"].search([("vat_tax_id", "in", self.other_tax.ids)])
+        )
+
+    def test_search_unset(self):
+        assets = self.env["account.asset"].search([("vat_tax_id", "=", False)])
+        self.assertIn(self.asset_no_vat, assets)
+        self.assertNotIn(self.asset, assets)
+        assets = self.env["account.asset"].search([("vat_tax_id", "!=", False)])
+        self.assertIn(self.asset, assets)
+        self.assertNotIn(self.asset_no_vat, assets)
+
+    def test_search_negative(self):
+        assets = self.env["account.asset"].search(
+            [("vat_tax_id", "not in", self.vat_tax.ids)]
+        )
+        self.assertNotIn(self.asset, assets)
+        self.assertIn(self.asset_no_vat, assets)
+
+    def test_search_empty_value(self):
+        Asset = self.env["account.asset"]
+        self.assertEqual(Asset._search_vat_tax_id("in", []), expression.FALSE_DOMAIN)
+        self.assertEqual(Asset._search_vat_tax_id("not in", []), expression.TRUE_DOMAIN)
+
+    def test_search_unsupported_operator(self):
+        with self.assertRaises(NotImplementedError):
+            self.env["account.asset"]._search_vat_tax_id("ilike", "vat")
+
+    def test_tax_write_triggers_recompute(self):
+        self.assertAlmostEqual(self.asset.vat_tax_amount, 210.0, places=2)
+        self.vat_tax.amount = 10.0
+        self.assertAlmostEqual(self.asset.vat_tax_amount, 100.0, places=2)
+
+    def test_tax_unlink_no_degradation(self):
+        throwaway = self.env["account.tax"].create(
+            {
+                "name": "Test Throwaway",
+                "amount": 1.0,
+                "type_tax_use": "purchase",
+            }
+        )
+        throwaway.unlink()
+        self.assertEqual(self.asset.vat_tax_id, self.vat_tax)


### PR DESCRIPTION
Any write to `account.tax.amount` (and any tax unlink, which touches every field) makes the ORM resolve which assets depend on the modified tax through the dotted dependencies `vat_tax_id.amount` (this module) and `vat_tax_id.prorate` (`l10n_es_aeat_prorate_asset`). Since `vat_tax_id` was a non-stored computed field without a search method, `odoo.osv.expression` logged **"Non-stored field account.asset.vat_tax_id cannot be searched."** at ERROR level and degraded the leaf to match-all, invalidating `vat_tax_amount` and recomputing the stored `prorate_tax_id` on every asset of the database.

Implement the search method the framework asks for, following the `_search_map_special_prorate_year_id` pattern already used in `l10n_es_aeat_prorate_asset`: only the VAT subset of the searched taxes can match, and since the module enforces a single VAT tax per asset, holding one of those taxes is exactly equivalent to it being the asset's `vat_tax_id`. Trigger resolution becomes precise — a non-VAT tax change matches no asset at all — the ERROR line disappears, and the dotted dependencies of both modules stay untouched.

Validated in an ephemeral clone of a real 14.0 database: unpatched write/unlink reproduce the ERROR (1/1); patched boot/write/unlink log 0 ERROR lines, the recompute trigger stays alive (a VAT amount change recomputes `vat_tax_amount` correctly), `_search_vat_tax_id('in', [non-VAT id])` returns the empty domain and `('in', [VAT id])` returns the exact `tax_ids` domain.