### PR TITLE
[14.0][IMP] account_invoice_batches: run batch jobs as the company invoice batch user

### DIFF
--- a/account_invoice_batches/README.rst
+++ b/account_invoice_batches/README.rst
@@ -25,6 +25,17 @@ each company:
   the company among its allowed companies; without a valid user, no invoice
   can be generated from a batch nor e-mailed from one.
 
+Usage
+=====
+
+* The invoices generated from a batch are created, followed and e-mailed by
+  the invoice batch user of the company, so the customer replies reach its
+  mailbox and not the person who launched the batch.
+* When a batch invoice is validated, the customer follower Odoo adds is the
+  batch e-mail contact of the invoice when it differs from the partner: the
+  contact is the one who receives the e-mail. Invoices outside a batch keep
+  the native follower.
+
 Bug Tracker
 ===========
 

--- a/account_invoice_batches/README.rst
+++ b/account_invoice_batches/README.rst
@@ -35,6 +35,8 @@ Usage
   batch e-mail contact of the invoice when it differs from the partner: the
   contact is the one who receives the e-mail. Invoices outside a batch keep
   the native follower.
+* The batch has a chatter: whoever creates it follows it, and each processing
+  leaves a note with the number of invoices launched per sending method.
 
 Bug Tracker
 ===========

--- a/account_invoice_batches/README.rst
+++ b/account_invoice_batches/README.rst
@@ -8,6 +8,20 @@ Invoice batches
 
 Group invoices to easy printing/emailing
 
+Configuration
+=============
+
+Go to *Invoicing > Configuration > Settings > Invoice batches* and set, for
+each company:
+
+* the default e-mail template of the batch invoices;
+* the invoice batch user: the internal user the batch jobs run as. The
+  invoices generated from a batch and the e-mails sent from it belong to that
+  user (creator, follower, author of the sent messages), so the customer
+  replies reach its mailbox. It needs the Billing group, an e-mail address and
+  the company among its allowed companies; without a valid user, no invoice
+  can be generated from a batch nor e-mailed from one.
+
 Bug Tracker
 ===========
 

--- a/account_invoice_batches/README.rst
+++ b/account_invoice_batches/README.rst
@@ -14,7 +14,10 @@ Configuration
 Go to *Invoicing > Configuration > Settings > Invoice batches* and set, for
 each company:
 
-* the default e-mail template of the batch invoices;
+* the default e-mail template of the batch invoices. Address it to the field
+  *Batch e-mail recipient* of the invoice
+  (``${object.invoice_batch_email_recipient_id.id}`` as recipients): the batch
+  e-mail contact of the invoice or, when it is empty, its partner;
 * the invoice batch user: the internal user the batch jobs run as. The
   invoices generated from a batch and the e-mails sent from it belong to that
   user (creator, follower, author of the sent messages), so the customer

--- a/account_invoice_batches/README.rst
+++ b/account_invoice_batches/README.rst
@@ -23,7 +23,9 @@ each company:
   user (creator, follower, author of the sent messages), so the customer
   replies reach its mailbox. It needs the Billing group, an e-mail address and
   the company among its allowed companies; without a valid user, no invoice
-  can be generated from a batch nor e-mailed from one. Processing a batch
+  can be generated from a batch nor e-mailed from one, and the sale invoicing
+  wizard proposes a batch by default only when the current company has one.
+  Processing a batch
   with the e-mail method enabled needs the user of the batch company even
   when none of its invoices is sent by e-mail; printing and factura-e alone
   do not.

--- a/account_invoice_batches/README.rst
+++ b/account_invoice_batches/README.rst
@@ -23,7 +23,10 @@ each company:
   user (creator, follower, author of the sent messages), so the customer
   replies reach its mailbox. It needs the Billing group, an e-mail address and
   the company among its allowed companies; without a valid user, no invoice
-  can be generated from a batch nor e-mailed from one.
+  can be generated from a batch nor e-mailed from one. Processing a batch
+  with the e-mail method enabled needs the user of the batch company even
+  when none of its invoices is sent by e-mail; printing and factura-e alone
+  do not.
 
 Usage
 =====

--- a/account_invoice_batches/__manifest__.py
+++ b/account_invoice_batches/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Invoice batches",
-    "version": "14.0.1.1.3",
+    "version": "14.0.1.2.0",
     "author": "NuoBiT Solutions, S.L., Eric Antones",
     "license": "AGPL-3",
     "category": "Accounting",

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -422,6 +422,26 @@ msgstr ""
 "archivado."
 
 #. module: account_invoice_batches
+#: code:addons/account_invoice_batches/models/res_company.py:0
+#, python-format
+msgid ""
+"The invoice batch user %(user)s of company %(company)s is not an internal "
+"user."
+msgstr ""
+"El usuario del lote de facturación %(user)s de la compañía %(company)s no es "
+"un usuario interno."
+
+#. module: account_invoice_batches
+#: code:addons/account_invoice_batches/models/res_company.py:0
+#, python-format
+msgid ""
+"The invoice batch user %(user)s of company %(company)s must be an internal "
+"user, not a portal or public one."
+msgstr ""
+"El usuario del lote de facturación %(user)s de la compañía %(company)s debe "
+"ser un usuario interno, no uno de portal o público."
+
+#. module: account_invoice_batches
 #: code:addons/account_invoice_batches/wizard/sale_make_invoice_advance.py:0
 #, python-format
 msgid "There is no invoiceable line."

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -42,6 +42,13 @@ msgid "All"
 msgstr "Todas"
 
 #. module: account_invoice_batches
+#: model:ir.model.fields,field_description:account_invoice_batches.field_account_bank_statement_line__invoice_batch_email_recipient_id
+#: model:ir.model.fields,field_description:account_invoice_batches.field_account_move__invoice_batch_email_recipient_id
+#: model:ir.model.fields,field_description:account_invoice_batches.field_account_payment__invoice_batch_email_recipient_id
+msgid "Batch e-mail recipient"
+msgstr "Destinatario del e-mail del lote"
+
+#. module: account_invoice_batches
 #: model_terms:ir.ui.view,arch_db:account_invoice_batches.account_invoice_batch_process_view_form
 msgid "Cancel"
 msgstr "Cancelar"
@@ -343,6 +350,17 @@ msgstr "Procesar lote"
 #: model_terms:ir.ui.view,arch_db:account_invoice_batches.account_invoice_batch_process_view_form
 msgid "Process invoices"
 msgstr "Procesar facturas"
+
+#. module: account_invoice_batches
+#: model:ir.model.fields,help:account_invoice_batches.field_account_bank_statement_line__invoice_batch_email_recipient_id
+#: model:ir.model.fields,help:account_invoice_batches.field_account_move__invoice_batch_email_recipient_id
+#: model:ir.model.fields,help:account_invoice_batches.field_account_payment__invoice_batch_email_recipient_id
+msgid ""
+"Recipient of the batch e-mail: the batch e-mail contact of the invoice or, "
+"when it is empty, its partner."
+msgstr ""
+"Destinatario del e-mail del lote: el contacto de e-mail del lote de la "
+"factura o, si está vacío, su cliente."
 
 #. module: account_invoice_batches
 #: model:ir.model,name:account_invoice_batches.model_sale_advance_payment_inv

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -248,6 +248,12 @@ msgstr ""
 "buzón."
 
 #. module: account_invoice_batches
+#: code:addons/account_invoice_batches/wizard/account_invoice_batch_process.py:0
+#, python-format
+msgid "Invoice %s does not belong to a batch."
+msgstr "La factura %s no pertenece a ningún lote."
+
+#. module: account_invoice_batches
 #: model:ir.model.fields,field_description:account_invoice_batches.field_res_partner__invoice_batch_email_partner_id
 #: model:ir.model.fields,field_description:account_invoice_batches.field_res_users__invoice_batch_email_partner_id
 msgid "Invoice Batch Contact"

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -49,6 +49,12 @@ msgid "Batch e-mail recipient"
 msgstr "Destinatario del e-mail del lote"
 
 #. module: account_invoice_batches
+#: code:addons/account_invoice_batches/wizard/account_invoice_batch_process.py:0
+#, python-format
+msgid "Batch processing launched: %s"
+msgstr "Procesamiento del lote lanzado: %s"
+
+#. module: account_invoice_batches
 #: model_terms:ir.ui.view,arch_db:account_invoice_batches.account_invoice_batch_process_view_form
 msgid "Cancel"
 msgstr "Cancelar"

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -57,6 +57,16 @@ msgid "Company"
 msgstr "Compañía"
 
 #. module: account_invoice_batches
+#: code:addons/account_invoice_batches/models/res_company.py:0
+#, python-format
+msgid ""
+"Company %(company)s has no invoice batch user. Set one in Settings > "
+"Invoicing > Invoice batches."
+msgstr ""
+"La compañía %(company)s no tiene usuario del lote de facturación. Configure "
+"uno en Ajustes > Facturación > Lotes de facturación."
+
+#. module: account_invoice_batches
 #: model:ir.model,name:account_invoice_batches.model_res_config_settings
 msgid "Config Settings"
 msgstr "Opciones de configuración"
@@ -203,6 +213,28 @@ msgid "In background"
 msgstr "En segundo plano"
 
 #. module: account_invoice_batches
+#: model_terms:ir.ui.view,arch_db:account_invoice_batches.res_config_settings_view_form
+msgid "Internal user the batch invoicing and e-mailing jobs run as."
+msgstr ""
+"Usuario interno con el que se ejecutan los trabajos de facturación y envío "
+"de e-mails del lote."
+
+#. module: account_invoice_batches
+#: model:ir.model.fields,help:account_invoice_batches.field_res_company__invoice_batch_user_id
+#: model:ir.model.fields,help:account_invoice_batches.field_res_config_settings__invoice_batch_user_id
+msgid ""
+"Internal user the invoice batch jobs run as. The invoices generated from a "
+"batch and the e-mails sent from it belong to this user: it is their creator, "
+"their follower and the author of the sent messages, so the customer replies "
+"reach its mailbox."
+msgstr ""
+"Usuario interno con el que se ejecutan los trabajos del lote de facturación. "
+"Las facturas generadas desde un lote y los e-mails enviados desde él "
+"pertenecen a este usuario: es su creador, su seguidor y el autor de los "
+"mensajes enviados, de modo que las respuestas de los clientes llegan a su "
+"buzón."
+
+#. module: account_invoice_batches
 #: model:ir.model.fields,field_description:account_invoice_batches.field_res_partner__invoice_batch_email_partner_id
 #: model:ir.model.fields,field_description:account_invoice_batches.field_res_users__invoice_batch_email_partner_id
 msgid "Invoice Batch Contact"
