### PR TITLE
[14.0][IMP] sale_order_invoicing_exclude: add never-invoice option

### DIFF
--- a/sale_order_invoicing_exclude/README.rst
+++ b/sale_order_invoicing_exclude/README.rst
@@ -6,7 +6,10 @@
 Sale order exclude invoicing
 ============================
 
-* Exclude orders from being invoiced.
+* Exclude orders from being invoiced: the invoicing process skips them while
+  they keep reporting *To invoice*, so they stay visible as pending.
+* Flag an excluded order as *Never invoice* to report it as *Nothing to
+  invoice* instead. The flag is only allowed on excluded orders.
 
 
 Bug Tracker

--- a/sale_order_invoicing_exclude/__manifest__.py
+++ b/sale_order_invoicing_exclude/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale order exclude invoicing",
     "summary": "Exclude orders from being invoiced.",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.2.0",
     "category": "Sales Management",
     "license": "AGPL-3",
     "author": "NuoBiT Solutions, S.L., Eric Antones",

--- a/sale_order_invoicing_exclude/i18n/es.po
+++ b/sale_order_invoicing_exclude/i18n/es.po
@@ -16,6 +16,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_order_invoicing_exclude
+#: code:addons/sale_order_invoicing_exclude/models/sale_order.py:0
+#, python-format
+msgid "'Never invoice' only makes sense on an order excluded from invoicing (%s)."
+msgstr ""
+"'No facturar nunca' solo tiene sentido en un pedido excluido de la "
+"facturación (%s)."
+
+#. module: sale_order_invoicing_exclude
 #: model:ir.model.fields,field_description:sale_order_invoicing_exclude.field_sale_order__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
@@ -44,6 +52,25 @@ msgstr "Incluido en la facturación"
 #: model:ir.model.fields,field_description:sale_order_invoicing_exclude.field_sale_order____last_update
 msgid "Last Modified on"
 msgstr "Última modificación el"
+
+#. module: sale_order_invoicing_exclude
+#: model:ir.model.fields,field_description:sale_order_invoicing_exclude.field_sale_order__sale_invoicing_exclude_never_invoice
+msgid "Never invoice"
+msgstr "No facturar nunca"
+
+#. module: sale_order_invoicing_exclude
+#: model_terms:ir.ui.view,arch_db:sale_order_invoicing_exclude.view_sales_order_filter
+msgid "Never to be invoiced"
+msgstr "No facturar nunca"
+
+#. module: sale_order_invoicing_exclude
+#: model:ir.model.fields,field_help:sale_order_invoicing_exclude.field_sale_order__sale_invoicing_exclude_never_invoice
+msgid ""
+"Report the order as 'Nothing to invoice' instead of 'To invoice'. Only for "
+"orders excluded from invoicing."
+msgstr ""
+"Muestra el pedido como 'Nada que facturar' en lugar de 'Para facturar'. Solo "
+"para pedidos excluidos de la facturación."
 
 #. module: sale_order_invoicing_exclude
 #: model:ir.model,name:sale_order_invoicing_exclude.model_sale_order

--- a/sale_order_invoicing_exclude/migrations/14.0.1.2.0/post-migration.py
+++ b/sale_order_invoicing_exclude/migrations/14.0.1.2.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright NuoBiT Solutions, S.L. (<https://www.nuobit.com>)
+# Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # 14.0.1.1.0 reported every excluded order as "Nothing to invoice". Only
+    # the ones flagged as "Never invoice" are from now on, so the excluded
+    # orders demoted back then have to report "To invoice" again.
+    env["sale.order"].search(
+        [("sale_invoicing_exclude_from_invoicing", "=", True)]
+    )._get_invoice_status()

--- a/sale_order_invoicing_exclude/models/sale_order.py
+++ b/sale_order_invoicing_exclude/models/sale_order.py
@@ -2,7 +2,8 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class SaleOrder(models.Model):
@@ -13,12 +14,41 @@ class SaleOrder(models.Model):
         default=False,
         tracking=True,
     )
