### PR TITLE
[14.0][FIX] connector_woocommerce: synchronize pricelist discounts and dates

### DIFF
--- a/connector_woocommerce/__manifest__.py
+++ b/connector_woocommerce/__manifest__.py
@@ -1,5 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
-# Copyright NuoBiT Solutions - Eric Antones <eantones@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 {
@@ -15,6 +15,7 @@
         ],
     },
     "depends": [
+        "account_payment_sale",
         "connector_extension_woocommerce",
         "connector_wordpress",
         "sale_stock",

--- a/connector_woocommerce/components/adapter.py
+++ b/connector_woocommerce/components/adapter.py
@@ -28,10 +28,16 @@ class ConnectorWooCommerceAdapter(AbstractComponent):
         )
 
     def _prepare_product_price_conversion_mapper(self):
-        """Return product price converters for WooCommerce."""
+        """Return product price and sale-date converters for WooCommerce."""
         return {
             "/regular_price": lambda x: str(round(x, 10)) if x is not None else None,
-            "/sale_price": lambda x: str(round(x, 10)) if x is not None else None,
+            "/sale_price": lambda x: x if x in (None, "") else str(round(x, 10)),
+            "/date_on_sale_from_gmt": lambda x: (
+                x if x in (None, "") else x.strftime("%Y-%m-%dT%H:%M:%S")
+            ),
+            "/date_on_sale_to_gmt": lambda x: (
+                x if x in (None, "") else x.strftime("%Y-%m-%dT%H:%M:%S")
+            ),
         }
 
     def _format_product(self, data):

--- a/connector_woocommerce/components/adapter.py
+++ b/connector_woocommerce/components/adapter.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from woocommerce import API as API
@@ -25,6 +26,17 @@ class ConnectorWooCommerceAdapter(AbstractComponent):
             verify_ssl=self.backend_record.verify_ssl,
             timeout=30,
         )
+
+    def _prepare_product_price_conversion_mapper(self):
+        """Return product price converters for WooCommerce."""
+        return {
+            "/regular_price": lambda x: str(round(x, 10)) if x is not None else None,
+            "/sale_price": lambda x: str(round(x, 10)) if x is not None else None,
+        }
+
+    def _format_product(self, data):
+        conv_mapper = self._prepare_product_price_conversion_mapper()
+        self._convert_format(data, conv_mapper)
 
     def prepare_meta_data(self, data):
         meta_data = []

--- a/connector_woocommerce/models/backend/backend.py
+++ b/connector_woocommerce/models/backend/backend.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import logging
 
@@ -115,6 +116,19 @@ class WooCommerceBackend(models.Model):
         required=True,
         domain="[('usage', 'in', ['internal','view'])]",
     )
+
+    def _get_woocommerce_sale(self, variant, regular_price):
+        """Return a sale and its UTC window, or explicit clear/unchanged values."""
+        self.ensure_one()
+        pricelist = self.discount_pricelist_id
+        if not pricelist:
+            return None, None, None
+        if not variant:
+            return "", "", ""
+        price, rule = pricelist._get_woocommerce_sale_rule(variant, regular_price)
+        if rule:
+            return price, rule.date_start or "", rule.date_end or ""
+        return "", "", ""
 
     def export_product_tmpl_since(self):
         self.env.user.company_id = self.company_id

--- a/connector_woocommerce/models/product_product/__init__.py
+++ b/connector_woocommerce/models/product_product/__init__.py
@@ -5,3 +5,4 @@ from . import export_mapper
 from . import exporter
 from . import product
 from . import product_pricelist_item
+from . import product_pricelist

--- a/connector_woocommerce/models/product_product/adapter.py
+++ b/connector_woocommerce/models/product_product/adapter.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _
 from odoo.exceptions import ValidationError
@@ -31,7 +32,7 @@ class WooCommerceProductProductAdapter(Component):
         return res[0]
 
     def create(self, data):  # pylint: disable=W8106
-        self._prepare_data(data)
+        self._format_data(data)
         url_l = ["products"]
         parent = data.pop("parent_id")
         url_l.append("%s/variations" % parent)
@@ -40,7 +41,7 @@ class WooCommerceProductProductAdapter(Component):
         return res
 
     def write(self, external_id, data):  # pylint: disable=W8106
-        self._prepare_data(data)
+        self._format_data(data)
         return self._exec(
             "put",
             "products/%s/variations/%s" % tuple(external_id),
@@ -86,5 +87,5 @@ class WooCommerceProductProductAdapter(Component):
         }
         self._convert_format(data, conv_mapper)
 
-    def _prepare_data(self, data):
+    def _format_data(self, data):
         self._format_product_product(data)

--- a/connector_woocommerce/models/product_product/adapter.py
+++ b/connector_woocommerce/models/product_product/adapter.py
@@ -80,12 +80,5 @@ class WooCommerceProductProductAdapter(Component):
     def _get_search_fields(self):
         return super()._get_search_fields() + ["sku", "parent"]
 