@@ -223,6 +255,13 @@ msgstr "Método de envío de Lote de facturación"
 #: model_terms:ir.ui.view,arch_db:account_invoice_batches.view_account_invoice_filter
 msgid "Invoice batch"
 msgstr "Lote de facturación"
+
+#. module: account_invoice_batches
+#: model:ir.model.fields,field_description:account_invoice_batches.field_res_company__invoice_batch_user_id
+#: model:ir.model.fields,field_description:account_invoice_batches.field_res_config_settings__invoice_batch_user_id
+#: model_terms:ir.ui.view,arch_db:account_invoice_batches.res_config_settings_view_form
+msgid "Invoice batch user"
+msgstr "Usuario del lote de facturación"
 
 #. module: account_invoice_batches
 #: model:ir.actions.act_window,name:account_invoice_batches.account_invoice_batch_action
@@ -330,6 +369,33 @@ msgstr "Método de envío"
 #: model_terms:ir.ui.view,arch_db:account_invoice_batches.account_invoice_batch_view_tree
 msgid "Sent"
 msgstr "Enviadas"
+
+#. module: account_invoice_batches
+#: code:addons/account_invoice_batches/models/res_company.py:0
+#, python-format
+msgid ""
+"The invoice batch user %(user)s is not allowed on company %(company)s."
+msgstr ""
+"El usuario del lote de facturación %(user)s no está permitido en la compañía "
+"%(company)s."
+
+#. module: account_invoice_batches
+#: code:addons/account_invoice_batches/models/res_company.py:0
+#, python-format
+msgid ""
+"The invoice batch user %(user)s of company %(company)s has no e-mail "
+"address."
+msgstr ""
+"El usuario del lote de facturación %(user)s de la compañía %(company)s no "
+"tiene dirección de e-mail."
+
+#. module: account_invoice_batches
+#: code:addons/account_invoice_batches/models/res_company.py:0
+#, python-format
+msgid "The invoice batch user %(user)s of company %(company)s is archived."
+msgstr ""
+"El usuario del lote de facturación %(user)s de la compañía %(company)s está "
+"archivado."
 
 #. module: account_invoice_batches
 #: code:addons/account_invoice_batches/wizard/sale_make_invoice_advance.py:0

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -450,8 +450,22 @@ msgstr ""
 #. module: account_invoice_batches
 #: code:addons/account_invoice_batches/wizard/sale_make_invoice_advance.py:0
 #, python-format
+msgid ""
+"The orders invoiced in a batch must belong to the current company %s."
+msgstr ""
+"Los pedidos facturados en un lote deben pertenecer a la compañía actual %s."
+
+#. module: account_invoice_batches
+#: code:addons/account_invoice_batches/wizard/sale_make_invoice_advance.py:0
+#, python-format
 msgid "There is no invoiceable line."
 msgstr "No hay ninguna línea facturable"
+
+#. module: account_invoice_batches
+#: code:addons/account_invoice_batches/wizard/sale_make_invoice_advance.py:0
+#, python-format
+msgid "There is no order to invoice."
+msgstr "No hay ningún pedido que facturar."
 
 #. module: account_invoice_batches
 #: code:addons/account_invoice_batches/wizard/account_invoice_batch_process.py:0

--- a/account_invoice_batches/i18n/es.po
+++ b/account_invoice_batches/i18n/es.po
@@ -172,6 +172,15 @@ msgid "E-mail template"
 msgstr "Plantilla de e-mail"
 
 #. module: account_invoice_batches
+#: model:ir.model.fields,help:account_invoice_batches.field_sale_advance_payment_inv__invoice_batch_create
+msgid ""
+"Enabled by default when the current company has an invoice batch user; a "
+"batch cannot be created without one."
+msgstr ""
+"Activado por defecto cuando la compañía actual tiene usuario del lote de "
+"facturación; sin él no se puede crear un lote."
+
+#. module: account_invoice_batches
 #: code:addons/account_invoice_batches/wizard/account_invoice_batch_process.py:0
 #: code:addons/account_invoice_batches/wizard/account_invoice_batch_process.py:0
 #, python-format

--- a/account_invoice_batches/models/account_invoice_batch.py
+++ b/account_invoice_batches/models/account_invoice_batch.py
@@ -9,6 +9,7 @@ from odoo import api, fields, models
 
 class AccountInvoiceBatch(models.Model):
     _name = "account.invoice.batch"
+    _inherit = ["mail.thread"]
     _description = "Account Invoice Batch"
     _order = "date desc"
 

--- a/account_invoice_batches/models/account_move.py
+++ b/account_invoice_batches/models/account_move.py
@@ -29,6 +29,20 @@ class AccountMove(models.Model):
         string="Contact",
         tracking=True,
     )
+    invoice_batch_email_recipient_id = fields.Many2one(
+        comodel_name="res.partner",
+        compute="_compute_invoice_batch_email_recipient_id",
+        string="Batch e-mail recipient",
+        help="Recipient of the batch e-mail: the batch e-mail contact of the "
+        "invoice or, when it is empty, its partner.",
+    )
+
+    @api.depends("invoice_batch_email_partner_id", "partner_id")
+    def _compute_invoice_batch_email_recipient_id(self):
+        for move in self:
+            move.invoice_batch_email_recipient_id = (
+                move.invoice_batch_email_partner_id or move.partner_id
+            )
 
     @api.onchange("partner_id", "company_id")
     def _onchange_partner_id(self):

--- a/account_invoice_batches/models/account_move.py
+++ b/account_invoice_batches/models/account_move.py
@@ -72,7 +72,8 @@ class AccountMove(models.Model):
         batch invoice whose contact differs from the partner, the contact
         takes the partner's place: it is the recipient of the batch e-mail, so
         it is the one whose replies must reach the invoice followers. A partner
-        already subscribed by hand stays (core then asks for nobody), and every
+        already subscribed by hand stays (core then asks for nobody), an
+        archived contact is dropped by core like any other partner, and every
         other call keeps the native behaviour.
         """
         if (

--- a/account_invoice_batches/models/account_move.py
+++ b/account_invoice_batches/models/account_move.py
@@ -56,3 +56,34 @@ class AccountMove(models.Model):
                 self.partner_id.invoice_batch_email_partner_id
             )
         return res
+
+    def _post(self, soft=True):
+        # the customer follower added at validation is, on a batch invoice,
+        # the batch e-mail contact: see message_subscribe
+        return super(
+            AccountMove, self.with_context(invoice_batch_swap_billing_follower=True)
+        )._post(soft=soft)
+
+    def message_subscribe(self, partner_ids=None, channel_ids=None, subtype_ids=None):
+        """Subscribe the batch e-mail contact instead of the partner at validation.
+
+        Core subscribes the partner of every posted move, one move at a time.
+        Under the flag set by ``_post``, and only for that exact call on a
+        batch invoice whose contact differs from the partner, the contact
+        takes the partner's place: it is the recipient of the batch e-mail, so
+        it is the one whose replies must reach the invoice followers. A partner
+        already subscribed by hand stays (core then asks for nobody), and every
+        other call keeps the native behaviour.
+        """
+        if (
+            self.env.context.get("invoice_batch_swap_billing_follower")
+            and len(self) == 1
+            and self.invoice_batch_id
+            and partner_ids == [self.partner_id.id]
+            and self.invoice_batch_email_partner_id
+            and self.invoice_batch_email_partner_id != self.partner_id
+        ):
+            partner_ids = [self.invoice_batch_email_partner_id.id]
+        return super().message_subscribe(
+            partner_ids=partner_ids, channel_ids=channel_ids, subtype_ids=subtype_ids
+        )

--- a/account_invoice_batches/models/res_company.py
+++ b/account_invoice_batches/models/res_company.py
@@ -2,7 +2,8 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import fields, models
+from odoo import _, fields, models
+from odoo.exceptions import UserError
 
 
 class ResCompany(models.Model):
@@ -13,3 +14,58 @@ class ResCompany(models.Model):
         comodel_name="mail.template",
         domain=[("model_id", "=", "account.move")],
     )
+    invoice_batch_user_id = fields.Many2one(
+        string="Invoice batch user",
+        comodel_name="res.users",
+        domain=[("share", "=", False)],
+        help="Internal user the invoice batch jobs run as. The invoices "
+        "generated from a batch and the e-mails sent from it belong to this "
+        "user: it is their creator, their follower and the author of the sent "
+        "messages, so the customer replies reach its mailbox.",
+    )
+
+    def _get_invoice_batch_user(self):
+        """Return the user the invoice batch jobs of this company run as.
+
+        Raise a UserError naming the company when no user is configured, the
+        user is archived, has no e-mail address or is not allowed on the
+        company, so nothing is queued or executed with a wrong identity.
+        """
+        self.ensure_one()
+        user = self.invoice_batch_user_id
+        if not user:
+            raise UserError(
+                _(
+                    "Company %(company)s has no invoice batch user. Set one in "
+                    "Settings > Invoicing > Invoice batches.",
+                    company=self.display_name,
+                )
+            )
+        if not user.active:
+            raise UserError(
+                _(
+                    "The invoice batch user %(user)s of company %(company)s is "
+                    "archived.",
+                    user=user.display_name,
+                    company=self.display_name,
+                )
+            )
+        if not user.email:
+            raise UserError(
+                _(
+                    "The invoice batch user %(user)s of company %(company)s has "
+                    "no e-mail address.",
+                    user=user.display_name,
+                    company=self.display_name,
+                )
+            )
+        if self not in user.company_ids:
+            raise UserError(
+                _(
+                    "The invoice batch user %(user)s is not allowed on company "
+                    "%(company)s.",
+                    user=user.display_name,
+                    company=self.display_name,
+                )
+            )
+        return user

--- a/account_invoice_batches/models/res_company.py
+++ b/account_invoice_batches/models/res_company.py
@@ -2,8 +2,8 @@
 # Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import _, fields, models
-from odoo.exceptions import UserError
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
 
 
 class ResCompany(models.Model):
@@ -24,12 +24,26 @@ class ResCompany(models.Model):
         "messages, so the customer replies reach its mailbox.",
     )
 
+    @api.constrains("invoice_batch_user_id")
+    def _check_invoice_batch_user_id(self):
+        # the field domain only guides the widget: the invariant lives here
+        for company in self.filtered("invoice_batch_user_id.share"):
+            raise ValidationError(
+                _(
+                    "The invoice batch user %(user)s of company %(company)s must "
+                    "be an internal user, not a portal or public one.",
+                    user=company.invoice_batch_user_id.display_name,
+                    company=company.display_name,
+                )
+            )
+
     def _get_invoice_batch_user(self):
         """Return the user the invoice batch jobs of this company run as.
 
         Raise a UserError naming the company when no user is configured, the