+    sale_invoicing_exclude_never_invoice = fields.Boolean(
+        string="Never invoice",
+        default=False,
+        tracking=True,
+        help="Report the order as 'Nothing to invoice' instead of 'To invoice'. "
+        "Only for orders excluded from invoicing.",
+    )
 
-    @api.depends("sale_invoicing_exclude_from_invoicing")
+    @api.constrains(
+        "sale_invoicing_exclude_from_invoicing",
+        "sale_invoicing_exclude_never_invoice",
+    )
+    def _check_never_invoice(self):
+        for order in self.filtered(
+            lambda so: so.sale_invoicing_exclude_never_invoice
+            and not so.sale_invoicing_exclude_from_invoicing
+        ):
+            raise ValidationError(
+                _(
+                    "'Never invoice' only makes sense on an order excluded "
+                    "from invoicing (%s).",
+                    order.name,
+                )
+            )
+
+    @api.onchange("sale_invoicing_exclude_from_invoicing")
+    def _onchange_sale_invoicing_exclude_from_invoicing(self):
+        if not self.sale_invoicing_exclude_from_invoicing:
+            self.sale_invoicing_exclude_never_invoice = False
+
+    @api.depends("sale_invoicing_exclude_never_invoice")
     def _get_invoice_status(self):
         super()._get_invoice_status()
         for order in self.filtered(
-            lambda so: so.sale_invoicing_exclude_from_invoicing
+            lambda so: so.sale_invoicing_exclude_never_invoice
             and so.state in ("sale", "done")
             and so.invoice_status == "to invoice"
         ):

--- a/sale_order_invoicing_exclude/tests/test_sale_order_invoicing_exclude.py
+++ b/sale_order_invoicing_exclude/tests/test_sale_order_invoicing_exclude.py
@@ -2,7 +2,8 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo.tests import common
+from odoo.exceptions import ValidationError
+from odoo.tests import Form, common
 
 
 class TestSaleOrderInvoicingExclude(common.TransactionCase):
@@ -33,17 +34,72 @@ class TestSaleOrderInvoicingExclude(common.TransactionCase):
             }
         )
 
-    def test_excluded_order_invoice_status(self):
+    def _invoice_orders(self, orders):
+        wizard = (
+            self.env["sale.advance.payment.inv"]
+            .with_context(active_model="sale.order", active_ids=orders.ids)
+            .create({"advance_payment_method": "delivered"})
+        )
+        wizard.create_invoices()
+
+    def test_excluded_order_keeps_to_invoice_status(self):
         self.order.action_confirm()
         self.assertEqual(self.order.invoice_status, "to invoice")
         self.order.sale_invoicing_exclude_from_invoicing = True
-        self.assertEqual(self.order.invoice_status, "no")
-        self.order.sale_invoicing_exclude_from_invoicing = False
         self.assertEqual(self.order.invoice_status, "to invoice")
+
+    def test_excluded_order_is_skipped_by_invoicing(self):
+        other_order = self.order.copy()
+        orders = self.order | other_order
+        orders.action_confirm()
+        self.order.sale_invoicing_exclude_from_invoicing = True
+        self._invoice_orders(orders)
+        self.assertFalse(self.order.invoice_ids)
+        self.assertEqual(self.order.invoice_status, "to invoice")
+        self.assertEqual(len(other_order.invoice_ids), 1)
+        self.assertEqual(other_order.invoice_status, "invoiced")
+
+    def test_never_invoice_order_invoice_status(self):
+        self.order.action_confirm()
+        self.order.sale_invoicing_exclude_from_invoicing = True
+        self.assertEqual(self.order.invoice_status, "to invoice")
+        self.order.sale_invoicing_exclude_never_invoice = True
+        self.assertEqual(self.order.invoice_status, "no")
+        self.order.sale_invoicing_exclude_never_invoice = False
+        self.assertEqual(self.order.invoice_status, "to invoice")
+
+    def test_never_invoice_requires_exclusion(self):
+        with self.assertRaises(ValidationError):
+            self.order.sale_invoicing_exclude_never_invoice = True
+        self.assertFalse(self.order.sale_invoicing_exclude_never_invoice)
+        with self.assertRaises(ValidationError):
+            self.order.copy({"sale_invoicing_exclude_never_invoice": True})
+        self.order.write(
+            {
+                "sale_invoicing_exclude_from_invoicing": True,
+                "sale_invoicing_exclude_never_invoice": True,
+            }
+        )
+        with self.assertRaises(ValidationError):
+            self.order.sale_invoicing_exclude_from_invoicing = False
+        self.assertTrue(self.order.sale_invoicing_exclude_from_invoicing)
+        self.assertTrue(self.order.sale_invoicing_exclude_never_invoice)
+
+    def test_form_clears_never_invoice_with_exclusion(self):
+        with Form(self.order) as order_form:
+            order_form.sale_invoicing_exclude_from_invoicing = True
+            order_form.sale_invoicing_exclude_never_invoice = True
+        self.assertTrue(self.order.sale_invoicing_exclude_never_invoice)
+        with Form(self.order) as order_form:
+            order_form.sale_invoicing_exclude_from_invoicing = False
+        self.assertFalse(self.order.sale_invoicing_exclude_from_invoicing)
+        self.assertFalse(self.order.sale_invoicing_exclude_never_invoice)
 
     def test_excluded_invoiced_order_keeps_invoiced_status(self):
         self.order.action_confirm()
         self.order._create_invoices()
         self.assertEqual(self.order.invoice_status, "invoiced")
         self.order.sale_invoicing_exclude_from_invoicing = True