-    def _format_product_product(self, data):
-        conv_mapper = {
-            "/regular_price": lambda x: str(round(x, 10)) if x is not None else None,
-            "/sale_price": lambda x: str(round(x, 10)) if x is not None else None,
-        }
-        self._convert_format(data, conv_mapper)
-
     def _format_data(self, data):
-        self._format_product_product(data)
+        self._format_product(data)

--- a/connector_woocommerce/models/product_product/export_mapper.py
+++ b/connector_woocommerce/models/product_product/export_mapper.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _
 from odoo.exceptions import ValidationError
@@ -25,12 +26,14 @@ class WooCommerceProductProductExportMapper(Component):
 
     @mapping
     def sale_price(self, record):
-        pricelist = self.backend_record.discount_pricelist_id
-        if pricelist:
-            return {
-                "sale_price": pricelist.price_get(record.id, 1)[pricelist.id],
-            }
-        return {"sale_price": None}
+        sale, date_from, date_to = self.backend_record._get_woocommerce_sale(
+            record, record.lst_price
+        )
+        return {
+            "sale_price": sale,
+            "date_on_sale_from_gmt": date_from,
+            "date_on_sale_to_gmt": date_to,
+        }
 
     @changed_by("default_code")
     @mapping

--- a/connector_woocommerce/models/product_product/product_pricelist.py
+++ b/connector_woocommerce/models/product_product/product_pricelist.py
@@ -1,11 +1,51 @@
 # Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class Pricelist(models.Model):
     _inherit = "product.pricelist"
+
+    def _get_woocommerce_sale_rule(self, variant, regular_price):
+        """Select the current or next discounted price and rule for one unit.
+
+        Return (None, an empty rule recordset) when no offer qualifies.
+        """
+        self.ensure_one()
+        variant.ensure_one()
+        now = fields.Datetime.now()
+        price, rule_id = self.get_product_price_rule(variant, 1, False, date=now)
+        rule_model = self.env["product.pricelist.item"]
+        if rule_id and price < regular_price:
+            return price, rule_model.browse(rule_id)
+
+        future_rules = rule_model.search(
+            [
+                ("pricelist_id", "=", self.id),
+                ("active", "=", True),
+                ("date_start", ">", now),
+                ("min_quantity", "<=", 1),
+                "|",
+                ("product_tmpl_id", "=", False),
+                ("product_tmpl_id", "=", variant.product_tmpl_id.id),
+                "|",
+                ("product_id", "=", False),
+                ("product_id", "=", variant.id),
+                "|",
+                ("categ_id", "=", False),
+                ("categ_id", "parent_of", variant.categ_id.id),
+            ],
+            order="date_start, id",
+        )
+        for candidate in future_rules:
+            # Let the pricelist resolve precedence, percentages and formulas.
+            price, rule_id = self.get_product_price_rule(
+                variant, 1, False, date=candidate.date_start
+            )
+            if rule_id and price < regular_price:
+                return price, rule_model.browse(rule_id)
+        return None, rule_model
 
     def write(self, values):
         if "active" not in values:

--- a/connector_woocommerce/models/product_product/product_pricelist.py
+++ b/connector_woocommerce/models/product_product/product_pricelist.py
@@ -1,0 +1,22 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class Pricelist(models.Model):
+    _inherit = "product.pricelist"
+
+    def write(self, values):
+        if "active" not in values:
+            return super().write(values)
+        # Item.active is related: archiving the list does not call item.write().
+        rules = (
+            self.env["product.pricelist.item"]
+            .with_context(active_test=False)
+            .search([("pricelist_id", "in", self.ids)])
+        )
+        templates, variants = rules._woocommerce_get_affected_products()
+        result = super().write(values)
+        rules._woocommerce_touch(templates, variants)
+        return result

--- a/connector_woocommerce/models/product_product/product_pricelist_item.py
+++ b/connector_woocommerce/models/product_product/product_pricelist_item.py
@@ -1,49 +1,102 @@
 # Copyright NuoBiT Solutions - Frank Cespedes <fcespedes@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 
 class PricelistItem(models.Model):
     _inherit = "product.pricelist.item"
 
-    def _update_woocommerce_write_date_by_pricelist(self, values):
-        product = values.get("product_id")
-        if product:
-            product = self.env["product.product"].browse(product).exists()
-        else:
-            product = values.get("product_tmpl_id")
-            if product:
-                product = self.env["product.template"].browse(product).exists()
-                product = product.with_context(active_test=False).product_variant_ids
-        if not product:
-            product = (
-                self.product_id
-                or self.product_tmpl_id.with_context(
-                    active_test=False
-                ).product_variant_ids
-            )
+    def _woocommerce_get_affected_products(self):
+        templates = self.env["product.template"].with_context(active_test=False)
+        variants = self.env["product.product"].with_context(active_test=False)
+        discount_pricelists = (
+            self.env["woocommerce.backend"]
+            .with_context(active_test=False)
+            .search([("discount_pricelist_id", "in", self.pricelist_id.ids)])
+            .discount_pricelist_id
+        )
+        rules = self.filtered(lambda item: item.pricelist_id in discount_pricelists)
+        if not rules:
+            return templates, variants
 