-        user is archived, has no e-mail address or is not allowed on the
-        company, so nothing is queued or executed with a wrong identity.
+        user is archived, is not internal, has no e-mail address or is not
+        allowed on the company, so nothing is queued or executed with a wrong
+        identity.
         """
         self.ensure_one()
         user = self.invoice_batch_user_id
@@ -46,6 +60,16 @@ class ResCompany(models.Model):
                 _(
                     "The invoice batch user %(user)s of company %(company)s is "
                     "archived.",
+                    user=user.display_name,
+                    company=self.display_name,
+                )
+            )
+        if user.share:
+            # the groups can change after the user was set on the company
+            raise UserError(
+                _(
+                    "The invoice batch user %(user)s of company %(company)s is "
+                    "not an internal user.",
                     user=user.display_name,
                     company=self.display_name,
                 )

--- a/account_invoice_batches/models/res_config_settings.py
+++ b/account_invoice_batches/models/res_config_settings.py
@@ -12,3 +12,7 @@ class ResConfigSettings(models.TransientModel):
         related="company_id.invoice_batch_sending_email_template_id",
         readonly=False,
     )
+    invoice_batch_user_id = fields.Many2one(
+        related="company_id.invoice_batch_user_id",
+        readonly=False,
+    )

--- a/account_invoice_batches/security/ir.model.access.csv
+++ b/account_invoice_batches/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_invoice_batch_manager,account.invoice.batch manager,model_account_invoice_batch,account.group_account_manager,1,1,1,1
 access_account_invoice_batch_process,account.invoice.batch.process,model_account_invoice_batch_process,,1,1,1,1
 access_account_invoice_batch_user,account.invoice.batch user,model_account_invoice_batch,account.group_account_invoice,1,1,1,0
+access_sale_advance_payment_inv_account_invoice,sale.advance.payment.inv account invoice,sale.model_sale_advance_payment_inv,account.group_account_invoice,1,1,1,0

--- a/account_invoice_batches/tests/__init__.py
+++ b/account_invoice_batches/tests/__init__.py
@@ -2,4 +2,5 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import test_invoice_batch_jobs
+from . import test_invoice_batch_recipient
 from . import test_invoice_batch_user

--- a/account_invoice_batches/tests/__init__.py
+++ b/account_invoice_batches/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_invoice_batch_user

--- a/account_invoice_batches/tests/__init__.py
+++ b/account_invoice_batches/tests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import test_invoice_batch_followers
 from . import test_invoice_batch_jobs
 from . import test_invoice_batch_recipient
 from . import test_invoice_batch_user

--- a/account_invoice_batches/tests/__init__.py
+++ b/account_invoice_batches/tests/__init__.py
@@ -1,4 +1,5 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import test_invoice_batch_jobs
 from . import test_invoice_batch_user

--- a/account_invoice_batches/tests/__init__.py
+++ b/account_invoice_batches/tests/__init__.py
@@ -1,6 +1,3 @@
-# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
 from . import test_invoice_batch_chatter
 from . import test_invoice_batch_followers
 from . import test_invoice_batch_jobs

--- a/account_invoice_batches/tests/__init__.py
+++ b/account_invoice_batches/tests/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import test_invoice_batch_chatter
 from . import test_invoice_batch_followers
 from . import test_invoice_batch_jobs
 from . import test_invoice_batch_recipient

--- a/account_invoice_batches/tests/common.py
+++ b/account_invoice_batches/tests/common.py
@@ -3,6 +3,20 @@
 
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 
+# a plain-text customer reply, formatted by MockEmail.format()
+REPLY_TEMPLATE = """Return-Path: {return_path}
+To: {to}
+Cc: {cc}
+From: {email_from}
+Subject: {subject}
+Date: Tue, 08 Sep 2026 14:16:26 +0000
+Message-ID: {msg_id}
+Content-Type: text/plain; charset=utf-8
+{extra}
+
+Received, thank you.
+"""
+
 
 class InvoiceBatchCommon(MailCommon):
     """Data shared by the invoice batch tests.
@@ -125,8 +139,10 @@ class InvoiceBatchCommon(MailCommon):
         order.action_confirm()
         return order
 
-    def _batch_invoicing_wizard(self, orders, in_background, user=None):
-        """The sale invoicing wizard opened on the orders with a batch."""
+    def _batch_invoicing_wizard(
+        self, orders, in_background, user=None, create_batch=True
+    ):
+        """The sale invoicing wizard opened on the orders, as the launcher."""
         return (
             self.env["sale.advance.payment.inv"]
             .with_user(user or self.launcher)
@@ -138,7 +154,7 @@ class InvoiceBatchCommon(MailCommon):
             .create(
                 {
                     "advance_payment_method": "delivered",
-                    "invoice_batch_create": True,
+                    "invoice_batch_create": create_batch,
                     "in_background": in_background,
                 }
             )

--- a/account_invoice_batches/tests/common.py
+++ b/account_invoice_batches/tests/common.py
@@ -93,6 +93,16 @@ class InvoiceBatchCommon(MailCommon):
                 "invoice_batch_sending_method": "pdf",
             }
         )
+        # cash customer whose batch e-mail goes to the billing mailbox itself:
+        # the contact is the partner of the invoice batch user
+        cls.customer_cash = cls.env["res.partner"].create(
+            {
+                "name": "Cash Customer",
+                "email": "customer4@test.example.com",
+                "invoice_batch_sending_method": "email",
+                "invoice_batch_email_partner_id": cls.batch_user.partner_id.id,
+            }
+        )
         cls.product = cls.env["product.product"].create(
             {
                 "name": "Batch Service",
@@ -108,7 +118,7 @@ class InvoiceBatchCommon(MailCommon):
                 "subject": "Invoice ${object.name}",
                 "body_html": "<p>Please find attached the invoice ${object.name}.</p>",
                 "email_from": '"Billing Service" <billing@test.example.com>',
-                "partner_to": "${object.invoice_batch_email_partner_id.id}",
+                "partner_to": "${object.invoice_batch_email_recipient_id.id}",
                 "auto_delete": False,
             }
         )