+        self.assertEqual(self.order.invoice_status, "invoiced")
+        self.order.sale_invoicing_exclude_never_invoice = True
         self.assertEqual(self.order.invoice_status, "invoiced")

--- a/sale_order_invoicing_exclude/views/sale_order_views.xml
+++ b/sale_order_invoicing_exclude/views/sale_order_views.xml
@@ -9,6 +9,10 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='sale_info']" position="inside">
                 <field name="sale_invoicing_exclude_from_invoicing" />
+                <field
+                    name="sale_invoicing_exclude_never_invoice"
+                    attrs="{'invisible': [('sale_invoicing_exclude_from_invoicing', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>
@@ -29,6 +33,11 @@
                     string="Included in invoicing"
                     name="sale_invoicing_exclude_from_invoicing"
                     domain="[('sale_invoicing_exclude_from_invoicing', '!=', 'True')]"
+                />
+                <filter
+                    string="Never to be invoiced"
+                    name="sale_invoicing_exclude_never_invoice"
+                    domain="[('sale_invoicing_exclude_never_invoice', '=', True)]"
                 />
             </xpath>
             <xpath expr="//group" position="inside">


### PR DESCRIPTION
## Summary

Since 14.0.1.1.0 every excluded pending order is reported as *Nothing to invoice*. That takes the orders that are only held back for a while out of the *To invoice* list the invoicing team works from, so a held order can no longer be told apart from an order with nothing left to invoice.

Whether an order will never be invoiced is known by whoever marks it, not by the company, so it becomes a second flag on the order, **Never invoice**, a sub-option of *Exclude from invoicing*:

- The exclusion alone no longer changes the computed invoice status (back to the pre-14.0.1.1.0 behaviour); the order is still skipped by `_create_invoices`.
- An excluded order flagged as *Never invoice* is reported as *Nothing to invoice*.
- *Never invoice* without the exclusion is rejected server side (`ValidationError`, `@api.constrains`); the form only hides the flag while the exclusion is unset and clears it when the exclusion is removed. Because the constraint guarantees the implication, the compute depends on the new flag alone.
- Search filter *Never to be invoiced*; Spanish translation (the module's only language); README.
- Post-migration 14.0.1.2.0 recomputes the invoice status of the excluded orders, so the ones demoted by 14.0.1.1.0 report *To invoice* again. It sets no flag: which excluded orders are never to be invoiced is decided by hand.

## Test plan

- [x] pre-commit passes locally
- [x] module test suite green on a local test database (invoicing gate through the wizard, status for each flag combination, constraint on write and on copy, form behaviour, invoiced orders keep *Invoiced*)
- [x] migration effect checked read-only against a production-like dataset (only excluded orders with something left to invoice change, back to *To invoice*)
- [ ] CI green