### PR TITLE
[16.0][FWP][REF] connector_extension: add fallback hook for incomplete external alt key

### DIFF
--- a/connector_extension/components/binder.py
+++ b/connector_extension/components/binder.py
@@ -496,8 +496,21 @@ class ConnectorExtensionBinderComposite(AbstractComponent):
             # TODO: check if we can put this in a hook
             external_alt_id = self.dict2id(id_values, in_field=False, alt_field=True)
             if self.is_id_null(external_alt_id):
-                return self.model
+                record = self._get_external_record_alt_fallback(relation, id_values)
+                return self._to_binding_from_external_record(relation, record)
         record = self._get_external_record_alt(relation, id_values)
+        return self._to_binding_from_external_record(relation, record)
+
+    def _get_external_record_alt_fallback(self, relation, id_values):
+        """Hook called when the external alternate key is incomplete (some
+        of its fields are null) and the external record cannot be searched
+        directly. Override it to find the external record by indirect means.
+        By default it returns no record, keeping the standard behaviour:
+        the record will be created on the external system.
+        """
+        return {}
+
+    def _to_binding_from_external_record(self, relation, record):
         if record:
             external_id = self.dict2id(record, in_field=False)
             binding = self.wrap_record(relation)


### PR DESCRIPTION
Forward-port of the framework part of #941 (merged into 14.0), applied to 16.0 for framework coherence across versions — same change as #960 on 18.0.

When the external alternate key computed from the export mapper has null fields, `to_binding_from_internal_key` gave up without any chance to find the existing external record, so the exporter always created a new one. This extracts the post-search binding logic into `_to_binding_from_external_record` and adds the overridable hook `_get_external_record_alt_fallback` for connectors to find the external record by indirect means (default keeps the previous behaviour).

No connector on this branch overrides the hook yet, so behaviour is unchanged.