--- a/account_invoice_batches/tests/common.py
+++ b/account_invoice_batches/tests/common.py
@@ -1,0 +1,168 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
+
+
+class InvoiceBatchCommon(MailCommon):
+    """Data shared by the invoice batch tests.
+
+    It reproduces the real setup: an invoice batch user with the Billing group
+    only, a launcher with sales and invoicing rights, a salesperson distinct
+    from both, customers with and without a billing contact, a printed
+    customer, a service product and a batch e-mail template sent from the
+    invoice batch user's mailbox.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._activate_multi_company()
+        cls.company = cls.company_admin
+        cls.batch_user = mail_new_test_user(
+            cls.env,
+            login="invoice_batch_user",
+            name="Billing Service",
+            email="billing@test.example.com",
+            groups="account.group_account_invoice",
+            company_id=cls.company.id,
+            company_ids=[(6, 0, cls.company.ids)],
+            notification_type="email",
+        )
+        cls.launcher = mail_new_test_user(
+            cls.env,
+            login="invoice_batch_launcher",
+            name="Batch Launcher",
+            email="launcher@test.example.com",
+            groups="sales_team.group_sale_salesman_all_leads,"
+            "account.group_account_invoice",
+            company_id=cls.company.id,
+            company_ids=[(6, 0, cls.company.ids)],
+            notification_type="email",
+        )
+        cls.salesperson = mail_new_test_user(
+            cls.env,
+            login="invoice_batch_salesperson",
+            name="Order Salesperson",
+            email="salesperson@test.example.com",
+            groups="sales_team.group_sale_salesman",
+            company_id=cls.company.id,
+            company_ids=[(6, 0, cls.company.ids)],
+            notification_type="email",
+        )
+        cls.customer = cls.env["res.partner"].create(
+            {
+                "name": "Customer With Billing Contact",
+                "email": "customer@test.example.com",
+                "invoice_batch_sending_method": "email",
+            }
+        )
+        cls.billing_contact = cls.env["res.partner"].create(
+            {
+                "name": "Customer Billing Contact",
+                "parent_id": cls.customer.id,
+                "email": "billing.contact@test.example.com",
+            }
+        )
+        cls.customer.invoice_batch_email_partner_id = cls.billing_contact
+        cls.customer_no_contact = cls.env["res.partner"].create(
+            {
+                "name": "Customer Without Billing Contact",
+                "email": "customer2@test.example.com",
+                "invoice_batch_sending_method": "email",
+            }
+        )
+        cls.customer_pdf = cls.env["res.partner"].create(
+            {
+                "name": "Printed Customer",
+                "email": "customer3@test.example.com",
+                "invoice_batch_sending_method": "pdf",
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Batch Service",
+                "type": "service",
+                "invoice_policy": "order",
+                "list_price": 100.0,
+            }
+        )
+        cls.template = cls.env["mail.template"].create(
+            {
+                "name": "Invoice batch e-mail",
+                "model_id": cls.env["ir.model"]._get_id("account.move"),
+                "subject": "Invoice ${object.name}",
+                "body_html": "<p>Please find attached the invoice ${object.name}.</p>",
+                "email_from": '"Billing Service" <billing@test.example.com>',
+                "partner_to": "${object.invoice_batch_email_partner_id.id}",
+                "auto_delete": False,
+            }
+        )
+        cls.company.write(
+            {
+                "invoice_batch_sending_email_template_id": cls.template.id,
+                "invoice_batch_user_id": cls.batch_user.id,
+                "report_service_id": cls.env.ref("account.account_invoices").id,
+            }
+        )
+
+    @classmethod
+    def _create_order(cls, partner):
+        """Confirmed order of one service line, sold by the salesperson."""
+        order = (
+            cls.env["sale.order"]
+            .with_user(cls.launcher)
+            .create(
+                {
+                    "partner_id": partner.id,
+                    "user_id": cls.salesperson.id,
+                    "order_line": [
+                        (0, 0, {"product_id": cls.product.id, "product_uom_qty": 1})
+                    ],
+                }
+            )
+        )
+        order.action_confirm()
+        return order
+
+    def _batch_invoicing_wizard(self, orders, in_background, user=None):
+        """The sale invoicing wizard opened on the orders with a batch."""
+        return (
+            self.env["sale.advance.payment.inv"]
+            .with_user(user or self.launcher)
+            .with_context(
+                active_model="sale.order",
+                active_ids=orders.ids,
+                active_id=orders[:1].id,
+            )
+            .create(
+                {
+                    "advance_payment_method": "delivered",
+                    "invoice_batch_create": True,
+                    "in_background": in_background,
+                }
+            )
+        )
+
+    def _batch_process_wizard(self, records, user=None, **values):
+        """The batch processing wizard opened on batches or on invoices."""
+        return (
+            self.env["account.invoice.batch.process"]
+            .with_user(user or self.launcher)
+            .with_context(
+                active_model=records._name,
+                active_ids=records.ids,
+                active_id=records[:1].id,
+            )
+            .create(values)
+        )
+
+    def _launch_batch(self, orders, in_background=False, user=None):
+        """Launch the batch invoicing of the orders; return the batch created."""
+        existing = self.env["account.invoice.batch"].search([])
+        self._batch_invoicing_wizard(orders, in_background, user).create_invoices()
+        batches = self.env["account.invoice.batch"].search(
+            [("id", "not in", existing.ids)]
+        )
+        self.assertEqual(len(batches), 1)
+        return batches

--- a/account_invoice_batches/tests/common.py
+++ b/account_invoice_batches/tests/common.py
@@ -79,6 +79,14 @@ class InvoiceBatchCommon(MailCommon):
             }
         )
         cls.customer.invoice_batch_email_partner_id = cls.billing_contact
+        cls.customer_self = cls.env["res.partner"].create(
+            {
+                "name": "Customer Own Contact",
+                "email": "customer5@test.example.com",
+                "invoice_batch_sending_method": "email",
+            }
+        )
+        cls.customer_self.invoice_batch_email_partner_id = cls.customer_self
         cls.customer_no_contact = cls.env["res.partner"].create(
             {
                 "name": "Customer Without Billing Contact",

--- a/account_invoice_batches/tests/test_invoice_batch_chatter.py
+++ b/account_invoice_batches/tests/test_invoice_batch_chatter.py
@@ -1,0 +1,68 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import InvoiceBatchCommon
+
+
+class TestInvoiceBatchChatter(InvoiceBatchCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.orders = (
+            cls._create_order(cls.customer)
+            + cls._create_order(cls.customer_no_contact)
+            + cls._create_order(cls.customer_pdf)
+        )
+
+    def _launch_notes(self, batch):
+        return batch.message_ids.filtered(
+            lambda msg: "Batch processing launched" in msg.body
+        )
+
+    def test_launcher_follows_the_batch(self):
+        batch = self._launch_batch(self.orders)
+        self.assertEqual(batch.create_uid, self.launcher)
+        self.assertIn(self.launcher.partner_id, batch.message_partner_ids)
+
+    def test_processing_a_batch_posts_one_note_with_the_counts(self):
+        batch = self._launch_batch(self.orders)
+        batch.invoice_ids.action_post()
+        with trap_jobs():
+            self._batch_process_wizard(batch).process_invoices()
+        note = self._launch_notes(batch)
+        self.assertEqual(len(note), 1)
+        self.assertEqual(note.author_id, self.launcher.partner_id)
+        self.assertEqual(note.subtype_id, self.env.ref("mail.mt_note"))
+        self.assertIn("1 PDF, 2 e-mail", note.body)
+
+    def test_processing_invoices_posts_one_note_per_batch(self):
+        batch_email = self._launch_batch(self.orders[:2])
+        batch_pdf = self._launch_batch(self.orders[2:])
+        invoices = (batch_email + batch_pdf).invoice_ids
+        invoices.action_post()
+        with trap_jobs():
+            self._batch_process_wizard(invoices).process_invoices()
+        note_email = self._launch_notes(batch_email)
+        self.assertEqual(len(note_email), 1)
+        self.assertIn("2 e-mail", note_email.body)
+        self.assertNotIn("PDF", note_email.body)
+        note_pdf = self._launch_notes(batch_pdf)
+        self.assertEqual(len(note_pdf), 1)
+        self.assertIn("1 PDF", note_pdf.body)
+        self.assertNotIn("e-mail", note_pdf.body)
+
+    def test_processing_with_no_method_enabled_posts_no_note(self):
+        batch = self._launch_batch(self.orders)
+        batch.invoice_ids.action_post()
+        with trap_jobs() as trap:
+            self._batch_process_wizard(
+                batch,
+                invoice_batch_sending_pdf=False,
+                invoice_batch_sending_email=False,
+                invoice_batch_sending_signedfacturae=False,
+                invoice_batch_sending_unsignedfacturae=False,
+            ).process_invoices()
+        trap.assert_jobs_count(0)
+        self.assertFalse(self._launch_notes(batch))

--- a/account_invoice_batches/tests/test_invoice_batch_chatter.py
+++ b/account_invoice_batches/tests/test_invoice_batch_chatter.py
@@ -28,7 +28,7 @@ class TestInvoiceBatchChatter(InvoiceBatchCommon):
 
     def test_processing_a_batch_posts_one_note_with_the_counts(self):
         batch = self._launch_batch(self.orders)
-        batch.invoice_ids.action_post()
+        batch.invoice_ids.with_user(self.launcher).action_post()
         with trap_jobs():
             self._batch_process_wizard(batch).process_invoices()
         note = self._launch_notes(batch)
@@ -41,7 +41,7 @@ class TestInvoiceBatchChatter(InvoiceBatchCommon):
         batch_email = self._launch_batch(self.orders[:2])
         batch_pdf = self._launch_batch(self.orders[2:])
         invoices = (batch_email + batch_pdf).invoice_ids
-        invoices.action_post()
+        invoices.with_user(self.launcher).action_post()
         with trap_jobs():
             self._batch_process_wizard(invoices).process_invoices()
         note_email = self._launch_notes(batch_email)
@@ -55,7 +55,7 @@ class TestInvoiceBatchChatter(InvoiceBatchCommon):
 
     def test_processing_with_no_method_enabled_posts_no_note(self):
         batch = self._launch_batch(self.orders)
-        batch.invoice_ids.action_post()
+        batch.invoice_ids.with_user(self.launcher).action_post()
         with trap_jobs() as trap:
             self._batch_process_wizard(
                 batch,

--- a/account_invoice_batches/tests/test_invoice_batch_followers.py
+++ b/account_invoice_batches/tests/test_invoice_batch_followers.py
@@ -1,0 +1,87 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from .common import InvoiceBatchCommon
+
+
+class TestInvoiceBatchFollowers(InvoiceBatchCommon):
+    """At validation, the customer follower of a batch invoice is its contact."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.orders = (
+            cls._create_order(cls.customer)
+            + cls._create_order(cls.customer_self)
+            + cls._create_order(cls.customer_no_contact)
+        )
+
+    def _posted_batch_invoice(self, batch, partner):
+        invoice = batch.invoice_ids.filtered(lambda inv: inv.partner_id == partner)
+        self.assertEqual(len(invoice), 1)
+        invoice.with_user(self.launcher).action_post()
+        return invoice
+
+    def test_contact_replaces_the_partner_as_follower(self):
+        batch = self._launch_batch(self.orders)
+        invoice = self._posted_batch_invoice(batch, self.customer)
+        self.assertIn(self.billing_contact, invoice.message_partner_ids)
+        self.assertNotIn(self.customer, invoice.message_partner_ids)
+        self.assertIn(self.batch_user.partner_id, invoice.message_partner_ids)
+
+    def test_contact_equal_to_the_partner_keeps_the_partner(self):
+        batch = self._launch_batch(self.orders)
+        invoice = self._posted_batch_invoice(batch, self.customer_self)
+        self.assertIn(self.customer_self, invoice.message_partner_ids)
+
+    def test_no_contact_keeps_the_partner(self):
+        batch = self._launch_batch(self.orders)
+        invoice = self._posted_batch_invoice(batch, self.customer_no_contact)
+        self.assertIn(self.customer_no_contact, invoice.message_partner_ids)
+
+    def test_partner_subscribed_by_hand_stays_and_the_contact_is_not_added(self):
+        batch = self._launch_batch(self.orders)
+        invoice = batch.invoice_ids.filtered(
+            lambda inv: inv.partner_id == self.customer
+        )
+        invoice.message_subscribe(partner_ids=self.customer.ids)
+        invoice.with_user(self.launcher).action_post()
+        self.assertIn(self.customer, invoice.message_partner_ids)
+        self.assertNotIn(self.billing_contact, invoice.message_partner_ids)
+
+    def test_invoice_outside_a_batch_keeps_the_native_follower(self):
+        invoice = (
+            self.env["account.move"]
+            .with_user(self.launcher)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "partner_id": self.customer.id,
+                    "invoice_batch_email_partner_id": self.billing_contact.id,
+                    "invoice_line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "product_id": self.product.id,
+                                "quantity": 1,
+                                "price_unit": 100.0,
+                            },
+                        )
+                    ],
+                }
+            )
+        )
+        invoice.action_post()
+        self.assertFalse(invoice.invoice_batch_id)
+        self.assertIn(self.customer, invoice.message_partner_ids)
+        self.assertNotIn(self.billing_contact, invoice.message_partner_ids)
+
+    def test_subscribing_the_partner_outside_validation_is_native(self):
+        batch = self._launch_batch(self.orders)
+        invoice = batch.invoice_ids.filtered(
+            lambda inv: inv.partner_id == self.customer
+        )
+        invoice.message_subscribe(partner_ids=self.customer.ids)
+        self.assertIn(self.customer, invoice.message_partner_ids)
+        self.assertNotIn(self.billing_contact, invoice.message_partner_ids)

--- a/account_invoice_batches/tests/test_invoice_batch_followers.py
+++ b/account_invoice_batches/tests/test_invoice_batch_followers.py
@@ -16,9 +16,13 @@ class TestInvoiceBatchFollowers(InvoiceBatchCommon):
             + cls._create_order(cls.customer_no_contact)
         )
 
-    def _posted_batch_invoice(self, batch, partner):
+    def _batch_invoice(self, batch, partner):
         invoice = batch.invoice_ids.filtered(lambda inv: inv.partner_id == partner)
         self.assertEqual(len(invoice), 1)
+        return invoice
+
+    def _posted_batch_invoice(self, batch, partner):
+        invoice = self._batch_invoice(batch, partner)
         invoice.with_user(self.launcher).action_post()
         return invoice
 
@@ -41,10 +45,10 @@ class TestInvoiceBatchFollowers(InvoiceBatchCommon):
 
     def test_partner_subscribed_by_hand_stays_and_the_contact_is_not_added(self):
         batch = self._launch_batch(self.orders)
