### PR TITLE
[14.0][IMP] sale_order_invoicing_exclude: report excluded orders as nothing to invoice

### DIFF
--- a/sale_order_invoicing_exclude/__manifest__.py
+++ b/sale_order_invoicing_exclude/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale order exclude invoicing",
     "summary": "Exclude orders from being invoiced.",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.1.0",
     "category": "Sales Management",
     "license": "AGPL-3",
     "author": "NuoBiT Solutions, S.L., Eric Antones",

--- a/sale_order_invoicing_exclude/migrations/14.0.1.1.0/post-migration.py
+++ b/sale_order_invoicing_exclude/migrations/14.0.1.1.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright NuoBiT Solutions, S.L. (<https://www.nuobit.com>)
+# Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env["sale.order"].search(
+        [("sale_invoicing_exclude_from_invoicing", "=", True)]
+    )._get_invoice_status()

--- a/sale_order_invoicing_exclude/models/sale_order.py
+++ b/sale_order_invoicing_exclude/models/sale_order.py
@@ -2,7 +2,7 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -13,6 +13,16 @@ class SaleOrder(models.Model):
         default=False,
         tracking=True,
     )
+
+    @api.depends("sale_invoicing_exclude_from_invoicing")
+    def _get_invoice_status(self):
+        super()._get_invoice_status()
+        for order in self.filtered(
+            lambda so: so.sale_invoicing_exclude_from_invoicing
+            and so.state in ("sale", "done")
+            and so.invoice_status == "to invoice"
+        ):
+            order.invoice_status = "no"
 
     def _create_invoices(self, grouped=False, final=False, date=None):
         return super(

--- a/sale_order_invoicing_exclude/tests/__init__.py
+++ b/sale_order_invoicing_exclude/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_invoicing_exclude

--- a/sale_order_invoicing_exclude/tests/test_sale_order_invoicing_exclude.py
+++ b/sale_order_invoicing_exclude/tests/test_sale_order_invoicing_exclude.py
@@ -1,0 +1,49 @@
+# Copyright NuoBiT Solutions, S.L. (<https://www.nuobit.com>)
+# Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.tests import common
+
+
+class TestSaleOrderInvoicingExclude(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env["res.partner"].create({"name": "Test partner"})
+        self.product = self.env["product.product"].create(
+            {
+                "name": "Test service",
+                "type": "service",
+                "invoice_policy": "order",
+                "list_price": 100.0,
+            }
+        )
+        self.order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 10.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_excluded_order_invoice_status(self):
+        self.order.action_confirm()
+        self.assertEqual(self.order.invoice_status, "to invoice")
+        self.order.sale_invoicing_exclude_from_invoicing = True
+        self.assertEqual(self.order.invoice_status, "no")
+        self.order.sale_invoicing_exclude_from_invoicing = False
+        self.assertEqual(self.order.invoice_status, "to invoice")
+
+    def test_excluded_invoiced_order_keeps_invoiced_status(self):
+        self.order.action_confirm()
+        self.order._create_invoices()
+        self.assertEqual(self.order.invoice_status, "invoiced")
+        self.order.sale_invoicing_exclude_from_invoicing = True
+        self.assertEqual(self.order.invoice_status, "invoiced")


### PR DESCRIPTION
## Summary
- Orders flagged as "Exclude from invoicing" that are pending to invoice now report "Nothing to invoice", so they stop appearing in to-invoice list views and filters. Until now the flag only skipped the order in `_create_invoices`, leaving the standard status untouched.
- Only the pending status is demoted: fully invoiced excluded orders keep reporting "Invoiced" (the flag is a prohibition on invoicing, not a claim about what got invoiced). This also keeps the concept clearly apart from OCA's `sale_force_invoiced` ("consider it fully invoiced"), which serves a different use case; both overrides compose cleanly if ever installed together.
- A post-migration recomputes the invoice status of already-flagged orders, so historic exclusions stop showing as pending right after the upgrade.
- Tests cover the demotion when flagging, the recomputation when unflagging, and that a fully invoiced excluded order keeps its "Invoiced" status.

## Test plan
- [x] pre-commit passes locally
- [x] module test suite green on a local test database
- [x] migration rehearsed on a local production-clone database (before/after diff limited to flagged pending orders)
- [ ] CI green