-        if product:
-            if product.woocommerce_bind_ids:
-                product.woocommerce_write_date = fields.Datetime.now()
+        template_domains = []
+        variant_domains = []
+        for rule in rules:
+            if rule.applied_on == "0_product_variant":
+                template_domains.append(
+                    [("id", "in", rule.product_id.product_tmpl_id.ids)]
+                )
+                variant_domains.append([("id", "in", rule.product_id.ids)])
+            elif rule.applied_on == "1_product":
+                template_domains.append([("id", "in", rule.product_tmpl_id.ids)])
+                variant_domains.append(
+                    [("product_tmpl_id", "in", rule.product_tmpl_id.ids)]
+                )
+            elif rule.applied_on == "2_product_category":
+                category_domain = [("categ_id", "child_of", rule.categ_id.ids)]
+                template_domains.append(category_domain)
+                variant_domains.append(category_domain)
+            else:
+                template_domains = [expression.TRUE_DOMAIN]
+                variant_domains = [expression.TRUE_DOMAIN]
+                break
+
+        bound_domain = [("woocommerce_bind_ids", "!=", False)]
+        return (
+            templates.search(
+                expression.AND([bound_domain, expression.OR(template_domains)])
+            ),
+            variants.search(
+                expression.AND([bound_domain, expression.OR(variant_domains)])
+            ),
+        )
+
+    def _woocommerce_touch(self, templates, variants):
+        now = fields.Datetime.now()
+        templates.woocommerce_write_date = now
+        variants.woocommerce_write_date = now
 
     def _dependent_field_product_woocommerce_write_date(self):
-        return {"product_id", "product_tmpl_id", "fixed_price", "applied_on"}
+        return {
+            "product_id",
+            "product_tmpl_id",
+            "categ_id",
+            "applied_on",
+            "pricelist_id",
+            "compute_price",
+            "fixed_price",
+            "percent_price",
+            "price_discount",
+            "price_surcharge",
+            "price_round",
+            "price_min_margin",
+            "price_max_margin",
+            "base",
+            "base_pricelist_id",
+            "min_quantity",
+            "date_start",
+            "date_end",
+            "active",
+        }
 
     @api.model_create_multi
     def create(self, vals_list):
-        for values in vals_list:
-            if self._dependent_field_product_woocommerce_write_date() & values.keys():
-                self._update_woocommerce_write_date_by_pricelist(values)
-        return super(PricelistItem, self).create(vals_list)
+        records = super().create(vals_list)
+        records._woocommerce_touch(*records._woocommerce_get_affected_products())
+        return records
 
     def write(self, values):
-        if self._dependent_field_product_woocommerce_write_date() & values.keys():
-            self._update_woocommerce_write_date_by_pricelist(values)
-        return super(PricelistItem, self).write(values)
+        if not self._dependent_field_product_woocommerce_write_date() & values.keys():
+            return super().write(values)
+        templates, variants = self._woocommerce_get_affected_products()
+        result = super().write(values)
+        new_templates, new_variants = self._woocommerce_get_affected_products()
+        self._woocommerce_touch(templates | new_templates, variants | new_variants)
+        return result
 
     def unlink(self):
-        for rec in self:
-            rec._update_woocommerce_write_date_by_pricelist({})
-        return super(PricelistItem, self).unlink()
+        self._woocommerce_touch(*self._woocommerce_get_affected_products())
+        return super().unlink()

--- a/connector_woocommerce/models/product_template/adapter.py
+++ b/connector_woocommerce/models/product_template/adapter.py
@@ -77,13 +77,6 @@ class WooCommerceProductTemplateAdapter(Component):
     def _get_search_fields(self):
         return super()._get_search_fields() + ["sku"]
 
-    def _format_product_template(self, data):
-        conv_mapper = {
-            "/regular_price": lambda x: str(round(x, 10)) if x is not None else None,
-            "/sale_price": lambda x: str(round(x, 10)) if x is not None else None,
-        }
-        self._convert_format(data, conv_mapper)
-
     # TODO: do we really need this
     def _normalize_simple_sku(self, sku):
         if isinstance(sku, list):
@@ -96,7 +89,7 @@ class WooCommerceProductTemplateAdapter(Component):
         return sku
 
     def _format_data(self, data):
-        self._format_product_template(data)
+        self._format_product(data)
         meta_data = self.prepare_meta_data(data)
         if meta_data:
             data["meta_data"] = meta_data

--- a/connector_woocommerce/models/product_template/adapter.py
+++ b/connector_woocommerce/models/product_template/adapter.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _
 from odoo.exceptions import ValidationError