-        invoice = batch.invoice_ids.filtered(
-            lambda inv: inv.partner_id == self.customer
+        invoice = self._batch_invoice(batch, self.customer)
+        invoice.with_user(self.launcher).message_subscribe(
+            partner_ids=self.customer.ids
         )
-        invoice.message_subscribe(partner_ids=self.customer.ids)
         invoice.with_user(self.launcher).action_post()
         self.assertIn(self.customer, invoice.message_partner_ids)
         self.assertNotIn(self.billing_contact, invoice.message_partner_ids)
@@ -79,9 +83,9 @@ class TestInvoiceBatchFollowers(InvoiceBatchCommon):
 
     def test_subscribing_the_partner_outside_validation_is_native(self):
         batch = self._launch_batch(self.orders)
-        invoice = batch.invoice_ids.filtered(
-            lambda inv: inv.partner_id == self.customer
+        invoice = self._batch_invoice(batch, self.customer)
+        invoice.with_user(self.launcher).message_subscribe(
+            partner_ids=self.customer.ids
         )
-        invoice.message_subscribe(partner_ids=self.customer.ids)
         self.assertIn(self.customer, invoice.message_partner_ids)
         self.assertNotIn(self.billing_contact, invoice.message_partner_ids)

--- a/account_invoice_batches/tests/test_invoice_batch_jobs.py
+++ b/account_invoice_batches/tests/test_invoice_batch_jobs.py
@@ -1,6 +1,8 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import UserError
+
 from odoo.addons.queue_job.tests.common import trap_jobs
 
 from .common import REPLY_TEMPLATE, InvoiceBatchCommon
@@ -74,6 +76,17 @@ class TestInvoiceBatchJobs(InvoiceBatchCommon):
         self.assertEqual(len(invoices), 2)
         self.assertFalse(invoices.mapped("invoice_batch_id"))
         self.assertEqual(invoices.mapped("create_uid"), self.launcher)
+
+    def test_send_email_job_requires_a_batch(self):
+        self._batch_invoicing_wizard(
+            self.orders, in_background=False, create_batch=False
+        ).create_invoices()
+        invoices = self.orders.invoice_ids
+        self.assertEqual(len(invoices), 2)
+        invoice = invoices[0]
+        with self.assertRaises(UserError):
+            self._batch_process_wizard(invoice).send_email(invoice.id)
+        self.assertFalse(invoice.is_move_sent)
 
     def test_send_email_runs_as_the_batch_user(self):
         batch = self._launch_batch(self.orders)

--- a/account_invoice_batches/tests/test_invoice_batch_jobs.py
+++ b/account_invoice_batches/tests/test_invoice_batch_jobs.py
@@ -96,12 +96,15 @@ class TestInvoiceBatchJobs(InvoiceBatchCommon):
             )
             self.assertEqual(invoice.message_partner_ids, followers_before[invoice])
             self.assertNotIn(self.launcher.partner_id, invoice.message_partner_ids)
-        invoice_with_contact = batch.invoice_ids.filtered(
-            lambda inv: inv.partner_id == self.customer
-        )
-        self.assertEqual(
-            self._sent_mail(invoice_with_contact).recipient_ids, self.billing_contact
-        )
+        expected_recipients = {
+            self.customer: self.billing_contact,
+            self.customer_no_contact: self.customer_no_contact,
+        }
+        for invoice in batch.invoice_ids:
+            self.assertEqual(
+                self._sent_mail(invoice).recipient_ids,
+                expected_recipients[invoice.partner_id],
+            )
 
     def test_customer_reply_notifies_the_batch_user_not_the_launcher(self):
         batch = self._launch_batch(self.orders)

--- a/account_invoice_batches/tests/test_invoice_batch_jobs.py
+++ b/account_invoice_batches/tests/test_invoice_batch_jobs.py
@@ -90,7 +90,7 @@ class TestInvoiceBatchJobs(InvoiceBatchCommon):
 
     def test_send_email_runs_as_the_batch_user(self):
         batch = self._launch_batch(self.orders)
-        batch.invoice_ids.action_post()
+        batch.invoice_ids.with_user(self.launcher).action_post()
         followers_before = {
             invoice: invoice.message_partner_ids for invoice in batch.invoice_ids
         }
@@ -121,7 +121,7 @@ class TestInvoiceBatchJobs(InvoiceBatchCommon):
 
     def test_customer_reply_notifies_the_batch_user_not_the_launcher(self):
         batch = self._launch_batch(self.orders)
-        batch.invoice_ids.action_post()
+        batch.invoice_ids.with_user(self.launcher).action_post()
         invoice = batch.invoice_ids.filtered(
             lambda inv: inv.partner_id == self.customer
         )

--- a/account_invoice_batches/tests/test_invoice_batch_jobs.py
+++ b/account_invoice_batches/tests/test_invoice_batch_jobs.py
@@ -1,0 +1,133 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import REPLY_TEMPLATE, InvoiceBatchCommon
+
+
+class TestInvoiceBatchJobs(InvoiceBatchCommon):
+    """The batch jobs run as the invoice batch user of the company.
+
+    That user has the Billing group only: these tests passing proves that
+    group, plus the access right the module gives it on the sale invoicing
+    wizard, is enough to generate and e-mail the batch invoices.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.orders = cls._create_order(cls.customer) + cls._create_order(
+            cls.customer_no_contact
+        )
+
+    def _assert_invoices_belong_to_the_batch_user(self, invoices):
+        self.assertEqual(len(invoices), 2)
+        for invoice in invoices:
+            self.assertEqual(invoice.create_uid, self.batch_user)
+            self.assertIn(self.batch_user.partner_id, invoice.message_partner_ids)
+            self.assertIn(self.salesperson.partner_id, invoice.message_partner_ids)
+            self.assertNotIn(self.launcher.partner_id, invoice.message_partner_ids)
+            self.assertEqual(
+                invoice.message_ids.mapped("author_id"), self.batch_user.partner_id
+            )
+
+    def _sent_mail(self, invoice):
+        mails = self.env["mail.mail"].search(
+            [("model", "=", "account.move"), ("res_id", "=", invoice.id)]
+        )
+        self.assertEqual(len(mails), 1)
+        return mails
+
+    def test_background_invoicing_runs_as_the_batch_user(self):
+        with trap_jobs() as trap:
+            batch = self._launch_batch(self.orders, in_background=True)
+            trap.assert_jobs_count(2)
+            trap.perform_enqueued_jobs()
+        self.assertEqual(batch.create_uid, self.launcher)
+        self._assert_invoices_belong_to_the_batch_user(batch.invoice_ids)
+
+    def test_synchronous_invoicing_runs_as_the_batch_user(self):
+        batch = self._launch_batch(self.orders, in_background=False)
+        self.assertEqual(batch.create_uid, self.launcher)
+        self._assert_invoices_belong_to_the_batch_user(batch.invoice_ids)
+
+    def test_background_invoicing_without_batch_keeps_the_launcher(self):
+        with trap_jobs() as trap:
+            self._batch_invoicing_wizard(
+                self.orders, in_background=True, create_batch=False
+            ).create_invoices()
+            trap.assert_jobs_count(2)
+            trap.perform_enqueued_jobs()
+        invoices = self.orders.invoice_ids
+        self.assertEqual(len(invoices), 2)
+        self.assertFalse(invoices.mapped("invoice_batch_id"))
+        self.assertEqual(invoices.mapped("create_uid"), self.launcher)
+        for invoice in invoices:
+            self.assertIn(self.launcher.partner_id, invoice.message_partner_ids)
+
+    def test_plain_invoicing_keeps_the_launcher(self):
+        self._batch_invoicing_wizard(
+            self.orders, in_background=False, create_batch=False
+        ).create_invoices()
+        invoices = self.orders.invoice_ids
+        self.assertEqual(len(invoices), 2)
+        self.assertFalse(invoices.mapped("invoice_batch_id"))
+        self.assertEqual(invoices.mapped("create_uid"), self.launcher)
+
+    def test_send_email_runs_as_the_batch_user(self):
+        batch = self._launch_batch(self.orders)
+        batch.invoice_ids.action_post()
+        followers_before = {
+            invoice: invoice.message_partner_ids for invoice in batch.invoice_ids
+        }
+        with self.mock_mail_gateway(), trap_jobs() as trap:
+            self._batch_process_wizard(
+                batch, invoice_batch_sending_pdf=False
+            ).process_invoices()
+            trap.assert_jobs_count(2)
+            trap.perform_enqueued_jobs()
+        for invoice in batch.invoice_ids:
+            self.assertTrue(invoice.is_move_sent)
+            mail = self._sent_mail(invoice)
+            self.assertEqual(mail.author_id, self.batch_user.partner_id)
+            self.assertEqual(
+                mail.email_from, '"Billing Service" <billing@test.example.com>'
+            )
+            self.assertEqual(invoice.message_partner_ids, followers_before[invoice])
+            self.assertNotIn(self.launcher.partner_id, invoice.message_partner_ids)
+        invoice_with_contact = batch.invoice_ids.filtered(
+            lambda inv: inv.partner_id == self.customer
+        )
+        self.assertEqual(
+            self._sent_mail(invoice_with_contact).recipient_ids, self.billing_contact
+        )
+
+    def test_customer_reply_notifies_the_batch_user_not_the_launcher(self):
+        batch = self._launch_batch(self.orders)
+        batch.invoice_ids.action_post()
+        invoice = batch.invoice_ids.filtered(
+            lambda inv: inv.partner_id == self.customer
+        )
+        with self.mock_mail_gateway(), trap_jobs() as trap:
+            self._batch_process_wizard(
+                batch, invoice_batch_sending_pdf=False
+            ).process_invoices()
+            trap.perform_enqueued_jobs()
+            sent = self._sent_mail(invoice)
+            self.format_and_process(
+                REPLY_TEMPLATE,
+                self.billing_contact.email_formatted,
+                sent.reply_to,
+                subject="Re: %s" % sent.subject,
+                extra="In-Reply-To: %s" % sent.message_id,
+                target_model="account.move",
+                target_field="name",
+            )
+        reply = invoice.message_ids.filtered(
+            lambda msg: msg.author_id == self.billing_contact
+        )
+        self.assertEqual(len(reply), 1)
+        notified = [address for mail in self._mails for address in mail["email_to"]]
+        self.assertTrue(any(self.batch_user.email in to for to in notified))
+        self.assertFalse(any(self.launcher.email in to for to in notified))

--- a/account_invoice_batches/tests/test_invoice_batch_recipient.py
+++ b/account_invoice_batches/tests/test_invoice_batch_recipient.py
@@ -50,7 +50,7 @@ class TestInvoiceBatchRecipient(InvoiceBatchCommon):
         self.assertEqual(
             invoice.invoice_batch_email_recipient_id, self.batch_user.partner_id
         )
-        invoice.action_post()
+        invoice.with_user(self.launcher).action_post()
         with self.mock_mail_gateway(), trap_jobs() as trap:
             self._batch_process_wizard(
                 batch, invoice_batch_sending_pdf=False

--- a/account_invoice_batches/tests/test_invoice_batch_recipient.py
+++ b/account_invoice_batches/tests/test_invoice_batch_recipient.py
@@ -1,0 +1,66 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import InvoiceBatchCommon
+
+
+class TestInvoiceBatchRecipient(InvoiceBatchCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.orders = cls._create_order(cls.customer) + cls._create_order(
+            cls.customer_no_contact
+        )
+
+    def test_recipient_is_the_contact_or_the_partner(self):
+        batch = self._launch_batch(self.orders)
+        for invoice in batch.invoice_ids:
+            if invoice.partner_id == self.customer:
+                self.assertEqual(
+                    invoice.invoice_batch_email_recipient_id, self.billing_contact
+                )
+            elif invoice.partner_id == self.customer_no_contact:
+                self.assertEqual(
+                    invoice.invoice_batch_email_recipient_id, self.customer_no_contact
+                )
+            else:
+                self.fail("unexpected invoice partner %s" % invoice.partner_id.name)
+
+    def test_entry_without_partner_has_no_recipient(self):
+        entry = self.env["account.move"].create({"move_type": "entry"})
+        self.assertFalse(entry.partner_id)
+        self.assertFalse(entry.invoice_batch_email_recipient_id)
+
+    def test_template_addresses_the_recipient(self):
+        batch = self._launch_batch(self.orders)
+        for invoice in batch.invoice_ids:
+            values = self.template.generate_email(invoice.ids, ["partner_to"])
+            self.assertEqual(
+                values[invoice.id]["partner_ids"],
+                invoice.invoice_batch_email_recipient_id.ids,
+            )
+
+    def test_contact_that_is_an_internal_partner_gets_the_email(self):
+        """A cash customer's batch e-mail goes to the billing mailbox itself."""
+        batch = self._launch_batch(self._create_order(self.customer_cash))
+        invoice = batch.invoice_ids
+        self.assertEqual(len(invoice), 1)
+        self.assertEqual(
+            invoice.invoice_batch_email_recipient_id, self.batch_user.partner_id
+        )
+        invoice.action_post()
+        with self.mock_mail_gateway(), trap_jobs() as trap:
+            self._batch_process_wizard(
+                batch, invoice_batch_sending_pdf=False
+            ).process_invoices()
+            trap.assert_jobs_count(1)
+            trap.perform_enqueued_jobs()
+        mails = self.env["mail.mail"].search(
+            [("model", "=", "account.move"), ("res_id", "=", invoice.id)]
+        )
+        self.assertEqual(len(mails), 1)
+        self.assertEqual(mails.author_id, self.batch_user.partner_id)
+        self.assertEqual(mails.recipient_ids, self.batch_user.partner_id)
+        self.assertTrue(invoice.is_move_sent)

--- a/account_invoice_batches/tests/test_invoice_batch_user.py
+++ b/account_invoice_batches/tests/test_invoice_batch_user.py
@@ -31,7 +31,7 @@ class TestInvoiceBatchUser(InvoiceBatchCommon):
     def _posted_batch(self):
         """A batch of the three orders with its invoices posted, e-mails unsent."""
         batch = self._launch_batch(self.orders)
-        batch.invoice_ids.action_post()
+        batch.invoice_ids.with_user(self.launcher).action_post()
         self.assertEqual(len(batch.unsent_invoice_ids), 3)
         return batch
 

--- a/account_invoice_batches/tests/test_invoice_batch_user.py
+++ b/account_invoice_batches/tests/test_invoice_batch_user.py
@@ -60,6 +60,13 @@ class TestInvoiceBatchUser(InvoiceBatchCommon):
         self.assertTrue(self.batch_user.share)
         self._assert_launch_blocked(in_background=True)
 
+    def test_batch_creation_defaults_to_the_company_configuration(self):
+        wizard = self.env["sale.advance.payment.inv"].with_user(self.launcher)
+        context = {"active_model": "sale.order", "active_ids": self.orders.ids}
+        self.assertTrue(wizard.with_context(**context).create({}).invoice_batch_create)
+        self.company.invoice_batch_user_id = False
+        self.assertFalse(wizard.with_context(**context).create({}).invoice_batch_create)
+
     def test_launch_without_invoice_batch_user_is_blocked(self):
         self.company.invoice_batch_user_id = False
         self._assert_launch_blocked(in_background=True)

--- a/account_invoice_batches/tests/test_invoice_batch_user.py
+++ b/account_invoice_batches/tests/test_invoice_batch_user.py
@@ -1,7 +1,7 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.queue_job.tests.common import trap_jobs
 
@@ -44,6 +44,21 @@ class TestInvoiceBatchUser(InvoiceBatchCommon):
         )
         settings.execute()
         self.assertEqual(self.company.invoice_batch_user_id, self.batch_user)
