### PR TITLE
[16.0][IMP] connector_extension: remove args/kwargs rebind workaround

### DIFF
--- a/connector_extension/models/binding/binding.py
+++ b/connector_extension/models/binding/binding.py
@@ -38,27 +38,6 @@ class ConnectorExtensionExternalBinding(models.AbstractModel):
     @api.model
     def export_data(self, backend_record, domain=None, delayed=True):
         """Prepare the batch export records to Channel"""
-        # Cursor-rebind workaround for OCA/queue queue_job (16.0+).
-        # `Job.in_temporary_env()` (added by OCA/queue#910 / commit f2bfda90)
-        # only rebinds `self.recordset` to the new cursor opened when
-        # `allow_commit=True`; it does NOT rebind args. Without this manual
-        # rebind, `backend_record.work_on()` builds a `WorkContext` whose
-        # `env` is the OUTER cursor (with `_prevent_commit` patched on
-        # `cr.commit`), so `binder.bind_export()` at `binder.py:315` still
-        # raises RuntimeError("Commit is forbidden in queue jobs") despite
-        # `allow_commit=True` being set. Pattern (cursor-only swap, preserves
-        # uid/su/context captured at `_job_prepare_context_before_enqueue`)
-        # matches what queue_job uses internally for `self.recordset`, and
-        # what @guewen (queue_job maintainer) himself suggested in
-        # OCA/queue#889 ("such export_record and such are implementation
-        # specific and need to be fixed in many places"). The OCA wiki page
-        # https://github.com/OCA/queue/wiki/Upgrade-warning:-commits-inside-jobs
-        # does NOT document this args-rebinding limitation.
-        # Same fix applied below in export_batch, export_record,
-        # export_delete_record. Imports do not need it because bind_import
-        # does not commit.
-        # Refs: OCA/queue#889, OCA/queue#910, OCA/connector#522.
-        backend_record = backend_record.with_env(backend_record.env(cr=self.env.cr))
         if delayed:
             model = self.with_delay()
         return model.export_batch(
@@ -82,8 +61,6 @@ class ConnectorExtensionExternalBinding(models.AbstractModel):
     @api.model
     def export_batch(self, backend_record, domain=None, delayed=True):
         """Prepare the batch export of records modified on Odoo"""
-        # Cursor-rebind workaround for queue_job; see export_data for rationale.
-        backend_record = backend_record.with_env(backend_record.env(cr=self.env.cr))
         if not domain:
             domain = []
         with backend_record.work_on(self._name) as work:
@@ -125,9 +102,6 @@ class ConnectorExtensionExternalBinding(models.AbstractModel):
     @api.model
     def export_record(self, backend_record, relation):
         """Export Odoo record"""
-        # Cursor-rebind workaround for queue_job; see export_data for rationale.
-        backend_record = backend_record.with_env(backend_record.env(cr=self.env.cr))
-        relation = relation.with_env(relation.env(cr=self.env.cr))
         with backend_record.work_on(self._name) as work:
             exporter = work.component(usage="record.direct.exporter")
             return exporter.run(relation)
@@ -135,9 +109,6 @@ class ConnectorExtensionExternalBinding(models.AbstractModel):
     @api.model
     def export_delete_record(self, backend_record, relation):
         """Export Odoo record"""
-        # Cursor-rebind workaround for queue_job; see export_data for rationale.
-        backend_record = backend_record.with_env(backend_record.env(cr=self.env.cr))
-        relation = relation.with_env(relation.env(cr=self.env.cr))
         with backend_record.work_on(self._name) as work:
             deleter = work.component(usage="record.direct.export.deleter")
             return deleter.run(relation)


### PR DESCRIPTION
## Summary

- Revert the manual args/kwargs cursor rebind at the export entry-points (the workaround half of #895): since queue_job 16.0.3.0.2 the job rebinds its args/kwargs to the current cursor by itself, so the manual rebind became a redundant double rebind.
- The allow_commit job functions from #895 stay — they are the feature switch, not the workaround.

## Test plan

- [x] pre-commit green
- [ ] CI green
- [ ] manual test: SAP export_record of a bound record commits inside the job without "Commit is forbidden in queue jobs"