### PR TITLE
[14.0][REM] sale_order_invoicing_exclude: drop the never-invoice search filter

### DIFF
--- a/sale_order_invoicing_exclude/__manifest__.py
+++ b/sale_order_invoicing_exclude/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Sale order exclude invoicing",
     "summary": "Exclude orders from being invoiced.",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.2.1",
     "category": "Sales Management",
     "license": "AGPL-3",
     "author": "NuoBiT Solutions, S.L., Eric Antones",

--- a/sale_order_invoicing_exclude/i18n/es.po
+++ b/sale_order_invoicing_exclude/i18n/es.po
@@ -59,11 +59,6 @@ msgid "Never invoice"
 msgstr "No facturar nunca"
 
 #. module: sale_order_invoicing_exclude
-#: model_terms:ir.ui.view,arch_db:sale_order_invoicing_exclude.view_sales_order_filter
-msgid "Never to be invoiced"
-msgstr "No facturar nunca"
-
-#. module: sale_order_invoicing_exclude
 #: model:ir.model.fields,field_help:sale_order_invoicing_exclude.field_sale_order__sale_invoicing_exclude_never_invoice
 msgid ""
 "Report the order as 'Nothing to invoice' instead of 'To invoice'. Only for "

--- a/sale_order_invoicing_exclude/views/sale_order_views.xml
+++ b/sale_order_invoicing_exclude/views/sale_order_views.xml
@@ -34,11 +34,6 @@
                     name="sale_invoicing_exclude_from_invoicing"
                     domain="[('sale_invoicing_exclude_from_invoicing', '!=', 'True')]"
                 />
-                <filter
-                    string="Never to be invoiced"
-                    name="sale_invoicing_exclude_never_invoice"
-                    domain="[('sale_invoicing_exclude_never_invoice', '=', True)]"
-                />
             </xpath>
             <xpath expr="//group" position="inside">
                 <separator />


### PR DESCRIPTION
Removes the "Never to be invoiced" search filter introduced in 14.0.1.2.0.

The filter is not part of the users' workflow: they keep using the "Excluded from invoicing" filter on the pending list, and orders flagged "Never invoice" leave that list on their own because they report "Nothing to invoice". An extra entry in the search menu only misleads them.

- Search view: filter removed.
- `i18n/es.po`: its translation entry removed.
- Version 14.0.1.2.0 → 14.0.1.2.1.

The "Never invoice" field itself is unchanged and stays visible on the order form. Module tests pass (6/6).