+
+    def test_settings_refuse_a_portal_user(self):
+        portal = self._create_portal_user()
+        with self.assertRaises(ValidationError):
+            self.env["res.config.settings"].with_user(self.user_admin).create(
+                {"invoice_batch_user_id": portal.id}
+            ).execute()
+        self.assertEqual(self.company.invoice_batch_user_id, self.batch_user)
+
+    def test_launch_with_user_turned_portal_is_blocked(self):
+        self.batch_user.write(
+            {"groups_id": [(6, 0, self.env.ref("base.group_portal").ids)]}
+        )
+        self.assertTrue(self.batch_user.share)
+        self._assert_launch_blocked(in_background=True)
 
     def test_launch_without_invoice_batch_user_is_blocked(self):
         self.company.invoice_batch_user_id = False

--- a/account_invoice_batches/tests/test_invoice_batch_user.py
+++ b/account_invoice_batches/tests/test_invoice_batch_user.py
@@ -1,0 +1,140 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import UserError
+
+from odoo.addons.queue_job.tests.common import trap_jobs
+
+from .common import InvoiceBatchCommon
+
+
+class TestInvoiceBatchUser(InvoiceBatchCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.orders = (
+            cls._create_order(cls.customer)
+            + cls._create_order(cls.customer_no_contact)
+            + cls._create_order(cls.customer_pdf)
+        )
+
+    def _assert_launch_blocked(self, in_background):
+        """The launch fails naming the company before any batch, job or invoice."""
+        batches_before = self.env["account.invoice.batch"].search([])
+        with trap_jobs() as trap, self.assertRaises(UserError) as error:
+            self._batch_invoicing_wizard(self.orders, in_background).create_invoices()
+        self.assertIn(self.company.name, str(error.exception))
+        trap.assert_jobs_count(0)
+        self.assertEqual(self.env["account.invoice.batch"].search([]), batches_before)
+        self.assertFalse(self.orders.invoice_ids)
+
+    def _posted_batch(self):
+        """A batch of the three orders with its invoices posted, e-mails unsent."""
+        batch = self._launch_batch(self.orders)
+        batch.invoice_ids.action_post()
+        self.assertEqual(len(batch.unsent_invoice_ids), 3)
+        return batch
+
+    def test_settings_store_the_invoice_batch_user(self):
+        self.company.invoice_batch_user_id = False
+        settings = (
+            self.env["res.config.settings"]
+            .with_user(self.user_admin)
+            .create({"invoice_batch_user_id": self.batch_user.id})
+        )
+        settings.execute()
+        self.assertEqual(self.company.invoice_batch_user_id, self.batch_user)
+
+    def test_launch_without_invoice_batch_user_is_blocked(self):
+        self.company.invoice_batch_user_id = False
+        self._assert_launch_blocked(in_background=True)
+        self._assert_launch_blocked(in_background=False)
+
+    def test_launch_with_archived_user_is_blocked(self):
+        self.batch_user.action_archive()
+        self._assert_launch_blocked(in_background=True)
+
+    def test_launch_with_user_without_email_is_blocked(self):
+        self.batch_user.email = False
+        self._assert_launch_blocked(in_background=True)
+
+    def test_launch_with_user_not_allowed_on_company_is_blocked(self):
+        self.batch_user.write(
+            {
+                "company_id": self.company_2.id,
+                "company_ids": [(6, 0, self.company_2.ids)],
+            }
+        )
+        self._assert_launch_blocked(in_background=True)
+
+    def test_launch_in_background_queues_one_job_per_invoicing_group(self):
+        with trap_jobs() as trap:
+            batch = self._launch_batch(self.orders, in_background=True)
+            trap.assert_jobs_count(3)
+            self.assertFalse(batch.invoice_ids)
+            trap.perform_enqueued_jobs()
+        self.assertEqual(len(batch.invoice_ids), 3)
+        self.assertEqual(self.orders.invoice_ids, batch.invoice_ids)
+        self.assertEqual(
+            batch.invoice_ids.mapped("partner_id"), self.orders.mapped("partner_id")
+        )
+
+    def test_launch_synchronously_creates_the_batch_invoices(self):
+        with trap_jobs() as trap:
+            batch = self._launch_batch(self.orders, in_background=False)
+        trap.assert_jobs_count(0)
+        self.assertEqual(len(batch.invoice_ids), 3)
+        self.assertEqual(self.orders.invoice_ids, batch.invoice_ids)
+        self.assertEqual(
+            batch.invoice_ids.mapped("invoice_batch_sending_method"),
+            self.orders.mapped("partner_id.invoice_batch_sending_method"),
+        )
+
+    def test_invoice_group_job_without_user_is_blocked(self):
+        with trap_jobs() as trap:
+            batch = self._launch_batch(self.orders, in_background=True)
+            trap.assert_jobs_count(3)
+            self.company.invoice_batch_user_id = False
+            with self.assertRaises(UserError) as error:
+                trap.perform_enqueued_jobs()
+        self.assertIn(self.company.name, str(error.exception))
+        self.assertFalse(batch.invoice_ids)
+
+    def test_process_with_email_without_user_is_blocked(self):
+        batch = self._posted_batch()
+        self.company.invoice_batch_user_id = False
+        for records in (batch, batch.invoice_ids):
+            with trap_jobs() as trap, self.assertRaises(UserError) as error:
+                self._batch_process_wizard(records).process_invoices()
+            self.assertIn(self.company.name, str(error.exception))
+            trap.assert_jobs_count(0)
+            self.assertFalse(any(batch.invoice_ids.mapped("is_move_sent")))
+
+    def test_process_without_email_does_not_need_the_user(self):
+        batch = self._posted_batch()
+        self.company.invoice_batch_user_id = False
+        with trap_jobs() as trap:
+            action = self._batch_process_wizard(
+                batch, invoice_batch_sending_email=False
+            ).process_invoices()
+        trap.assert_jobs_count(0)
+        self.assertEqual(action["type"], "ir.actions.report")
+        printed = batch.invoice_ids.filtered(
+            lambda inv: inv.invoice_batch_sending_method == "pdf"
+        )
+        self.assertEqual(len(printed), 1)
+        self.assertTrue(printed.is_move_sent)
+        self.assertFalse(any((batch.invoice_ids - printed).mapped("is_move_sent")))
+
+    def test_send_email_job_without_user_is_blocked(self):
+        batch = self._posted_batch()
+        with trap_jobs() as trap:
+            self._batch_process_wizard(
+                batch, invoice_batch_sending_pdf=False
+            ).process_invoices()
+            trap.assert_jobs_count(2)
+            self.company.invoice_batch_user_id = False
+            with self.assertRaises(UserError) as error:
+                trap.perform_enqueued_jobs()
+        self.assertIn(self.company.name, str(error.exception))
+        self.assertFalse(any(batch.invoice_ids.mapped("is_move_sent")))

--- a/account_invoice_batches/tests/test_invoice_batch_user.py
+++ b/account_invoice_batches/tests/test_invoice_batch_user.py
@@ -82,6 +82,33 @@ class TestInvoiceBatchUser(InvoiceBatchCommon):
         )
         self._assert_launch_blocked(in_background=True)
 
