### PR TITLE
[18.0][FWP][REF] connector_extension: add fallback hook for incomplete external alt key

### DIFF
--- a/connector_extension/components/binder.py
+++ b/connector_extension/components/binder.py
@@ -504,8 +504,21 @@ class ConnectorExtensionBinderComposite(AbstractComponent):
             # TODO: check if we can put this in a hook
             external_alt_id = self.dict2id(id_values, in_field=False, alt_field=True)
             if self.is_id_null(external_alt_id):
-                return self.model
+                record = self._get_external_record_alt_fallback(relation, id_values)
+                return self._to_binding_from_external_record(relation, record)
         record = self._get_external_record_alt(relation, id_values)
+        return self._to_binding_from_external_record(relation, record)
+
+    def _get_external_record_alt_fallback(self, relation, id_values):
+        """Hook called when the external alternate key is incomplete (some
+        of its fields are null) and the external record cannot be searched
+        directly. Override it to find the external record by indirect means.
+        By default it returns no record, keeping the standard behaviour:
+        the record will be created on the external system.
+        """
+        return {}
+
+    def _to_binding_from_external_record(self, relation, record):
         if record:
             external_id = self.dict2id(record, in_field=False)
             binding = self.wrap_record(relation)
@@ -513,9 +526,9 @@ class ConnectorExtensionBinderComposite(AbstractComponent):
                 current_external_id = self.to_external(binding)
                 if current_external_id != external_id:
                     raise InvalidDataError(
-                        f"More than one external records found. "
-                        f"The alternate external id field '{ext_alt_id}'"
-                        f" is not unique in the backend"
+                        f"Integrity error: The current external_id "
+                        f"'{current_external_id}' should be the same as the "
+                        f"one we are trying to assign '{external_id}'"
                     )
                 _logger.debug("%d already binded to Backend", binding)
             else:


### PR DESCRIPTION
Forward-port of the framework part of #941 (merged into 14.0).

When the external alternate key computed from the export mapper has null fields, `to_binding_from_internal_key` gave up without any chance to find the existing external record, so the exporter always created a new one. This extracts the post-search binding logic into `_to_binding_from_external_record` and adds the overridable hook `_get_external_record_alt_fallback` for connectors to find the external record by indirect means (default keeps the previous behaviour).

The connector implementations of the hook are forward-ported separately into the open MIG PRs of their modules: #874 (connector_woocommerce) and #879 (connector_woocommerce_wpml).

Port note: the integrity error raised on external id mismatch recovers its 14.0 wording — the 18.0 migration had replaced it with a copy of the not-unique message, which also references the alternate key variable that falls out of scope after the extraction.