@@ -28,11 +29,11 @@ class WooCommerceProductTemplateAdapter(Component):
         return res[0]
 
     def create(self, data):  # pylint: disable=W8106
-        self._prepare_data(data)
+        self._format_data(data)
         return self._exec("post", "products", data=data)
 
     def write(self, external_id, data):  # pylint: disable=W8106
-        self._prepare_data(data)
+        self._format_data(data)
         url_l = ["products", str(external_id[0])]
         res = self._exec("put", "/".join(url_l), data=data)
         return res
@@ -94,7 +95,7 @@ class WooCommerceProductTemplateAdapter(Component):
                 sku = sku[0]
         return sku
 
-    def _prepare_data(self, data):
+    def _format_data(self, data):
         self._format_product_template(data)
         meta_data = self.prepare_meta_data(data)
         if meta_data:

--- a/connector_woocommerce/models/product_template/binding.py
+++ b/connector_woocommerce/models/product_template/binding.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 
 from odoo import api, fields, models
@@ -41,13 +42,9 @@ class WooCommerceProductTemplate(models.Model):
     def export_product_tmpl_since(self, backend_record=None, since_date=None):
         domain = self._get_base_domain()
         if since_date:
-            domain = [
-                (
-                    "woocommerce_write_date",
-                    ">",
-                    fields.Datetime.to_string(since_date),
-                )
-            ]
+            domain.append(
+                ("woocommerce_write_date", ">", fields.Datetime.to_string(since_date))
+            )
         self.with_delay().export_batch(backend_record, domain=domain)
         return True
 

--- a/connector_woocommerce/models/product_template/export_mapper.py
+++ b/connector_woocommerce/models/product_template/export_mapper.py
@@ -1,4 +1,5 @@
 # Copyright NuoBiT Solutions - Kilian Niubo <kniubo@nuobit.com>
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl)
 from odoo import _
 from odoo.exceptions import ValidationError
@@ -109,15 +110,17 @@ class WooCommerceProductTemplateExportMapper(Component):
 
     @mapping
     def sale_price(self, record):
+        sale, date_from, date_to = None, None, None
         if not record.has_attributes:
-            pricelist = self.backend_record.discount_pricelist_id
-            if pricelist:
-                return {
-                    "sale_price": pricelist.price_get(record.product_variant_id.id, 1)[
-                        pricelist.id
-                    ],
-                }
-        return {"sale_price": None}
+            sale, date_from, date_to = self.backend_record._get_woocommerce_sale(
+                record.with_context(active_test=False).product_variant_id,
+                record.list_price,
+            )
+        return {
+            "sale_price": sale,
+            "date_on_sale_from_gmt": date_from,
+            "date_on_sale_to_gmt": date_to,
+        }
 
     def _get_product_description(self, record):
         description = record.with_context(

--- a/connector_woocommerce/tests/__init__.py
+++ b/connector_woocommerce/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_export_since
 from . import test_sale_order
 from . import test_product_pricelist_item
+from . import test_woocommerce_sale

--- a/connector_woocommerce/tests/__init__.py
+++ b/connector_woocommerce/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_export_since
 from . import test_sale_order

--- a/connector_woocommerce/tests/__init__.py
+++ b/connector_woocommerce/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_export_since
 from . import test_sale_order
+from . import test_product_pricelist_item

--- a/connector_woocommerce/tests/common.py
+++ b/connector_woocommerce/tests/common.py
@@ -1,0 +1,108 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import SavepointCase
+
+
+class WooCommerceCase(SavepointCase):
+    """Backend, discount pricelist and bound products without any HTTP call."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._write_dates = {}
+        lang = cls.env.ref("base.lang_en")
+        cls.discount_pricelist = cls.env["product.pricelist"].create(
+            {"name": "WooCommerce discount pricelist"}
+        )
+        cls.other_pricelist = cls.env["product.pricelist"].create(
+            {"name": "Other pricelist"}
+        )
+        cls.backend = cls.env["woocommerce.backend"].create(
+            {
+                "name": "WooCommerce test backend",
+                "url": "http://127.0.0.1:1",
+                "consumer_key": "ck_test",
+                "consumer_secret": "cs_test",
+                "lang_ids": [(6, 0, lang.ids)],
+                "language_id": lang.id,
+                "client_order_ref_prefix": "WC",
+                "stock_location_ids": [
+                    (6, 0, cls.env.ref("stock.stock_location_stock").ids)
+                ],
+                "discount_pricelist_id": cls.discount_pricelist.id,
+            }
+        )
+        cls.category = cls.env["product.category"].create(
+            {"name": "WooCommerce test category"}
+        )
+        cls.template = cls._create_template("WooCommerce bound product", 1001)
+        cls.unbound_template = cls._create_template("WooCommerce unbound product")
+
+    @classmethod
+    def _create_template(cls, name, woocommerce_idproduct=None, list_price=100.0):
+        template = cls.env["product.template"].create(
+            {
+                "name": name,
+                "list_price": list_price,
+                "categ_id": cls.category.id,
+                "woocommerce_enabled": True,
+            }
+        )
+        if woocommerce_idproduct:
+            cls.env["woocommerce.product.template"].create(
+                {
+                    "odoo_id": template.id,
+                    "backend_id": cls.backend.id,
+                    "woocommerce_idproduct": woocommerce_idproduct,
+                }
+            )
+        cls._remember_write_dates(template)
+        return template
+
+    @classmethod
+    def _bind_variant(cls, variant, woocommerce_idproduct):
+        return cls.env["woocommerce.product.product"].create(
+            {
+                "odoo_id": variant.id,
+                "backend_id": cls.backend.id,
+                "woocommerce_idproduct": woocommerce_idproduct,
+                "woocommerce_idparent": woocommerce_idproduct + 1,
+            }
+        )
+
+    @classmethod
+    def _remember_write_dates(cls, template):
+        variants = template.with_context(active_test=False).product_variant_ids
+        for records in (template, variants):
+            for record in records:
+                cls._write_dates[
+                    record._name, record.id
+                ] = record.woocommerce_write_date
+
+    def _create_rule(self, pricelist=None, **values):
+        vals = {
+            "pricelist_id": (pricelist or self.discount_pricelist).id,
+            "applied_on": "1_product",
+            "product_tmpl_id": self.template.id,
+            "compute_price": "fixed",
+            "fixed_price": 80.0,
+        }
+        vals.update(values)
+        return self.env["product.pricelist.item"].create(vals)
+
+    def assert_touched(self, records):
+        for record in records:
+            self.assertNotEqual(
+                record.woocommerce_write_date,
+                self._write_dates[record._name, record.id],
+                "%s should have been marked for export" % record.display_name,
+            )
+
+    def assert_untouched(self, records):
+        for record in records:
+            self.assertEqual(
+                record.woocommerce_write_date,
+                self._write_dates[record._name, record.id],
+                "%s should not have been marked for export" % record.display_name,
+            )

--- a/connector_woocommerce/tests/test_export_since.py
+++ b/connector_woocommerce/tests/test_export_since.py
@@ -1,0 +1,36 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import datetime
+
+from .common import WooCommerceCase
+
+
+class TestExportSince(WooCommerceCase):
+    def _new_export_batch_job(self, model_name, run):
+        job_model = self.env["queue.job"]
+        domain = [("model_name", "=", model_name), ("method_name", "=", "export_batch")]
+        before = job_model.search(domain)
+        run()
+        jobs = job_model.search(domain) - before
+        self.assertEqual(len(jobs), 1)
+        return jobs
+
+    def test_export_product_tmpl_since_keeps_base_domain(self):
+        self.backend.export_product_tmpl_since_date = datetime(2026, 1, 1)
+        job = self._new_export_batch_job(
+            "woocommerce.product.template", self.backend.export_product_tmpl_since
+        )
+        domain = [list(clause) for clause in job.kwargs["domain"]]
+        self.assertIn(["woocommerce_enabled", "=", True], domain)
+        self.assertIn(["has_attributes", "=", False], domain)
+        self.assertIn(["woocommerce_write_date", ">", "2026-01-01 00:00:00"], domain)
+
+    def test_export_product_tmpl_without_since_date_uses_base_domain(self):
+        job = self._new_export_batch_job(
+            "woocommerce.product.template", self.backend.export_product_tmpl_since
+        )
+        domain = [list(clause) for clause in job.kwargs["domain"]]
+        self.assertEqual(
+            domain, [["woocommerce_enabled", "=", True], ["has_attributes", "=", False]]
+        )

--- a/connector_woocommerce/tests/test_product_pricelist_item.py
+++ b/connector_woocommerce/tests/test_product_pricelist_item.py
@@ -1,0 +1,219 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from datetime import timedelta
+
+from freezegun import freeze_time
+
+from .common import WooCommerceCase
+
+
+class TestProductPricelistItem(WooCommerceCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.second_template = cls._create_template("Second bound product", 1002)
+        cls.child_category = cls.env["product.category"].create(
+            {"name": "Child category", "parent_id": cls.category.id}
+        )
+        cls.child_template = cls._create_template("Child category product", 1003)
+        cls.child_template.categ_id = cls.child_category
+        cls.variable_template = cls._create_template("Variable product", 1004)
+        attribute = cls.env["product.attribute"].create({"name": "Size"})
+        values = cls.env["product.attribute.value"].create(
+            [
+                {"name": "Small", "attribute_id": attribute.id},
+                {"name": "Large", "attribute_id": attribute.id},
+            ]
+        )
+        cls.variable_template.write(
+            {
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": attribute.id,
+                            "value_ids": [(6, 0, values.ids)],
+                        },
+                    )
+                ]
+            }
+        )
+        for index, variant in enumerate(cls.variable_template.product_variant_ids):
+            cls._bind_variant(variant, 2001 + index)
+        cls.templates = (
+            cls.template
+            | cls.unbound_template
+            | cls.second_template
+            | cls.child_template
+            | cls.variable_template
+        )
+
+    def setUp(self):
+        super().setUp()
+        self._remember_write_dates(self.templates)
+        freezer = freeze_time("2030-01-01 12:00:00")
+        self.clock = freezer.start()
+        self.addCleanup(freezer.stop)
+
+    def _next_change(self):
+        self._remember_write_dates(self.templates)
+        self.clock.tick(timedelta(seconds=1))
+
+    def test_create_marks_simple_template_without_variant_binding(self):
+        self._create_rule()
+        self.assert_touched(self.template)
+        self.assert_untouched(self.template.product_variant_ids)
+        self.assert_untouched(self.unbound_template | self.second_template)
+
+    def test_price_and_validity_edits_mark_template(self):
+        rule = self._create_rule()
+        changes = [
+            {"fixed_price": 75.0},
+            {"date_start": "2030-01-01 00:00:00"},
+            {"date_end": "2030-02-01 00:00:00"},
+            {"min_quantity": 2.0},
+            {"compute_price": "percentage"},
+            {"percent_price": 25.0},
+            {"compute_price": "formula"},
+            {"price_discount": 20.0},
+            {"price_surcharge": 2.0},
+            {"price_round": 0.5},
+            {"price_max_margin": 10.0},
+            {"price_min_margin": 1.0},
+            {"base_pricelist_id": self.other_pricelist.id},
+            {"base": "pricelist"},
+        ]
+        for values in changes:
+            with self.subTest(values=values):
+                self._next_change()
+                rule.write(values)
+                self.assert_touched(self.template)
+                self.assert_untouched(self.unbound_template | self.second_template)
+
+    def test_moving_template_marks_old_and_new_products(self):
+        rule = self._create_rule()
+        self._next_change()
+        rule.product_tmpl_id = self.second_template
+        self.assert_touched(self.template | self.second_template)
+        self.assert_untouched(self.unbound_template)
+
+    def test_moving_variant_marks_old_and_new_variants(self):
+        variants = self.variable_template.product_variant_ids.sorted("id")
+        first, second = variants
+        rule = self._create_rule(
+            applied_on="0_product_variant",
+            product_tmpl_id=False,
+            product_id=first.id,
+        )
+        self._next_change()
+        rule.product_id = second
+        self.assert_touched(variants)
+        self.assert_touched(self.variable_template)
+        self.assert_untouched(self.template)
+
+    def test_moving_pricelist_marks_leaving_and_entering_discount_list(self):
+        rule = self._create_rule()
+        self._next_change()
+        rule.pricelist_id = self.other_pricelist
+        self.assert_touched(self.template)
+        self._next_change()
+        rule.pricelist_id = self.discount_pricelist
+        self.assert_touched(self.template)
+
+    def test_template_rule_marks_archived_bound_variants(self):
+        variants = self.variable_template.product_variant_ids.sorted("id")
+        first, second = variants
+        first.action_archive()
+        self._next_change()
+        self._create_rule(product_tmpl_id=self.variable_template.id)
+        self.assert_touched(self.variable_template)
+        self.assert_touched(first | second)
+        self.assert_untouched(self.template)
+
+    def test_category_rule_includes_descendants_and_only_bound_records(self):
+        self._create_rule(
+            applied_on="2_product_category",
+            product_tmpl_id=False,
+            categ_id=self.category.id,
+        )
+        self.assert_touched(self.templates - self.unbound_template)
+        self.assert_touched(self.variable_template.product_variant_ids)
+        self.assert_untouched(self.unbound_template)
+        self.assert_untouched(self.template.product_variant_ids)
+
+    def test_moving_category_marks_previous_and_new_subtrees(self):
+        other_category = self.env["product.category"].create({"name": "Other category"})
+        self.second_template.categ_id = other_category
+        rule = self._create_rule(
+            applied_on="2_product_category",
+            product_tmpl_id=False,
+            categ_id=self.child_category.id,
+        )
+        self._next_change()
+        rule.categ_id = other_category
+        self.assert_touched(self.child_template | self.second_template)
+        self.assert_untouched(self.template | self.unbound_template)
+
+    def test_global_rule_marks_all_bound_templates_and_variants(self):
+        self._create_rule(applied_on="3_global", product_tmpl_id=False)
+        self.assert_touched(self.templates - self.unbound_template)
+        self.assert_touched(self.variable_template.product_variant_ids)
+        self.assert_untouched(self.unbound_template)
+        self.assert_untouched(self.template.product_variant_ids)
+
+    def test_rule_on_another_pricelist_does_not_mark_products(self):
+        self._create_rule(pricelist=self.other_pricelist)
+        self.assert_untouched(self.templates)
+        self.assert_untouched(self.templates.product_variant_ids)
+
+    def test_changing_scope_marks_previous_and_new_targets(self):
+        rule = self._create_rule()
+        self._next_change()
+        rule.write({"applied_on": "3_global", "product_tmpl_id": False})
+        self.assert_touched(self.templates - self.unbound_template)
+        self.assert_untouched(self.unbound_template)
+
+    def test_batch_create_and_write_handle_multiple_rules(self):
+        rules = self.env["product.pricelist.item"].create(
+            [
+                {
+                    "pricelist_id": self.discount_pricelist.id,
+                    "applied_on": "1_product",
+                    "product_tmpl_id": template.id,
+                    "fixed_price": 70.0,
+                }
+                for template in self.template | self.second_template
+            ]
+        )
+        self.assert_touched(self.template | self.second_template)
+        self._next_change()
+        rules.write({"fixed_price": 65.0})
+        self.assert_touched(self.template | self.second_template)
+        self.assert_untouched(self.unbound_template)
+
+    def test_deleting_rules_marks_all_previous_targets(self):
+        rules = self._create_rule() | self._create_rule(
+            product_tmpl_id=self.variable_template.id
+        )
+        self._next_change()
+        rules.unlink()
+        self.assert_touched(self.template | self.variable_template)
+        self.assert_touched(self.variable_template.product_variant_ids)
+        self.assert_untouched(self.unbound_template)
+
+    def test_archiving_and_restoring_discount_pricelist_marks_bound_products(self):
+        self._create_rule()
+        self._next_change()
+        self.discount_pricelist.action_archive()
+        self.assert_touched(self.template)
+        self._next_change()
+        self.discount_pricelist.action_unarchive()
+        self.assert_touched(self.template)
+
+    def test_empty_rule_operations_do_not_mark_products(self):
+        rules = self.env["product.pricelist.item"]
+        rules.write({"fixed_price": 50.0})
+        rules.unlink()
+        self.assert_untouched(self.templates)

--- a/connector_woocommerce/tests/test_woocommerce_sale.py
+++ b/connector_woocommerce/tests/test_woocommerce_sale.py
@@ -1,0 +1,164 @@
+# Copyright 2026 NuoBiT Solutions SL - Eric Antones <eantones@nuobit.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from unittest.mock import patch
+
+from freezegun import freeze_time
+
+from odoo.addons.component.tests.common import SavepointComponentCase
+
+from .common import WooCommerceCase
+
+
+class TestWooCommerceSale(WooCommerceCase, SavepointComponentCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.template.write({"default_code": "WC-SALE", "taxes_id": [(5, 0, 0)]})
+        cls.variant = cls.template.product_variant_id
+        cls._bind_variant(cls.variant, 2001)
+
+    def setUp(self):
+        super().setUp()
+        freezer = freeze_time("2030-01-01 12:00:00")
+        freezer.start()
+        self.addCleanup(freezer.stop)
+
+    def _assert_sale_payload(self, price, start="", end=""):
+        for model_name, product, external_id in (
+            ("woocommerce.product.template", self.template, [1001]),
+            ("woocommerce.product.product", self.variant, [1001, 2001]),
+        ):
+            with self.subTest(model=model_name):
+                with self.backend.work_on(model_name) as work:
+                    mapper = work.component(usage="export.mapper")
+                    # The exporter maps the actual product, not its binding.
+                    data = mapper.map_record(product).values()
+                    adapter = work.component(usage="backend.adapter")
+                    # Stop only at the external API boundary; run real formatting.
+                    with patch.object(type(adapter), "_exec", return_value={}) as call:
+                        adapter.write(external_id, data)
+                    call.assert_called_once()
+                    args, kwargs = call.call_args
+                    self.assertEqual(args[0], "put")
+                    payload = kwargs["data"]
+                    self.assertEqual(payload["sale_price"], price)
+                    self.assertEqual(payload["date_on_sale_from_gmt"], start)
+                    self.assertEqual(payload["date_on_sale_to_gmt"], end)
+
+    def test_current_sale_exports_utc_dates(self):
+        self._create_rule(
+            date_start="2029-12-20 08:30:00", date_end="2030-01-10 19:45:00"
+        )
+        self.backend = self.backend.with_context(tz="Pacific/Honolulu")
+        self._assert_sale_payload("80.0", "2029-12-20T08:30:00", "2030-01-10T19:45:00")
+
+    def test_expired_sale_clears_price_and_dates(self):
+        self._create_rule(
+            date_start="2029-12-01 00:00:00", date_end="2029-12-31 23:59:59"
+        )
+        self._assert_sale_payload("")
+
+    def test_future_sale_exports_its_schedule(self):
+        self._create_rule(
+            fixed_price=70.0,
+            date_start="2030-01-10 08:30:00",
+            date_end="2030-01-20 19:45:00",
+        )
+        self._assert_sale_payload("70.0", "2030-01-10T08:30:00", "2030-01-20T19:45:00")
+
+    def test_undated_sale_clears_previous_schedule(self):
+        self._create_rule()
+        self._assert_sale_payload("80.0")
+
+    def test_missing_rule_clears_remote_sale(self):
+        self._assert_sale_payload("")
+
+    def test_missing_discount_pricelist_leaves_remote_sale_unchanged(self):
+        self.backend.discount_pricelist_id = False
+        self._assert_sale_payload(None, None, None)
+
+    def test_price_at_or_above_regular_clears_sale(self):
+        rule = self._create_rule(fixed_price=100.0)
+        for price in (100.0, 120.0):
+            with self.subTest(price=price):
+                rule.fixed_price = price
+                self._assert_sale_payload("")
+
+    def test_zero_price_is_exported_as_a_sale(self):
+        self._create_rule(fixed_price=0.0)
+        self._assert_sale_payload("0.0")
+
+    def test_future_lookup_skips_non_discounts_and_quantity_rules(self):
+        self._create_rule(fixed_price=120.0, date_start="2030-01-02 00:00:00")
+        self._create_rule(
+            fixed_price=50.0, min_quantity=2.0, date_start="2030-01-03 00:00:00"
+        )
+        self._create_rule(fixed_price=70.0, date_start="2030-01-10 00:00:00")
+        self._assert_sale_payload("70.0", "2030-01-10T00:00:00")
+
+    def test_future_category_rule_matches_ancestors_only(self):
+        parent = self.env["product.category"].create({"name": "Parent category"})
+        other = self.env["product.category"].create({"name": "Unrelated category"})
+        self.category.parent_id = parent
+        self._create_rule(
+            applied_on="2_product_category",
+            product_tmpl_id=False,
+            categ_id=other.id,
+            fixed_price=50.0,
+            date_start="2030-01-02 00:00:00",
+        )
+        self._create_rule(
+            applied_on="2_product_category",
+            product_tmpl_id=False,
+            categ_id=parent.id,
+            date_start="2030-01-10 00:00:00",
+        )
+        self._assert_sale_payload("80.0", "2030-01-10T00:00:00")
+
+    def test_future_rule_uses_pricelist_precedence(self):
+        self._create_rule(
+            applied_on="3_global",
+            product_tmpl_id=False,
+            fixed_price=50.0,
+            date_start="2030-01-10 00:00:00",
+            date_end="2030-01-20 00:00:00",
+        )
+        self._create_rule(
+            applied_on="0_product_variant",
+            product_tmpl_id=False,
+            product_id=self.variant.id,
+            fixed_price=90.0,
+            date_start="2030-01-10 00:00:00",
+            date_end="2030-01-15 00:00:00",
+        )
+        self._assert_sale_payload("90.0", "2030-01-10T00:00:00", "2030-01-15T00:00:00")
+
+    def test_future_percentage_uses_standard_pricelist_calculation(self):
+        self._create_rule(
+            compute_price="percentage",
+            percent_price=25.0,
+            date_start="2030-01-10 00:00:00",
+        )
+        self._assert_sale_payload("75.0", "2030-01-10T00:00:00")
+
+    def test_future_formula_uses_base_pricelist(self):
+        self._create_rule(pricelist=self.other_pricelist, fixed_price=80.0)
+        self._create_rule(
+            compute_price="formula",
+            base="pricelist",
+            base_pricelist_id=self.other_pricelist.id,
+            price_discount=10.0,
+            date_start="2030-01-10 00:00:00",
+        )
+        self._assert_sale_payload("72.0", "2030-01-10T00:00:00")
+
+    def test_current_sale_is_kept_ahead_of_a_later_offer(self):
+        self._create_rule(date_end="2030-01-05 00:00:00")
+        self._create_rule(fixed_price=70.0, date_start="2030-01-10 00:00:00")
+        self._assert_sale_payload("80.0", "", "2030-01-05T00:00:00")
+
+    def test_archived_product_uses_its_archived_variant(self):
+        self._create_rule()
+        self.template.action_archive()
+        self._assert_sale_payload("80.0")


### PR DESCRIPTION
Changing discount pricelist rules did not reliably mark simple products for re-export, so WooCommerce could retain an outdated discount. The export also omitted validity dates and discarded the normal product filter when an incremental date was supplied.

The connector now marks bound templates and variants affected by rule creation, edits, removal and pricelist archiving, including both the previous and new rule scope. Incremental template exports retain the enabled/simple-product filter.

Sale exports use Odoo's pricelist calculation to select the current discount or the earliest applicable future discount and send its UTC validity window. A configured pricelist with no applicable discount clears the remote sale price and dates; an unconfigured discount pricelist leaves them unchanged. Zero remains a valid sale price. WooCommerce receives one sale window per export and handles its activation and expiry through its native scheduler. The module also declares its existing dependency on `account_payment_sale`.

Validation: 35 Odoo connector tests passed. Local integration verified normal queued exports, API values and product-page prices in three languages, including one-export scheduled activation/expiry, rule edits, archiving, removal and restoration.