+    def test_launch_with_orders_of_another_company_is_blocked(self):
+        self.launcher.write({"company_ids": [(4, self.company_2.id)]})
+        foreign_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.customer.id,
+                "company_id": self.company_2.id,
+                "order_line": [
+                    (0, 0, {"product_id": self.product.id, "product_uom_qty": 1})
+                ],
+            }
+        )
+        batches_before = self.env["account.invoice.batch"].search([])
+        with trap_jobs() as trap, self.assertRaises(UserError) as error:
+            self._batch_invoicing_wizard(
+                self.orders + foreign_order, in_background=True
+            ).create_invoices()
+        self.assertIn(self.company.name, str(error.exception))
+        trap.assert_jobs_count(0)
+        self.assertEqual(self.env["account.invoice.batch"].search([]), batches_before)
+        self.assertFalse(self.orders.invoice_ids)
+
+    def test_launch_without_orders_is_blocked(self):
+        with self.assertRaises(UserError):
+            self._batch_invoicing_wizard(
+                self.env["sale.order"], in_background=True
+            ).create_invoices()
+
     def test_launch_in_background_queues_one_job_per_invoicing_group(self):
         with trap_jobs() as trap:
             batch = self._launch_batch(self.orders, in_background=True)

--- a/account_invoice_batches/views/account_invoice_batch.xml
+++ b/account_invoice_batches/views/account_invoice_batch.xml
@@ -112,6 +112,10 @@
                         <field name="name" widget="text" />
                     </group>
                 </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" />
+                    <field name="message_ids" />
+                </div>
             </form>
         </field>
     </record>

--- a/account_invoice_batches/views/res_config_settings_views.xml
+++ b/account_invoice_batches/views/res_config_settings_views.xml
@@ -33,6 +33,24 @@
                             <field name="invoice_batch_sending_email_template_id" />
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane" />
+                        <div class="o_setting_right_pane">
+                            <label
+                                for="invoice_batch_user_id"
+                                string="Invoice batch user"
+                            />
+                            <span
+                                class="fa fa-lg fa-building-o"
+                                title="Values set here are company-specific."
+                                groups="base.group_multi_company"
+                            />
+                            <div
+                                class="text-muted"
+                            >Internal user the batch invoicing and e-mailing jobs run as.</div>
+                            <field name="invoice_batch_user_id" />
+                        </div>
+                    </div>
                 </div>
             </div>
         </field>

--- a/account_invoice_batches/wizard/account_invoice_batch_process.py
+++ b/account_invoice_batches/wizard/account_invoice_batch_process.py
@@ -84,20 +84,20 @@ class AccountInvoiceBatchProcess(models.TransientModel):
     def send_email(self, move_id):
         inv = self.env["account.move"].browse(move_id)
         if not inv.is_move_sent:
-            template_id = self.invoice_batch_sending_email_template_id.id
             batch = inv.invoice_batch_id
-            if batch:
-                # the e-mail belongs to the invoice batch user of the batch
-                # company: author of the message, mailbox of the replies. Only
-                # that company stays among the allowed ones, and a configuration
-                # withdrawn between the enqueue and the run fails loud here
-                # instead of running with another identity.
-                user = batch.company_id._get_invoice_batch_user()
-                inv = inv.with_user(user).with_context(
-                    allowed_company_ids=batch.company_id.ids
+            if not batch:
+                raise UserError(
+                    _("Invoice %s does not belong to a batch.", inv.display_name)
                 )
-            # an invoice outside a batch keeps the launcher's identity
-            inv.with_context(lang=inv.partner_id.lang).message_post_with_template(
+            # the e-mail belongs to the invoice batch user of the batch company
+            # (author of the message, mailbox of the replies); a configuration
+            # withdrawn between the enqueue and the run fails loud here
+            user = batch.company_id._get_invoice_batch_user()
+            template_id = self.invoice_batch_sending_email_template_id.id
+            inv = inv.with_user(user).with_context(
+                allowed_company_ids=batch.company_id.ids, lang=inv.partner_id.lang
+            )
+            inv.message_post_with_template(
                 template_id,
                 message_type="comment",
                 composition_mode="mass_mail",

--- a/account_invoice_batches/wizard/account_invoice_batch_process.py
+++ b/account_invoice_batches/wizard/account_invoice_batch_process.py
@@ -81,12 +81,21 @@ class AccountInvoiceBatchProcess(models.TransientModel):
     def send_email(self, move_id):
         inv = self.env["account.move"].browse(move_id)
         if not inv.is_move_sent:
-            if inv.invoice_batch_id:
-                # a configuration withdrawn between the enqueue and the run
-                # fails loud here instead of running with another identity
-                inv.invoice_batch_id.company_id._get_invoice_batch_user()
+            template_id = self.invoice_batch_sending_email_template_id.id
+            batch = inv.invoice_batch_id
+            if batch:
+                # the e-mail belongs to the invoice batch user of the batch
+                # company: author of the message, mailbox of the replies. Only
+                # that company stays among the allowed ones, and a configuration
+                # withdrawn between the enqueue and the run fails loud here
+                # instead of running with another identity.
+                user = batch.company_id._get_invoice_batch_user()
+                inv = inv.with_user(user).with_context(
+                    allowed_company_ids=batch.company_id.ids
+                )
+            # an invoice outside a batch keeps the launcher's identity
             inv.with_context(lang=inv.partner_id.lang).message_post_with_template(
-                self.invoice_batch_sending_email_template_id.id,
+                template_id,
                 message_type="comment",
                 composition_mode="mass_mail",
             )

--- a/account_invoice_batches/wizard/account_invoice_batch_process.py
+++ b/account_invoice_batches/wizard/account_invoice_batch_process.py
@@ -4,9 +4,12 @@
 
 import base64
 import logging
+from collections import Counter
 
 from odoo import _, fields, models
 from odoo.exceptions import UserError
+
+from ..models.common import BATCH_SENDING_METHODS
 
 _logger = logging.getLogger(__name__)
 
@@ -116,6 +119,45 @@ class AccountInvoiceBatchProcess(models.TransientModel):
         for company in batches.mapped("company_id"):
             company._get_invoice_batch_user()
 
+    def _get_invoice_batch_enabled_sending_methods(self):
+        """Sending methods enabled on this wizard, in BATCH_SENDING_METHODS order.
+
+        Extend it together with BATCH_SENDING_METHODS to add a method.
+        """
+        self.ensure_one()
+        enabled = {
+            "pdf": self.invoice_batch_sending_pdf,
+            "email": self.invoice_batch_sending_email,
+            "signedfacturae": self.invoice_batch_sending_signedfacturae,
+            "unsignedfacturae": self.invoice_batch_sending_unsignedfacturae,
+        }
+        return [
+            method for method, _label in BATCH_SENDING_METHODS if enabled.get(method)
+        ]
+
+    def _post_invoice_batch_launch_note(self, batch, invoices):
+        """Note on the batch, as the launcher, counting the invoices per method.
+
+        Only the invoices to be sent with an enabled method are counted; when
+        there is none, nothing was launched and no note is posted.
+        """
+        labels = dict(
+            self.env["account.move"]
+            ._fields["invoice_batch_sending_method"]
+            ._description_selection(self.env)
+        )
+        counted = Counter(invoices.mapped("invoice_batch_sending_method"))
+        counts = [
+            "%d %s" % (counted[method], labels[method])
+            for method in self._get_invoice_batch_enabled_sending_methods()
+            if counted[method]
+        ]
+        if counts:
+            batch.message_post(
+                body=_("Batch processing launched: %s", ", ".join(counts)),
+                subtype_xmlid="mail.mt_note",
+            )
+
     def prepare_invoices(self, invoices):
         self.ensure_one()
 
@@ -169,6 +211,7 @@ class AccountInvoiceBatchProcess(models.TransientModel):
             for batch in active_objects:
                 invoices = batch.unsent_invoice_ids
                 invoices_pdf += self.prepare_invoices(invoices)
+                self._post_invoice_batch_launch_note(batch, invoices)
         elif model == "account.move":
             if not active_objects:
                 raise UserError(_("There's no invoices to process"))
@@ -178,6 +221,11 @@ class AccountInvoiceBatchProcess(models.TransientModel):
             if self._invoice_batch_user_required():
                 self._invoice_batch_check_users(invoices.mapped("invoice_batch_id"))
             invoices_pdf = self.prepare_invoices(invoices)
+            for batch in invoices.mapped("invoice_batch_id"):
+                self._post_invoice_batch_launch_note(
+                    batch,
+                    invoices.filtered_domain([("invoice_batch_id", "=", batch.id)]),
+                )
         else:
             raise UserError(_("Unexpected model '%s'" % model))
 

--- a/account_invoice_batches/wizard/account_invoice_batch_process.py
+++ b/account_invoice_batches/wizard/account_invoice_batch_process.py
@@ -131,9 +131,8 @@ class AccountInvoiceBatchProcess(models.TransientModel):
             "signedfacturae": self.invoice_batch_sending_signedfacturae,
             "unsignedfacturae": self.invoice_batch_sending_unsignedfacturae,
         }
-        return [
-            method for method, _label in BATCH_SENDING_METHODS if enabled.get(method)
-        ]
+        # a method without flag here fails loud (KeyError) instead of vanishing
+        return [method for method, _label in BATCH_SENDING_METHODS if enabled[method]]
 
     def _post_invoice_batch_launch_note(self, batch, invoices):
         """Note on the batch, as the launcher, counting the invoices per method.

--- a/account_invoice_batches/wizard/account_invoice_batch_process.py
+++ b/account_invoice_batches/wizard/account_invoice_batch_process.py
@@ -81,12 +81,31 @@ class AccountInvoiceBatchProcess(models.TransientModel):
     def send_email(self, move_id):
         inv = self.env["account.move"].browse(move_id)
         if not inv.is_move_sent:
+            if inv.invoice_batch_id:
+                # a configuration withdrawn between the enqueue and the run
+                # fails loud here instead of running with another identity
+                inv.invoice_batch_id.company_id._get_invoice_batch_user()
             inv.with_context(lang=inv.partner_id.lang).message_post_with_template(
                 self.invoice_batch_sending_email_template_id.id,
                 message_type="comment",
                 composition_mode="mass_mail",
             )
             inv.is_move_sent = True
+
+    def _invoice_batch_user_required(self):
+        """Whether the processing needs the invoice batch user of the companies.
+
+        Only the e-mail job runs as that user: printing and factura-e keep the
+        launcher's identity, so a batch of a company without user can still be
+        printed or sent as factura-e.
+        """
+        self.ensure_one()
+        return bool(self.invoice_batch_sending_email)
+
+    def _invoice_batch_check_users(self, batches):
+        """Fail before enqueueing anything when a batch company has no valid user."""
+        for company in batches.mapped("company_id"):
+            company._get_invoice_batch_user()
 
     def prepare_invoices(self, invoices):
         self.ensure_one()
@@ -136,6 +155,8 @@ class AccountInvoiceBatchProcess(models.TransientModel):
         if model == "account.invoice.batch":
             if not active_objects.mapped("unsent_invoice_ids"):
                 raise UserError(_("There's no invoices to process"))
+            if self._invoice_batch_user_required():
+                self._invoice_batch_check_users(active_objects)
             for batch in active_objects:
                 invoices = batch.unsent_invoice_ids
                 invoices_pdf += self.prepare_invoices(invoices)
@@ -145,6 +166,8 @@ class AccountInvoiceBatchProcess(models.TransientModel):
             invoices = active_objects.filtered(
                 lambda x: x.invoice_batch_id and not x.is_move_sent
             )
+            if self._invoice_batch_user_required():
+                self._invoice_batch_check_users(invoices.mapped("invoice_batch_id"))
             invoices_pdf = self.prepare_invoices(invoices)
         else:
             raise UserError(_("Unexpected model '%s'" % model))

--- a/account_invoice_batches/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_batches/wizard/sale_make_invoice_advance.py
@@ -39,6 +39,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def create_invoice_group(self, order_group, invoice_batch=None):
         context = {"active_ids": order_group.mapped("id")}
         if invoice_batch:
+            # a configuration withdrawn between the enqueue and the run fails
+            # loud here instead of running with another identity
+            invoice_batch.company_id._get_invoice_batch_user()
             context.update(
                 {
                     "batch_id": invoice_batch.id,
@@ -53,6 +56,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
         invoice_batch = None
         if self.invoice_batch_create:
+            # the batch belongs to the current company: fail before creating
+            # it when that company has no valid invoice batch user
+            self.env.company._get_invoice_batch_user()
             invoice_batch = self.env["account.invoice.batch"].create(
                 {
                     "date": fields.Datetime.now(),

--- a/account_invoice_batches/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_batches/wizard/sale_make_invoice_advance.py
@@ -10,7 +10,12 @@ from odoo.exceptions import UserError
 class SaleAdvancePaymentInv(models.TransientModel):
     _inherit = "sale.advance.payment.inv"
 
-    invoice_batch_create = fields.Boolean(string="Create invoice batch", default=True)
+    invoice_batch_create = fields.Boolean(
+        string="Create invoice batch",
+        default=lambda self: bool(self.env.company.invoice_batch_user_id),
+        help="Enabled by default when the current company has an invoice batch "
+        "user; a batch cannot be created without one.",
+    )
     in_background = fields.Boolean(string="In background", default=False)
 
     def _create_invoice(self, order, so_line, amount):

--- a/account_invoice_batches/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_batches/wizard/sale_make_invoice_advance.py
@@ -37,7 +37,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
         return invoice
 
     def _invoice_batch_as_batch_user(self, invoice_batch):
-        """This wizard run as the invoice batch user of the batch company.
+        """The wizard, run as the invoice batch user of the batch company.
 
         Only the batch company stays among the allowed companies: the ones the
         launcher had enabled would raise an access error for a user not allowed

--- a/account_invoice_batches/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_batches/wizard/sale_make_invoice_advance.py
@@ -63,10 +63,22 @@ class SaleAdvancePaymentInv(models.TransientModel):
         if not self.in_background and not self.invoice_batch_create:
             return super(SaleAdvancePaymentInv, self).create_invoices()
 
+        sale_orders = self.env["sale.order"].browse(self._context.get("active_ids", []))
         invoice_batch = None
         if self.invoice_batch_create:
-            # the batch belongs to the current company: fail before creating
-            # it when that company has no valid invoice batch user
+            # the batch belongs to the current company and so must its orders:
+            # fail before creating it when they do not, or when that company
+            # has no valid invoice batch user
+            if not sale_orders:
+                raise UserError(_("There is no order to invoice."))
+            if sale_orders.company_id != self.env.company:
+                raise UserError(
+                    _(
+                        "The orders invoiced in a batch must belong to the "
+                        "current company %s.",
+                        self.env.company.display_name,
+                    )
+                )
             self.env.company._get_invoice_batch_user()
             invoice_batch = self.env["account.invoice.batch"].create(
                 {
@@ -75,9 +87,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
             )
 
         if self.in_background:
-            sale_orders = self.env["sale.order"].browse(
-                self._context.get("active_ids", [])
-            )
             order_groups = {}
             for order in sale_orders:
                 group_key = order._get_sale_invoicing_group_key()

--- a/account_invoice_batches/wizard/sale_make_invoice_advance.py
+++ b/account_invoice_batches/wizard/sale_make_invoice_advance.py
@@ -36,19 +36,28 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
         return invoice
 
+    def _invoice_batch_as_batch_user(self, invoice_batch):
+        """This wizard run as the invoice batch user of the batch company.
+
+        Only the batch company stays among the allowed companies: the ones the
+        launcher had enabled would raise an access error for a user not allowed
+        on them. A configuration withdrawn between the enqueue and the run
+        fails loud here instead of running with another identity.
+        """
+        company = invoice_batch.company_id
+        user = company._get_invoice_batch_user()
+        return self.with_user(user).with_context(allowed_company_ids=company.ids)
+
     def create_invoice_group(self, order_group, invoice_batch=None):
-        context = {"active_ids": order_group.mapped("id")}
+        wizard = self.with_context(active_ids=order_group.ids)
         if invoice_batch:
-            # a configuration withdrawn between the enqueue and the run fails
-            # loud here instead of running with another identity
-            invoice_batch.company_id._get_invoice_batch_user()
-            context.update(
-                {
-                    "batch_id": invoice_batch.id,
-                }
+            # the invoices belong to the invoice batch user: creator, follower
+            # and author of their messages
+            wizard = wizard._invoice_batch_as_batch_user(invoice_batch).with_context(
+                batch_id=invoice_batch.id
             )
-        self = self.with_context(**context)
-        return super(SaleAdvancePaymentInv, self).create_invoices()
+        # without a batch, invoicing in background keeps the launcher's identity
+        return super(SaleAdvancePaymentInv, wizard).create_invoices()
 
     def create_invoices(self):
         if not self.in_background and not self.invoice_batch_create:
@@ -83,7 +92,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
             res = {"type": "ir.actions.act_window_close"}
         else:
             if invoice_batch:
-                self = self.with_context(batch_id=invoice_batch.id)
+                # the invoices belong to the invoice batch user, as in background
+                self = self._invoice_batch_as_batch_user(invoice_batch).with_context(
+                    batch_id=invoice_batch.id
+                )
             res = super(SaleAdvancePaymentInv, self).create_invoices()
 
             invoices = self.env["account.move"].search(


### PR DESCRIPTION
The invoices generated from a batch and the e-mails sent from it belonged to whoever launched the wizards, so that user followed every invoice and received the customer replies instead of the company billing mailbox. Besides, the batch e-mail went to the batch e-mail contact of the invoice while core subscribed the partner at validation, so the person replying was not the one following.

This PR makes the batch jobs run as a per-company service user and aligns the followers with the recipients:

- **Invoice batch user** (`res.company.invoice_batch_user_id`, Settings > Invoicing > Invoice batches): the internal user the batch jobs run as. A server constraint refuses a portal user, and `_get_invoice_batch_user()` fails with a clear error naming the company (no user, archived, not internal, no e-mail address, company not allowed) before anything is queued and again inside the jobs.
- **Jobs as that user**: the invoice generation (background job and synchronous path) and the e-mail job switch identity inside the job (`with_user` with the batch company as the only allowed one). The invoices are created and followed by that user, who is also the author of the sent e-mails; the batch itself keeps being created by the launcher. Invoicing without a batch, the PDF printing and the factura-e job keep the launcher's identity. The Billing group gets read, write and create on `sale.advance.payment.inv`, which core grants to salesmen only.
- **Follower at validation**: on a batch invoice, the customer follower core adds at validation is the batch e-mail contact when it differs from the partner. A partner already subscribed by hand stays; invoices outside a batch keep the native follower.
- **Recipient with fallback**: computed `invoice_batch_email_recipient_id` (the contact or, when empty, the partner) for the templates to address.
- **Batch chatter**: `account.invoice.batch` becomes a mail thread; each processing leaves an internal note with the invoices launched per sending method (the enabled methods come from a hook, so a module adding a method can join).
- **Launch guards**: a batch launch refuses an empty selection or orders of another company; the e-mail job refuses an invoice that belongs to no batch.

Tests: 36 tests driving the two wizards as realistic users (a launcher with sales and billing rights, a batch user with the Billing group only, a distinct salesperson on the orders), including a customer reply through the mail gateway that notifies the batch user and not the launcher.

Deployment: set the invoice batch user on each company and address the batch e-mail templates to `${object.invoice_batch_email_recipient_id.id}`.